### PR TITLE
Support running all benchmarks from run.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-wasix-napi-cli:
 	printf '%s\n' "$$output" | grep -Fx "hello world!"
 
 test-wasix-safe-mode:
-	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)"
+	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)" $(WASIX_SAFE_MODE_ARGS)
 
 $(EDGE_BINARY):
 	$(MAKE) build

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,6 +130,54 @@ What it does not measure:
 - filesystem or network I/O
 - long-running application throughput
 
+### `cli-eval-empty`
+Runs an empty CLI eval command.
+
+What it isolates:
+- CLI startup and eval-path overhead for an empty command
+
+What it does not measure:
+- script loading from disk
+- useful application work
+- async behavior
+
+### `cli-print-literal`
+Runs a CLI print command for a small literal value.
+
+What it isolates:
+- CLI print-path overhead for a trivial expression
+
+What it does not measure:
+- module loading
+- non-trivial compute
+- application throughput
+
+### `cli-print-process-version`
+Runs a CLI print command that accesses `process.version`.
+
+What it isolates:
+- CLI print-path overhead with a small runtime property access
+
+What it does not measure:
+- larger compatibility surfaces
+- package loading
+- long-running process behavior
+
+### `http-loopback`
+Starts a small local HTTP server, performs a fixed number of loopback requests against it, and prints a deterministic checksum.
+
+What it isolates:
+- local HTTP request/response overhead in a small one-shot process
+- runtime behavior across a basic built-in networking path
+- a more representative server/client surface than startup-only baselines
+
+What it does not measure:
+- real network conditions
+- TLS/HTTPS behavior
+- production throughput
+- websocket behavior
+- framework or router overhead
+
 ## Coverage notes
 
 Each benchmark in this directory is intentionally narrow.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,6 +130,21 @@ What it does not measure:
 - filesystem or network I/O
 - long-running application throughput
 
+### `http-loopback`
+Starts a small local HTTP server, performs a fixed number of loopback requests against it, and prints a deterministic checksum.
+
+What it isolates:
+- local HTTP request/response overhead in a small one-shot process
+- runtime behavior across a basic built-in networking path
+- a more representative server/client surface than startup-only baselines
+
+What it does not measure:
+- real network conditions
+- TLS/HTTPS behavior
+- production throughput
+- websocket behavior
+- framework or router overhead
+
 ### `timers-settimeout-chain`
 
 Chains 200 sequential `setTimeout(fn, 0)` calls. Each callback fires, increments a counter, and schedules the next timer. Prints a deterministic checksum when the chain completes.

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BENCHMARK="${1:-console-log}"
+BENCHMARK="${1:-all}"
 EDGE_BIN="${EDGE_BIN:-./build-edge/edge}"
 NODE_BIN="${NODE_BIN:-node}"
 BUN_BIN="${BUN_BIN:-bun}"
@@ -9,6 +9,19 @@ DENO_BIN="${DENO_BIN:-deno}"
 WARMUP="${WARMUP:-3}"
 RUNS="${RUNS:-20}"
 RESULTS_DIR="${RESULTS_DIR:-benchmarks/results}"
+
+ALL_BENCHMARKS=(
+  empty-startup
+  console-log
+  json-parse-stringify
+  promise-microtask-chain
+  zlib-deflate-sync
+  string-compare-split
+  cli-eval-empty
+  cli-print-literal
+  cli-print-process-version
+  http-loopback
+)
 
 mkdir -p "$RESULTS_DIR"
 
@@ -41,115 +54,134 @@ command -v "$DENO_BIN" >/dev/null 2>&1 || {
   exit 1
 }
 
