### PR TITLE
fix(tests): Improve lib testing support

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -56,6 +56,9 @@ if (internalBinding('config').hasInspector) {
   profiler = internalBinding('profiler');
 }
 
+// HACK(edgejs): Proper fix is to implement the profiler binding instead of patching JS exports.
+function noop() {}
+
 const assert = require('internal/assert');
 const { inspect } = require('internal/util/inspect');
 const { FastBuffer } = require('internal/buffer');
@@ -505,8 +508,8 @@ module.exports = {
   DefaultSerializer,
   DefaultDeserializer,
   deserialize,
-  takeCoverage: profiler.takeCoverage,
-  stopCoverage: profiler.stopCoverage,
+  takeCoverage: profiler.takeCoverage ?? noop,
+  stopCoverage: profiler.stopCoverage ?? noop,
   serialize,
   writeHeapSnapshot,
   promiseHooks,

--- a/src/internal_binding/binding_worker.cc
+++ b/src/internal_binding/binding_worker.cc
@@ -479,6 +479,12 @@ bool IsDisallowedWorkerExecArgvFlag(const std::string& flag) {
          flag == "--redirect-warnings";
 }
 
+bool IsAlwaysAllowedWorkerExecArgvFlag(const std::string& flag) {
+  // Node allows source map support in worker execArgv, and userland test
+  // runners like AVA rely on that behavior for worker startup.
+  return flag == "--enable-source-maps";
+}
+
 std::vector<std::string> ValidateExecArgv(napi_env env,
                                           const std::vector<std::string>& args,
                                           bool explicitly_provided) {
@@ -489,6 +495,7 @@ std::vector<std::string> ValidateExecArgv(napi_env env,
     std::string flag = arg;
     const size_t eq = flag.find('=');
     if (eq != std::string::npos) flag.resize(eq);
+    if (IsAlwaysAllowedWorkerExecArgvFlag(flag)) continue;
     if (IsDisallowedWorkerExecArgvFlag(flag) || !IsAllowedNodeEnvironmentFlag(env, flag)) {
       invalid.push_back(arg);
     }


### PR DESCRIPTION
- Lib testing fails because there is no profiler available
- Allow passing --enable-source-maps flag to workers