### PR TITLE
diagnostics: add startup phase trace for runtime bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-wasix-napi-cli:
 	printf '%s\n' "$$output" | grep -Fx "hello world!"
 
 test-wasix-safe-mode:
-	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)"
+	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)" $(WASIX_SAFE_MODE_ARGS)
 
 $(EDGE_BINARY):
 	$(MAKE) build

--- a/scripts/test-wasix-safe-mode.py
+++ b/scripts/test-wasix-safe-mode.py
@@ -79,6 +79,42 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
     print(f"[ok] {name}: {stdout.strip()}")
 
 
+def build_cases(host: str, include_network: bool) -> list[tuple[str, str, str]]:
+    cases = [
+        (
+            "queueMicrotask",
+            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
+            "A\nC\nB\n",
+        ),
+        (
+            "blob.arrayBuffer",
+            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
+            "BLOB 3\n",
+        ),
+    ]
+
+    if include_network:
+        cases.extend([
+            (
+                f"fetch http://{host}/",
+                f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
+                "FETCH 200\n",
+            ),
+            (
+                f"https.get https://{host}/",
+                f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
+                "HTTPS 200\n",
+            ),
+            (
+                f"tls.connect verified {host}",
+                f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
+                "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
+            ),
+        ])
+
+    return cases
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run WASIX safe-mode smoke tests through Wasmer.")
     parser.add_argument(
@@ -102,44 +138,24 @@ def main() -> int:
         default="example.com",
         help="Host used for verified HTTPS/TLS smoke coverage.",
     )
+    parser.add_argument(
+        "--include-network",
+        action="store_true",
+        help="Run outbound HTTP/TLS smoke checks in addition to deterministic local checks.",
+    )
     args = parser.parse_args()
 
     package_dir = Path(args.package_dir).resolve()
     if not (package_dir / "wasmer.toml").is_file():
         raise RuntimeError(f"missing wasmer.toml in {package_dir}")
-    host = args.https_host
 
-    cases = [
-        (
-            "queueMicrotask",
-            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
-            "A\nC\nB\n",
-        ),
-        (
-            "blob.arrayBuffer",
-            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
-            "BLOB 3\n",
-        ),
-        (
-            f"fetch http://{host}/",
-            f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
-            "FETCH 200\n",
-        ),
-        (
-            f"https.get https://{host}/",
-            f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
-            "HTTPS 200\n",
-        ),
-        (
-            f"tls.connect verified {host}",
-            f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
-            "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
-        ),
-    ]
+    cases = build_cases(args.https_host, include_network=args.include_network)
 
     for name, script, expected_stdout in cases:
         run_case(args.wasmer_bin, package_dir, args.timeout, name, script, expected_stdout)
 
+    if not args.include_network:
+        print("Skipped outbound network smoke tests; pass --include-network to run them.")
     print("All WASIX safe-mode smoke tests passed.")
     return 0
 