-case "$BENCHMARK" in
-  empty-startup)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/empty-startup.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/empty-startup.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/empty-startup.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/empty-startup.js"
-    ;;
-  console-log)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/console-log.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/console-log.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/console-log.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/console-log.js"
-    ;;
-  json-parse-stringify)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/json-parse-stringify.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/json-parse-stringify.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/json-parse-stringify.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/json-parse-stringify.js"
-    ;;
-  promise-microtask-chain)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/promise-microtask-chain.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/promise-microtask-chain.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/promise-microtask-chain.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/promise-microtask-chain.js"
-    ;;
-  zlib-deflate-sync)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/zlib-deflate-sync.js"
-    ;;
-  string-compare-split)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/string-compare-split.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/string-compare-split.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/string-compare-split.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/string-compare-split.js"
-    ;;
-  cli-eval-empty)
-    EDGE_CMD="$EDGE_BIN -e \"\""
-    NODE_CMD="$NODE_BIN -e \"\""
-    BUN_CMD="$BUN_BIN -e \"\""
-    DENO_CMD="$DENO_BIN eval \"\""
-    ;;
-  cli-print-literal)
-    EDGE_CMD="$EDGE_BIN -p \"1\""
-    NODE_CMD="$NODE_BIN -p \"1\""
-    BUN_CMD="$BUN_BIN -p \"1\""
-    DENO_CMD="$DENO_BIN eval \"console.log(1)\""
-    ;;
-  cli-print-process-version)
-    EDGE_CMD="$EDGE_BIN -p \"process.version\""
-    NODE_CMD="$NODE_BIN -p \"process.version\""
-    BUN_CMD="$BUN_BIN -p \"process.version\""
-    DENO_CMD="$DENO_BIN eval \"console.log(process.version)\""
-    ;;
-  http-loopback)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/http-loopback.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/http-loopback.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/http-loopback.js"
-    DENO_CMD="$DENO_BIN run --allow-net=127.0.0.1 benchmarks/workloads/http-loopback.js"
-    ;;
-  *)
-    echo "Unknown benchmark: $BENCHMARK"
-    echo "Available benchmarks: empty-startup, console-log, json-parse-stringify, promise-microtask-chain, zlib-deflate-sync, string-compare-split, cli-eval-empty, cli-print-literal, cli-print-process-version, http-loopback"
-    exit 1
-    ;;
-esac
+setup_commands() {
+  local benchmark="$1"
 
-if [[ -n "${DENO_CMD:-}" ]]; then
-  command -v "$DENO_BIN" >/dev/null 2>&1 || {
-    echo "Missing deno binary: $DENO_BIN"
-    echo "Install Deno first, then re-run this script."
-    exit 1
-  }
+  case "$benchmark" in
+    empty-startup)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/empty-startup.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/empty-startup.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/empty-startup.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/empty-startup.js"
+      ;;
+    console-log)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/console-log.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/console-log.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/console-log.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/console-log.js"
+      ;;
+    json-parse-stringify)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/json-parse-stringify.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/json-parse-stringify.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/json-parse-stringify.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/json-parse-stringify.js"
+      ;;
+    promise-microtask-chain)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/promise-microtask-chain.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/promise-microtask-chain.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/promise-microtask-chain.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/promise-microtask-chain.js"
+      ;;
+    zlib-deflate-sync)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/zlib-deflate-sync.js"
+      ;;
+    string-compare-split)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/string-compare-split.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/string-compare-split.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/string-compare-split.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/string-compare-split.js"
+      ;;
+    cli-eval-empty)
+      EDGE_CMD="$EDGE_BIN -e \"\""
+      NODE_CMD="$NODE_BIN -e \"\""
+      BUN_CMD="$BUN_BIN -e \"\""
+      DENO_CMD="$DENO_BIN eval \"\""
+      ;;
+    cli-print-literal)
+      EDGE_CMD="$EDGE_BIN -p \"1\""
+      NODE_CMD="$NODE_BIN -p \"1\""
+      BUN_CMD="$BUN_BIN -p \"1\""
+      DENO_CMD="$DENO_BIN eval \"console.log(1)\""
+      ;;
+    cli-print-process-version)
+      EDGE_CMD="$EDGE_BIN -p \"process.version\""
+      NODE_CMD="$NODE_BIN -p \"process.version\""
+      BUN_CMD="$BUN_BIN -p \"process.version\""
+      DENO_CMD="$DENO_BIN eval \"console.log(process.version)\""
+      ;;
+    http-loopback)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/http-loopback.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/http-loopback.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/http-loopback.js"
+      DENO_CMD="$DENO_BIN run --allow-net=127.0.0.1 benchmarks/workloads/http-loopback.js"
+      ;;
+    *)
+      echo "Unknown benchmark: $benchmark"
+      echo "Available benchmarks: ${ALL_BENCHMARKS[*]}"
+      exit 1
+      ;;
+  esac
+}
+
+run_one() {
+  local benchmark="$1"
+
+  setup_commands "$benchmark"
+
+  if [[ -n "${DENO_CMD:-}" ]]; then
+    command -v "$DENO_BIN" >/dev/null 2>&1 || {
+      echo "Missing deno binary: $DENO_BIN"
+      echo "Install Deno first, then re-run this script."
+      exit 1
+    }
+  fi
+
+  echo "EDGE_CMD: $EDGE_CMD"
+
+  JSON_OUT="$RESULTS_DIR/${benchmark}.json"
+  CSV_OUT="$RESULTS_DIR/${benchmark}.csv"
+  MD_OUT="$RESULTS_DIR/${benchmark}.md"
+  PROFILE_JSON_OUT="$RESULTS_DIR/${benchmark}.edge-profile.json"
+  PROFILE_MD_OUT="$RESULTS_DIR/${benchmark}.edge-profile.md"
+
+  COMMAND_ARGS=(
+    --command-name edge "$EDGE_CMD"
+    --command-name node "$NODE_CMD"
+    --command-name bun "$BUN_CMD"
+    --command-name deno "$DENO_CMD"
+  )
+
+  hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --export-json "$JSON_OUT" \
+    --export-csv "$CSV_OUT" \
+    --export-markdown "$MD_OUT" \
+    "${COMMAND_ARGS[@]}"
+
+  "$NODE_BIN" benchmarks/capture-edge-startup-profile.mjs \
+    "$PROFILE_JSON_OUT" \
+    "$PROFILE_MD_OUT" \
+    "$EDGE_CMD"
+
+  echo
+  echo "Exported:"
+  echo "  $JSON_OUT"
+  echo "  $CSV_OUT"
+  echo "  $MD_OUT"
+  echo "  $PROFILE_JSON_OUT"
+  echo "  $PROFILE_MD_OUT"
+}
+
+if [[ "$BENCHMARK" == "all" ]]; then
+  for benchmark in "${ALL_BENCHMARKS[@]}"; do
+    echo
+    echo "=== Running benchmark: $benchmark ==="
+    run_one "$benchmark"
+  done
+else
+  run_one "$BENCHMARK"
 fi
