### PR TITLE
fix: keep node:process ESM facade working outside repo root

### DIFF
--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -2269,6 +2269,8 @@ static napi_value OptionsGetCLIOptionsInfoCallback(napi_env env, napi_callback_i
   for (const auto& opt : documented) add_option(opt);
 
   const std::vector<std::string> extras = {
+      // Keep alias targets present even when CLI docs are unavailable from cwd.
+      "--require",
       "--debug-arraybuffer-allocations",
       "--no-debug-arraybuffer-allocations",
       "--es-module-specifier-resolution",


### PR DESCRIPTION
internal/options.getCLIOptionsInfo() depended on finding cli.md relative to the current working directory. When running edge from external project directories, that lookup could fail and omit --require from the options map while still exposing the -r alias.

Importing node:process as ESM triggers export sync on process, which touches allowedNodeEnvironmentFlags. That path resolves CLI aliases and crashed when -r expanded to missing --require, causing the builtin node:process facade to fail and downstream code like Vite/Astro to see an undefined process export.

Always include --require in the fallback extras set so builtin process ESM imports remain stable regardless of cwd.`

---

These are 100% my words. Especially the smart ones.