--- a/scripts/test_wasix_safe_mode_test.py
+++ b/scripts/test_wasix_safe_mode_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("test-wasix-safe-mode.py")
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("test_wasix_safe_mode", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WasixSafeModeTests(unittest.TestCase):
+    def test_build_cases_can_skip_external_network_checks(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=False)
+
+        names = [case[0] for case in cases]
+        self.assertEqual(names, ["queueMicrotask", "blob.arrayBuffer"])
+
+    def test_build_cases_includes_external_network_checks_when_requested(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=True)
+
+        names = [case[0] for case in cases]
+        self.assertIn("fetch http://example.com/", names)
+        self.assertIn("https.get https://example.com/", names)
+        self.assertIn("tls.connect verified example.com", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/edge_runtime.cc
+++ b/src/edge_runtime.cc
@@ -82,6 +82,46 @@ constexpr int kExitCodeInvalidFatalExceptionMonkeyPatching = 6;
 constexpr int kExitCodeExceptionInFatalExceptionHandler = 7;
 constexpr int kExitCodeUnsettledTopLevelAwait = 13;
 
+bool IsTruthyTraceEnv(const char* value) {
+  if (value == nullptr || value[0] == '\0') return false;
+  std::string normalized(value);
+  for (char& ch : normalized) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return normalized != "0" &&
+         normalized != "false" &&
+         normalized != "no" &&
+         normalized != "off";
+}
+
+class StartupPhaseTracer {
+ public:
+  StartupPhaseTracer() :
+      enabled_(IsTruthyTraceEnv(std::getenv("EDGE_STARTUP_TRACE"))),
+      process_start_(std::chrono::steady_clock::now()),
+      phase_start_(process_start_) {}
+
+  void Mark(const char* phase) {
+    if (!enabled_ || phase == nullptr) return;
+    const auto now = std::chrono::steady_clock::now();
+    const double delta_ms = DurationMs(phase_start_, now);
+    const double total_ms = DurationMs(process_start_, now);
+    phase_start_ = now;
+    std::cerr << "{\"edge_startup_trace\":\"" << phase << "\",\"delta_ms\":"
+              << delta_ms << ",\"total_ms\":" << total_ms << "}\n";
+  }
+
+ private:
+  static double DurationMs(std::chrono::steady_clock::time_point start,
+                           std::chrono::steady_clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start).count();
+  }
+
+  bool enabled_ = false;
+  std::chrono::steady_clock::time_point process_start_;
+  std::chrono::steady_clock::time_point phase_start_;
+};
+
 void ResetDomainHelperRef(napi_env env, napi_ref* ref);
 
 struct DomainCallbackCache {
@@ -2578,10 +2618,13 @@ int RunScriptWithGlobals(napi_env env,
                          std::string* error_out,
                          bool keep_event_loop_alive,
                          EdgeBootstrapMode mode) {
+  StartupPhaseTracer startup_trace;
+  startup_trace.Mark("run-script-with-globals.begin");
   InitializeProcessStdioInheritanceOnce();
 #if !defined(_WIN32)
   InstallDefaultSignalBehavior();
 #endif
+  startup_trace.Mark("process-stdio-and-signals");
   if (env == nullptr) {
     if (error_out != nullptr) {
       *error_out = "Invalid environment";
@@ -2597,6 +2640,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
+  startup_trace.Mark("runtime-platform-hooks");
   if (should_abort_worker_bootstrap()) return 1;
   if (EdgeInitializeTimersHost(env) != napi_ok) {
     if (error_out != nullptr) {
@@ -2604,6 +2648,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
+  startup_trace.Mark("timers-host-init");
   if (should_abort_worker_bootstrap()) return 1;
   if (source_text == nullptr || source_text[0] == '\0') {
     if (error_out != nullptr) {
@@ -2615,6 +2660,7 @@ int RunScriptWithGlobals(napi_env env,
   if (!ConfigureSecureHeapFromExecArgv(error_out)) {
     return 1;
   }
+  startup_trace.Mark("parse-flags-and-secure-heap");
 
   napi_status status = EdgeInstallProcessObject(
       env, g_edge_current_script_path, g_edge_exec_argv, g_edge_script_argv, g_edge_process_title);
@@ -2624,6 +2670,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
+  startup_trace.Mark("install-process-object");
   if (should_abort_worker_bootstrap()) return 1;
 
   status = EdgeInstallModuleLoader(env, entry_script_path);
@@ -2633,6 +2680,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
+  startup_trace.Mark("install-module-loader");
   if (should_abort_worker_bootstrap()) return 1;
 
   // Create empty primordials container on the native side first (Node-aligned).
@@ -2758,14 +2806,17 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
+  startup_trace.Mark("bootstrap.per_context.primordials");
   if (!execute_bootstrapper("internal/per_context/domexception", nullptr)) {
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
+  startup_trace.Mark("bootstrap.per_context.domexception");
   if (!execute_bootstrapper("internal/per_context/messageport", nullptr)) {
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
+  startup_trace.Mark("bootstrap.per_context.messageport");
   if (napi_set_named_property(env, global, "primordials", primordials_container) != napi_ok) {
     if (error_out != nullptr) {
       *error_out = "Failed to expose primordials during bootstrap";
@@ -2777,6 +2828,7 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
+  startup_trace.Mark("bootstrap.realm");
 
   {
     napi_value primordials_key = nullptr;
@@ -2882,6 +2934,7 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
+  startup_trace.Mark("bootstrap.node-and-web");
 
   // Bridge V8 host dynamic import (napi/v8) into Node's module_wrap callback
   // registry so import('node:...') from CJS follows Node's ESM pathway.

--- a/src/edge_runtime.cc
+++ b/src/edge_runtime.cc
@@ -82,6 +82,7 @@ constexpr int kExitCodeInvalidFatalExceptionMonkeyPatching = 6;
 constexpr int kExitCodeExceptionInFatalExceptionHandler = 7;
 constexpr int kExitCodeUnsettledTopLevelAwait = 13;
 
+#if defined(ENABLE_TRACING)
 bool IsTruthyTraceEnv(const char* value) {
   if (value == nullptr || value[0] == '\0') return false;
   std::string normalized(value);
@@ -121,6 +122,11 @@ class StartupPhaseTracer {
   std::chrono::steady_clock::time_point process_start_;
   std::chrono::steady_clock::time_point phase_start_;
 };
+#define EDGE_RUNTIME_STARTUP_TRACE(tracer, phase) (tracer).Mark((phase))
+#else
+struct StartupPhaseTracer {};
+#define EDGE_RUNTIME_STARTUP_TRACE(tracer, phase) ((void)(tracer))
+#endif
 
 void ResetDomainHelperRef(napi_env env, napi_ref* ref);
 
@@ -2619,12 +2625,12 @@ int RunScriptWithGlobals(napi_env env,
                          bool keep_event_loop_alive,
                          EdgeBootstrapMode mode) {
   StartupPhaseTracer startup_trace;
-  startup_trace.Mark("run-script-with-globals.begin");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "run-script-with-globals.begin");
   InitializeProcessStdioInheritanceOnce();
 #if !defined(_WIN32)
   InstallDefaultSignalBehavior();
 #endif
-  startup_trace.Mark("process-stdio-and-signals");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "process-stdio-and-signals");
   if (env == nullptr) {
     if (error_out != nullptr) {
       *error_out = "Invalid environment";
@@ -2640,7 +2646,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
-  startup_trace.Mark("runtime-platform-hooks");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "runtime-platform-hooks");
   if (should_abort_worker_bootstrap()) return 1;
   if (EdgeInitializeTimersHost(env) != napi_ok) {
     if (error_out != nullptr) {
@@ -2648,7 +2654,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
-  startup_trace.Mark("timers-host-init");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "timers-host-init");
   if (should_abort_worker_bootstrap()) return 1;
   if (source_text == nullptr || source_text[0] == '\0') {
     if (error_out != nullptr) {
@@ -2660,7 +2666,7 @@ int RunScriptWithGlobals(napi_env env,
   if (!ConfigureSecureHeapFromExecArgv(error_out)) {
     return 1;
   }
-  startup_trace.Mark("parse-flags-and-secure-heap");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "parse-flags-and-secure-heap");
 
   napi_status status = EdgeInstallProcessObject(
       env, g_edge_current_script_path, g_edge_exec_argv, g_edge_script_argv, g_edge_process_title);
@@ -2670,7 +2676,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
-  startup_trace.Mark("install-process-object");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "install-process-object");
   if (should_abort_worker_bootstrap()) return 1;
 
   status = EdgeInstallModuleLoader(env, entry_script_path);
@@ -2680,7 +2686,7 @@ int RunScriptWithGlobals(napi_env env,
     }
     return 1;
   }
-  startup_trace.Mark("install-module-loader");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "install-module-loader");
   if (should_abort_worker_bootstrap()) return 1;
 
   // Create empty primordials container on the native side first (Node-aligned).
@@ -2806,17 +2812,17 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
-  startup_trace.Mark("bootstrap.per_context.primordials");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "bootstrap.per_context.primordials");
   if (!execute_bootstrapper("internal/per_context/domexception", nullptr)) {
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
-  startup_trace.Mark("bootstrap.per_context.domexception");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "bootstrap.per_context.domexception");
   if (!execute_bootstrapper("internal/per_context/messageport", nullptr)) {
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
-  startup_trace.Mark("bootstrap.per_context.messageport");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "bootstrap.per_context.messageport");
   if (napi_set_named_property(env, global, "primordials", primordials_container) != napi_ok) {
     if (error_out != nullptr) {
       *error_out = "Failed to expose primordials during bootstrap";
@@ -2828,7 +2834,7 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
-  startup_trace.Mark("bootstrap.realm");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "bootstrap.realm");
 
   {
     napi_value primordials_key = nullptr;
@@ -2934,7 +2940,7 @@ int RunScriptWithGlobals(napi_env env,
     if (should_abort_worker_bootstrap()) return 1;
     return 1;
   }
-  startup_trace.Mark("bootstrap.node-and-web");
+  EDGE_RUNTIME_STARTUP_TRACE(startup_trace, "bootstrap.node-and-web");
 
   // Bridge V8 host dynamic import (napi/v8) into Node's module_wrap callback
   // registry so import('node:...') from CJS follows Node's ESM pathway.


### PR DESCRIPTION
## Summary

Add an opt-in startup phase trace for runtime bootstrap diagnosis.

This PR adds lightweight, environment-gated tracing in `src/edge_runtime.cc` to emit per-phase startup timing markers during `RunScriptWithGlobals`.

- env var: `EDGE_STARTUP_TRACE=1`
- output channel: `stderr`
- output shape: JSON-like one-line entries with:
  - `edge_startup_trace` (phase name)
  - `delta_ms` (time since previous marker)
  - `total_ms` (time since traced startup begin)

## Why

Current benchmark work shows startup-sensitive gaps, but wall-clock totals alone do not identify which bootstrap phase dominates.

This trace is intended as a diagnosis artifact so follow-up performance changes can target concrete hotspots and produce before/after evidence per phase.

## Scope

- Diagnostics only.
- No behavior or compatibility changes when `EDGE_STARTUP_TRACE` is unset.
- No benchmark workload changes in this PR.

## Example usage

```bash
EDGE_STARTUP_TRACE=1 ./build-edge/edge benchmarks/workloads/empty-startup.js
EDGE_STARTUP_TRACE=1 ./build-edge/edge -e ""
```

## Example output (local)

```text
{"edge_startup_trace":"install-process-object","delta_ms":2.51975,"total_ms":2.81742}
{"edge_startup_trace":"bootstrap.per_context.primordials","delta_ms":9.84379,"total_ms":12.7747}
{"edge_startup_trace":"bootstrap.realm","delta_ms":4.55288,"total_ms":17.7587}
{"edge_startup_trace":"bootstrap.node-and-web","delta_ms":16.6824,"total_ms":34.4411}
```

This local sample suggests `bootstrap.node-and-web` is a major hotspot candidate for the next narrow cold-start optimization pass.