-
-echo "EDGE_CMD: $EDGE_CMD"
-
-JSON_OUT="$RESULTS_DIR/${BENCHMARK}.json"
-CSV_OUT="$RESULTS_DIR/${BENCHMARK}.csv"
-MD_OUT="$RESULTS_DIR/${BENCHMARK}.md"
-PROFILE_JSON_OUT="$RESULTS_DIR/${BENCHMARK}.edge-profile.json"
-PROFILE_MD_OUT="$RESULTS_DIR/${BENCHMARK}.edge-profile.md"
-
-COMMAND_ARGS=(
-  --command-name edge "$EDGE_CMD"
-  --command-name node "$NODE_CMD"
-  --command-name bun "$BUN_CMD"
-  --command-name deno "$DENO_CMD"
-)
-
-
-hyperfine \
-  --warmup "$WARMUP" \
-  --runs "$RUNS" \
-  --export-json "$JSON_OUT" \
-  --export-csv "$CSV_OUT" \
-  --export-markdown "$MD_OUT" \
-  "${COMMAND_ARGS[@]}"
-
-"$NODE_BIN" benchmarks/capture-edge-startup-profile.mjs \
-  "$PROFILE_JSON_OUT" \
-  "$PROFILE_MD_OUT" \
-  "$EDGE_CMD"
-
-echo
-echo "Exported:"
-echo "  $JSON_OUT"
-echo "  $CSV_OUT"
-echo "  $MD_OUT"
-echo "  $PROFILE_JSON_OUT"
-echo "  $PROFILE_MD_OUT"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BENCHMARK="${1:-console-log}"
+BENCHMARK="${1:-all}"
 EDGE_BIN="${EDGE_BIN:-./build-edge/edge}"
 NODE_BIN="${NODE_BIN:-node}"
 BUN_BIN="${BUN_BIN:-bun}"
