### PR TITLE
process: fix execPath detection and spawnSync pipe shutdown

### DIFF
--- a/src/edge_process.cc
+++ b/src/edge_process.cc
@@ -491,29 +491,15 @@ std::string DetectExecPath() {
   if (forced_exec != nullptr && forced_exec[0] != '\0') {
     return forced_exec;
   }
-#if defined(__APPLE__)
-  uint32_t size = 0;
-  _NSGetExecutablePath(nullptr, &size);
-  if (size > 0) {
-    std::vector<char> buf(size + 1, '\0');
-    if (_NSGetExecutablePath(buf.data(), &size) == 0) {
-      char resolved[4096] = {'\0'};
-      if (realpath(buf.data(), resolved) != nullptr) {
-        return MaybePreferSiblingEdgeBinary(std::string(resolved));
-      }
-      return MaybePreferSiblingEdgeBinary(std::string(buf.data()));
-    }
+  char exec_path_buf[8192];
+  size_t exec_path_len = sizeof(exec_path_buf);
+  if (uv_exepath(exec_path_buf, &exec_path_len) == 0) {
+    return MaybePreferSiblingEdgeBinary(std::string(exec_path_buf, exec_path_len));
   }
-  return "edge";
-#elif defined(__linux__)
-  std::vector<char> buf(4096, '\0');
-  ssize_t n = readlink("/proc/self/exe", buf.data(), buf.size() - 1);
-  if (n > 0) {
-    buf[static_cast<size_t>(n)] = '\0';
-    return MaybePreferSiblingEdgeBinary(std::string(buf.data()));
+  if (!g_edge_argv0.empty()) {
+    return g_edge_argv0;
   }
-  return "edge";
-#elif defined(_WIN32)
+#if defined(_WIN32)
   return "edge.exe";
 #else
   return "edge";

--- a/src/edge_spawn_sync.cc
+++ b/src/edge_spawn_sync.cc
@@ -734,10 +734,23 @@ void PipeShutdownCallback(uv_shutdown_t* req, int status) {
   auto* pipe = static_cast<SyncPipe*>(req->data);
   if (pipe == nullptr || pipe->runner == nullptr) return;
   pipe->shutdown_pending = false;
-  if (status < 0 && status != UV_ENOTCONN) {
+  if (status < 0 &&
+      status != UV_ENOTCONN
+#if defined(__wasi__)
+      // WASIX stdin uses a one-way pipe here rather than a socket-like stream.
+      // Closing the writer through uv_shutdown() can surface as UV_EACCES even
+      // after the child has already consumed stdin successfully, so treat it as
+      // a close/EOF condition instead of a real spawnSync failure.
+      && status != UV_EACCES
+#endif
+  ) {
     SetPipeErrorIfUnset(pipe->runner, status);
   }
-  if (!pipe->writable) {
+  if (!pipe->writable
+#if defined(__wasi__)
+      || status == UV_EACCES
+#endif
+  ) {
     ClosePipeIfNeeded(pipe);
   }
 }
@@ -758,6 +771,15 @@ void StartPipeShutdown(SyncPipe* pipe) {
     if (!pipe->writable) ClosePipeIfNeeded(pipe);
     return;
   }
+#if defined(__wasi__)
+  if (rc == UV_EACCES) {
+    // See PipeShutdownCallback(): on WASIX this means the stdin writer cannot
+    // be shutdown like a socket stream, not that the child spawn failed.
+    pipe->shutdown_pending = false;
+    ClosePipeIfNeeded(pipe);
+    return;
+  }
+#endif
   if (rc < 0) {
     pipe->shutdown_pending = false;
     SetPipeErrorIfUnset(pipe->runner, rc);

--- a/wasix/setup-wasix-deps.sh
+++ b/wasix/setup-wasix-deps.sh
@@ -36,7 +36,7 @@ clone_or_update() {
 
 mkdir -p "${DEPS_DIR}"
 # Keep the upstream branch name until the external repo renames it.
-clone_or_update "${DEPS_DIR}/libuv-wasix" "https://github.com/wasix-org/libuv.git" "ubi"
+clone_or_update "${DEPS_DIR}/libuv-wasix" "https://github.com/wasix-org/libuv.git" "fix/spawn"
 clone_or_update "${DEPS_DIR}/openssl-wasix" "https://github.com/wasix-org/openssl.git" "master"
 
 echo "WASIX deps are ready under ${DEPS_DIR}"


### PR DESCRIPTION
- use `uv_exepath()` for `process.execPath`, with `argv0` fallback
- ignore `UV_EACCES` from `spawnSync()` stdin shutdown on WASIX

After moving subprocesses onto the WASIX spawn model, `spawnSync()` could still return a successful child result while attaching an `EACCES` error from pipe shutdown cleanup. `process.execPath` also needed to follow the Node-style `uv_exepath()` path. 

~~Depends on https://github.com/wasix-org/libuv/pull/1~~ I've updated the project to look to the fixed libuv branch

With libuv fix and this PR `process.execPath` works, `spawnSync(process.execPath, ['-e', ...])` works as well and lib test for `cross-spawn` now doesn't stall anymore