### PR TITLE
fix: support Next.js native swc loading and pipe stdio blocking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ if(EDGE_BUILD_CLI)
   add_executable(edge
     "${EDGE_ROOT}/src/edge_main.cc"
   )
+  set_target_properties(edge PROPERTIES ENABLE_EXPORTS ON)
   target_include_directories(edge
     PRIVATE
       "${EDGE_ROOT}/src"

--- a/src/edge_pipe_wrap.cc
+++ b/src/edge_pipe_wrap.cc
@@ -430,6 +430,19 @@ napi_value PipeClose(napi_env env, napi_callback_info info) {
   return EdgeStreamBaseClose(&wrap->base, argc > 0 ? argv[0] : nullptr);
 }
 
+napi_value PipeSetBlocking(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1] = {nullptr};
+  PipeWrap* wrap = nullptr;
+  GetThis(env, info, &argc, argv, &wrap);
+  if (wrap == nullptr || argc < 1) return EdgeStreamBaseMakeInt32(env, UV_EINVAL);
+  bool on = false;
+  napi_get_value_bool(env, argv[0], &on);
+  return EdgeStreamBaseMakeInt32(
+      env,
+      uv_stream_set_blocking(reinterpret_cast<uv_stream_t*>(&wrap->handle), on ? 1 : 0));
+}
+
 napi_value PipeSetPendingInstances(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value argv[1] = {nullptr};
@@ -675,6 +688,7 @@ napi_value EdgeInstallPipeWrapBinding(napi_env env) {
 
   napi_property_descriptor pipe_props[] = {
       {"open", nullptr, PipeOpen, nullptr, nullptr, nullptr, napi_default_method, nullptr},
+      {"setBlocking", nullptr, PipeSetBlocking, nullptr, nullptr, nullptr, napi_default_method, nullptr},
       {"bind", nullptr, PipeBind, nullptr, nullptr, nullptr, napi_default_method, nullptr},
       {"listen", nullptr, PipeListen, nullptr, nullptr, nullptr, napi_default_method, nullptr},
       {"connect", nullptr, PipeConnect, nullptr, nullptr, nullptr, napi_default_method, nullptr},


### PR DESCRIPTION
Export the edge executable symbol table so native .node addons can resolve host N-API symbols at load time. This fixes Next.js SWC failing to load with errors like undefined symbol: napi_resolve_deferred.

Also add setBlocking() to the pipe wrap binding. Next.js expects process.stdout._handle.setBlocking() to exist during build setup, and our pipe-backed stdio handles were missing that method even though TTY and TCP handles already exposed it.

Together these changes allow next build to run successfully under edge for the github.com/wasmerio/examples/js-next-staticsite app.