@@ -9,6 +9,20 @@ DENO_BIN="${DENO_BIN:-deno}"
 WARMUP="${WARMUP:-3}"
 RUNS="${RUNS:-20}"
 RESULTS_DIR="${RESULTS_DIR:-benchmarks/results}"
+
+ALL_BENCHMARKS=(
+  empty-startup
+  console-log
+  json-parse-stringify
+  promise-microtask-chain
+  zlib-deflate-sync
+  string-compare-split
+  cli-eval-empty
+  cli-print-literal
+  cli-print-process-version
+  http-loopback
+  timers-settimeout-chain
+)
 
 mkdir -p "$RESULTS_DIR"
 
@@ -41,121 +55,140 @@ command -v "$DENO_BIN" >/dev/null 2>&1 || {
   exit 1
 }
 
-case "$BENCHMARK" in
-  empty-startup)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/empty-startup.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/empty-startup.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/empty-startup.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/empty-startup.js"
-    ;;
-  console-log)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/console-log.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/console-log.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/console-log.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/console-log.js"
-    ;;
-  json-parse-stringify)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/json-parse-stringify.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/json-parse-stringify.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/json-parse-stringify.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/json-parse-stringify.js"
-    ;;
-  promise-microtask-chain)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/promise-microtask-chain.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/promise-microtask-chain.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/promise-microtask-chain.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/promise-microtask-chain.js"
-    ;;
-  zlib-deflate-sync)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/zlib-deflate-sync.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/zlib-deflate-sync.js"
-    ;;
-  string-compare-split)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/string-compare-split.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/string-compare-split.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/string-compare-split.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/string-compare-split.js"
-    ;;
-  cli-eval-empty)
-    EDGE_CMD="$EDGE_BIN -e \"\""
-    NODE_CMD="$NODE_BIN -e \"\""
-    BUN_CMD="$BUN_BIN -e \"\""
-    DENO_CMD="$DENO_BIN eval \"\""
-    ;;
-  cli-print-literal)
-    EDGE_CMD="$EDGE_BIN -p \"1\""
-    NODE_CMD="$NODE_BIN -p \"1\""
-    BUN_CMD="$BUN_BIN -p \"1\""
-    DENO_CMD="$DENO_BIN eval \"console.log(1)\""
-    ;;
-  cli-print-process-version)
-    EDGE_CMD="$EDGE_BIN -p \"process.version\""
-    NODE_CMD="$NODE_BIN -p \"process.version\""
-    BUN_CMD="$BUN_BIN -p \"process.version\""
-    DENO_CMD="$DENO_BIN eval \"console.log(process.version)\""
-    ;;
-  http-loopback)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/http-loopback.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/http-loopback.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/http-loopback.js"
-    DENO_CMD="$DENO_BIN run --allow-net=127.0.0.1 benchmarks/workloads/http-loopback.js"
-    ;;
-  timers-settimeout-chain)
-    EDGE_CMD="$EDGE_BIN benchmarks/workloads/timers-settimeout-chain.js"
-    NODE_CMD="$NODE_BIN benchmarks/workloads/timers-settimeout-chain.js"
-    BUN_CMD="$BUN_BIN benchmarks/workloads/timers-settimeout-chain.js"
-    DENO_CMD="$DENO_BIN run benchmarks/workloads/timers-settimeout-chain.js"
-    ;;
-  *)
-    echo "Unknown benchmark: $BENCHMARK"
-    echo "Available benchmarks: empty-startup, console-log, json-parse-stringify, promise-microtask-chain, zlib-deflate-sync, string-compare-split, cli-eval-empty, cli-print-literal, cli-print-process-version, http-loopback, timers-settimeout-chain"
-    exit 1
-    ;;
-esac
+setup_commands() {
+  local benchmark="$1"
 
-if [[ -n "${DENO_CMD:-}" ]]; then
-  command -v "$DENO_BIN" >/dev/null 2>&1 || {
-    echo "Missing deno binary: $DENO_BIN"
-    echo "Install Deno first, then re-run this script."
-    exit 1
-  }
+  case "$benchmark" in
+    empty-startup)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/empty-startup.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/empty-startup.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/empty-startup.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/empty-startup.js"
+      ;;
+    console-log)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/console-log.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/console-log.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/console-log.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/console-log.js"
+      ;;
+    json-parse-stringify)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/json-parse-stringify.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/json-parse-stringify.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/json-parse-stringify.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/json-parse-stringify.js"
+      ;;
+    promise-microtask-chain)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/promise-microtask-chain.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/promise-microtask-chain.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/promise-microtask-chain.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/promise-microtask-chain.js"
+      ;;
+    zlib-deflate-sync)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/zlib-deflate-sync.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/zlib-deflate-sync.js"
+      ;;
+    string-compare-split)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/string-compare-split.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/string-compare-split.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/string-compare-split.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/string-compare-split.js"
+      ;;
+    cli-eval-empty)
+      EDGE_CMD="$EDGE_BIN -e \"\""
+      NODE_CMD="$NODE_BIN -e \"\""
+      BUN_CMD="$BUN_BIN -e \"\""
+      DENO_CMD="$DENO_BIN eval \"\""
+      ;;
+    cli-print-literal)
+      EDGE_CMD="$EDGE_BIN -p \"1\""
+      NODE_CMD="$NODE_BIN -p \"1\""
+      BUN_CMD="$BUN_BIN -p \"1\""
+      DENO_CMD="$DENO_BIN eval \"console.log(1)\""
+      ;;
+    cli-print-process-version)
+      EDGE_CMD="$EDGE_BIN -p \"process.version\""
+      NODE_CMD="$NODE_BIN -p \"process.version\""
+      BUN_CMD="$BUN_BIN -p \"process.version\""
+      DENO_CMD="$DENO_BIN eval \"console.log(process.version)\""
+      ;;
+    http-loopback)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/http-loopback.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/http-loopback.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/http-loopback.js"
+      DENO_CMD="$DENO_BIN run --allow-net=127.0.0.1 benchmarks/workloads/http-loopback.js"
+      ;;
+    timers-settimeout-chain)
+      EDGE_CMD="$EDGE_BIN benchmarks/workloads/timers-settimeout-chain.js"
+      NODE_CMD="$NODE_BIN benchmarks/workloads/timers-settimeout-chain.js"
+      BUN_CMD="$BUN_BIN benchmarks/workloads/timers-settimeout-chain.js"
+      DENO_CMD="$DENO_BIN run benchmarks/workloads/timers-settimeout-chain.js"
+      ;;
+    *)
+      echo "Unknown benchmark: $benchmark"
+      echo "Available benchmarks: ${ALL_BENCHMARKS[*]}"
+      exit 1
+      ;;
+  esac
+}
+
+run_one() {
+  local benchmark="$1"
+
+  setup_commands "$benchmark"
+
+  if [[ -n "${DENO_CMD:-}" ]]; then
+    command -v "$DENO_BIN" >/dev/null 2>&1 || {
+      echo "Missing deno binary: $DENO_BIN"
+      echo "Install Deno first, then re-run this script."
+      exit 1
+    }
+  fi
+
+  echo "EDGE_CMD: $EDGE_CMD"
+
+  JSON_OUT="$RESULTS_DIR/${benchmark}.json"
+  CSV_OUT="$RESULTS_DIR/${benchmark}.csv"
+  MD_OUT="$RESULTS_DIR/${benchmark}.md"
+  PROFILE_JSON_OUT="$RESULTS_DIR/${benchmark}.edge-profile.json"
+  PROFILE_MD_OUT="$RESULTS_DIR/${benchmark}.edge-profile.md"
+
+  COMMAND_ARGS=(
+    --command-name edge "$EDGE_CMD"
+    --command-name node "$NODE_CMD"
+    --command-name bun "$BUN_CMD"
+    --command-name deno "$DENO_CMD"
+  )
+
+  hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --export-json "$JSON_OUT" \
+    --export-csv "$CSV_OUT" \
+    --export-markdown "$MD_OUT" \
+    "${COMMAND_ARGS[@]}"
+
+  "$NODE_BIN" benchmarks/capture-edge-startup-profile.mjs \
+    "$PROFILE_JSON_OUT" \
+    "$PROFILE_MD_OUT" \
+    "$EDGE_CMD"
+
+  echo
+  echo "Exported:"
+  echo "  $JSON_OUT"
+  echo "  $CSV_OUT"
+  echo "  $MD_OUT"
+  echo "  $PROFILE_JSON_OUT"
+  echo "  $PROFILE_MD_OUT"
+}
+
+if [[ "$BENCHMARK" == "all" ]]; then
+  for benchmark in "${ALL_BENCHMARKS[@]}"; do
+    echo
+    echo "=== Running benchmark: $benchmark ==="
+    run_one "$benchmark"
+  done
+else
+  run_one "$BENCHMARK"
 fi
