### PR TITLE
fix: make Angular SSR work by aligning lazy globals and N-API finalizers with Node

### DIFF
--- a/napi/v8/src/js_native_api_v8.cc
+++ b/napi/v8/src/js_native_api_v8.cc
@@ -3054,7 +3054,32 @@ napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
                                           void* finalize_hint,
                                           napi_ref* result) {
   if (!CheckValue(env, js_object) || finalize_cb == nullptr) return napi_invalid_arg;
-  return napi_wrap(env, js_object, finalize_data, finalize_cb, finalize_hint, result);
+
+  v8::Local<v8::Value> value = napi_v8_unwrap_value(js_object);
+  if (!value->IsObject()) return napi_object_expected;
+
+  auto* record = new (std::nothrow) WrapFinalizerRecord();
+  if (record == nullptr) return napi_generic_failure;
+
+  record->env = env;
+  record->native_object = finalize_data;
+  record->finalize_cb = finalize_cb;
+  record->finalize_hint = finalize_hint;
+  record->handle.Reset(env->isolate, value.As<v8::Object>());
+  record->handle.SetWeak(record, WrapWeakCallback, v8::WeakCallbackType::kParameter);
+  env->wrap_finalizers.push_back(record);
+
+  if (result != nullptr) {
+    napi_status status = napi_create_reference(env, js_object, 0, result);
+    if (status != napi_ok) {
+      RemoveWrapFinalizerRecord(env, record);
+      record->handle.Reset();
+      delete record;
+      return status;
+    }
+  }
+
+  return napi_ok;
 }
 
 napi_status NAPI_CDECL napi_get_version(node_api_basic_env env, uint32_t* result) {

--- a/src/edge_util.cc
+++ b/src/edge_util.cc
@@ -484,15 +484,25 @@ napi_value IsInsideNodeModulesCallback(napi_env env, napi_callback_info info) {
   return out != nullptr ? out : Undefined(env);
 }
 
-napi_value LazyPropertyGetter(napi_env env, napi_callback_info info) {
-  size_t argc = 0;
-  napi_value this_arg = nullptr;
-  void* data = nullptr;
-  if (napi_get_cb_info(env, info, &argc, nullptr, &this_arg, &data) != napi_ok || data == nullptr) {
-    return Undefined(env);
-  }
+void MaterializeLazyProperty(napi_env env, napi_value target, const LazyPropertyData& lazy, napi_value value) {
+  if (!IsObjectLike(env, target)) return;
+  if (value == nullptr) value = Undefined(env);
 
-  auto* lazy = static_cast<LazyPropertyData*>(data);
+  napi_property_descriptor descriptor = {
+      .utf8name = lazy.key.c_str(),
+      .name = nullptr,
+      .method = nullptr,
+      .getter = nullptr,
+      .setter = nullptr,
+      .value = value,
+      .attributes = static_cast<napi_property_attributes>(napi_writable | napi_configurable |
+                                                          (lazy.enumerable ? napi_enumerable : napi_default)),
+      .data = nullptr,
+  };
+  napi_define_properties(env, target, 1, &descriptor);
+}
+
+napi_value ResolveLazyPropertyValue(napi_env env, const LazyPropertyData& lazy) {
   napi_value require_fn = EdgeGetRequireFunction(env);
   if (!IsFunction(env, require_fn)) {
     require_fn = GetGlobalNamed(env, "require");
@@ -500,7 +510,7 @@ napi_value LazyPropertyGetter(napi_env env, napi_callback_info info) {
   if (!IsFunction(env, require_fn)) return Undefined(env);
 
   napi_value id = nullptr;
-  if (napi_create_string_utf8(env, lazy->module_id.c_str(), lazy->module_id.size(), &id) != napi_ok || id == nullptr) {
+  if (napi_create_string_utf8(env, lazy.module_id.c_str(), lazy.module_id.size(), &id) != napi_ok || id == nullptr) {
     return Undefined(env);
   }
 
@@ -510,26 +520,40 @@ napi_value LazyPropertyGetter(napi_env env, napi_callback_info info) {
   if (!IsObjectLike(env, module)) return Undefined(env);
 
   napi_value value = nullptr;
-  if (napi_get_named_property(env, module, lazy->key.c_str(), &value) != napi_ok || value == nullptr) {
+  if (napi_get_named_property(env, module, lazy.key.c_str(), &value) != napi_ok || value == nullptr) {
     value = Undefined(env);
   }
 
-  if (IsObjectLike(env, this_arg)) {
-    napi_property_descriptor descriptor = {
-        .utf8name = lazy->key.c_str(),
-        .name = nullptr,
-        .method = nullptr,
-        .getter = nullptr,
-        .setter = nullptr,
-        .value = value,
-        .attributes = static_cast<napi_property_attributes>(napi_writable | napi_configurable |
-                                                            (lazy->enumerable ? napi_enumerable : napi_default)),
-        .data = nullptr,
-    };
-    napi_define_properties(env, this_arg, 1, &descriptor);
+  return value;
+}
+
+napi_value LazyPropertyGetter(napi_env env, napi_callback_info info) {
+  size_t argc = 0;
+  napi_value this_arg = nullptr;
+  void* data = nullptr;
+  if (napi_get_cb_info(env, info, &argc, nullptr, &this_arg, &data) != napi_ok || data == nullptr) {
+    return Undefined(env);
   }
 
+  auto* lazy = static_cast<LazyPropertyData*>(data);
+  napi_value value = ResolveLazyPropertyValue(env, *lazy);
+  MaterializeLazyProperty(env, this_arg, *lazy, value);
   return value;
+}
+
+napi_value LazyPropertySetter(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1] = {nullptr};
+  napi_value this_arg = nullptr;
+  void* data = nullptr;
+  if (napi_get_cb_info(env, info, &argc, argv, &this_arg, &data) != napi_ok || data == nullptr) {
+    return Undefined(env);
+  }
+
+  auto* lazy = static_cast<LazyPropertyData*>(data);
+  napi_value value = (argc >= 1 && argv[0] != nullptr) ? argv[0] : Undefined(env);
+  MaterializeLazyProperty(env, this_arg, *lazy, value);
+  return Undefined(env);
 }
 
 void TrySetLazyGetterName(napi_env env, napi_value target, const std::string& key) {
@@ -616,7 +640,7 @@ napi_value DefineLazyPropertiesCallback(napi_env env, napi_callback_info info) {
         .name = nullptr,
         .method = nullptr,
         .getter = LazyPropertyGetter,
-        .setter = nullptr,
+        .setter = LazyPropertySetter,
         .value = nullptr,
         .attributes = static_cast<napi_property_attributes>(napi_configurable |
                                                             (enumerable ? napi_enumerable : napi_default)),


### PR DESCRIPTION
Angular’s dev server was failing under edgejs for two separate compatibility reasons.

The first failure was in Angular SSR’s server-side DOM shim. Angular replaces globals such as `CustomEvent` via `Object.assign(globalThis, ...)`. In Node, lazy globals are replaceable before first access and become normal writable properties. In Edge, our native `defineLazyProperties` exposed them as getter-only accessors, so assignment threw on first request.

Fix `defineLazyProperties` to behave like Node’s lazy data properties: materialize the property into a normal writable/configurable value property on both get and set. This makes globals such as `CustomEvent` safely replaceable before first access.

After that, Angular startup exposed a second bug in our N-API layer through `lmdb-js`/`node-addon-api`. Our `napi_add_finalizer()` implementation was incorrectly delegated to `napi_wrap()`, but `node-addon-api` expects `napi_add_finalizer()` to register an independent finalizer without claiming the object as a wrapped native instance. That mismatch caused a fatal abort during addon class definition.

Fix `napi_add_finalizer()` to register its own weak finalizer record and only create a reference when requested, instead of reusing `napi_wrap()`.

---
To reproduce/verify, see: https://github.com/wasmerio/edgejs/issues/22