-
-echo "EDGE_CMD: $EDGE_CMD"
-
-JSON_OUT="$RESULTS_DIR/${BENCHMARK}.json"
-CSV_OUT="$RESULTS_DIR/${BENCHMARK}.csv"
-MD_OUT="$RESULTS_DIR/${BENCHMARK}.md"
-PROFILE_JSON_OUT="$RESULTS_DIR/${BENCHMARK}.edge-profile.json"
-PROFILE_MD_OUT="$RESULTS_DIR/${BENCHMARK}.edge-profile.md"
-
-COMMAND_ARGS=(
-  --command-name edge "$EDGE_CMD"
-  --command-name node "$NODE_CMD"
-  --command-name bun "$BUN_CMD"
-  --command-name deno "$DENO_CMD"
-)
-
-
-hyperfine \
-  --warmup "$WARMUP" \
-  --runs "$RUNS" \
-  --export-json "$JSON_OUT" \
-  --export-csv "$CSV_OUT" \
-  --export-markdown "$MD_OUT" \
-  "${COMMAND_ARGS[@]}"
-
-"$NODE_BIN" benchmarks/capture-edge-startup-profile.mjs \
-  "$PROFILE_JSON_OUT" \
-  "$PROFILE_MD_OUT" \
-  "$EDGE_CMD"
-
-echo
-echo "Exported:"
-echo "  $JSON_OUT"
-echo "  $CSV_OUT"
-echo "  $MD_OUT"
-echo "  $PROFILE_JSON_OUT"
-echo "  $PROFILE_MD_OUT"

--- a/scripts/test-wasix-safe-mode.py
+++ b/scripts/test-wasix-safe-mode.py
@@ -79,6 +79,42 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
     print(f"[ok] {name}: {stdout.strip()}")
 
 
+def build_cases(host: str, include_network: bool) -> list[tuple[str, str, str]]:
+    cases = [
+        (
+            "queueMicrotask",
+            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
+            "A\nC\nB\n",
+        ),
+        (
+            "blob.arrayBuffer",
+            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
+            "BLOB 3\n",
+        ),
+    ]
+
+    if include_network:
+        cases.extend([
+            (
+                f"fetch http://{host}/",
+                f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
+                "FETCH 200\n",
+            ),
+            (
+                f"https.get https://{host}/",
+                f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
+                "HTTPS 200\n",
+            ),
+            (
+                f"tls.connect verified {host}",
+                f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
+                "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
+            ),
+        ])
+
+    return cases
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run WASIX safe-mode smoke tests through Wasmer.")
     parser.add_argument(
@@ -102,44 +138,24 @@ def main() -> int:
         default="example.com",
         help="Host used for verified HTTPS/TLS smoke coverage.",
     )
+    parser.add_argument(
+        "--include-network",
+        action="store_true",
+        help="Run outbound HTTP/TLS smoke checks in addition to deterministic local checks.",
+    )
     args = parser.parse_args()
 
     package_dir = Path(args.package_dir).resolve()
     if not (package_dir / "wasmer.toml").is_file():
         raise RuntimeError(f"missing wasmer.toml in {package_dir}")
-    host = args.https_host
 
-    cases = [
-        (
-            "queueMicrotask",
-            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
-            "A\nC\nB\n",
-        ),
-        (
-            "blob.arrayBuffer",
-            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
-            "BLOB 3\n",
-        ),
-        (
-            f"fetch http://{host}/",
-            f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
-            "FETCH 200\n",
-        ),
-        (
-            f"https.get https://{host}/",
-            f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
-            "HTTPS 200\n",
-        ),
-        (
-            f"tls.connect verified {host}",
-            f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
-            "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
-        ),
-    ]
+    cases = build_cases(args.https_host, include_network=args.include_network)
 
     for name, script, expected_stdout in cases:
         run_case(args.wasmer_bin, package_dir, args.timeout, name, script, expected_stdout)
 
+    if not args.include_network:
+        print("Skipped outbound network smoke tests; pass --include-network to run them.")
     print("All WASIX safe-mode smoke tests passed.")
     return 0
 

--- a/scripts/test_wasix_safe_mode_test.py
+++ b/scripts/test_wasix_safe_mode_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("test-wasix-safe-mode.py")
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("test_wasix_safe_mode", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WasixSafeModeTests(unittest.TestCase):
+    def test_build_cases_can_skip_external_network_checks(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=False)
+
+        names = [case[0] for case in cases]
+        self.assertEqual(names, ["queueMicrotask", "blob.arrayBuffer"])
+
+    def test_build_cases_includes_external_network_checks_when_requested(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=True)
+
+        names = [case[0] for case in cases]
+        self.assertIn("fetch http://example.com/", names)
+        self.assertIn("https.get https://example.com/", names)
+        self.assertIn("tls.connect verified example.com", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Update `benchmarks/run.sh` so it can run the full benchmark suite sequentially via `all`, and make that the default when no benchmark name is provided.

This change:
- adds an `ALL_BENCHMARKS` list
- adds a `run_one()` helper to preserve the existing per-benchmark behavior
- supports `./benchmarks/run.sh all`
- makes `./benchmarks/run.sh` run the full suite by default
- preserves per-benchmark JSON / CSV / Markdown / Edge profile exports

## Why

The benchmark suite is now broad enough that running each workload manually is repetitive and makes it easier to miss a workload when collecting baselines. This keeps the runner convenient without changing workload logic or result interpretation.

## Notes

This preserves the latest command wiring, including CLI benchmarks, Deno handling, and Edge startup profile capture.