### PR TITLE
bench: add setTimeout chain workload

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,6 +130,21 @@ What it does not measure:
 - filesystem or network I/O
 - long-running application throughput
 
+### `timers-settimeout-chain`
+
+Chains 200 sequential `setTimeout(fn, 0)` calls. Each callback fires, increments a counter, and schedules the next timer. Prints a deterministic checksum when the chain completes.
+
+What it isolates:
+- per-`setTimeout` dispatch cost in the event loop timer phase
+- callback scheduling and execution overhead across N iterations
+- a runtime surface that maps to the roadmap's timers benchmark lane
+
+What it does not measure:
+- concurrent timer scheduling (all timers here are sequential)
+- high-resolution timer behavior
+- timer cancellation or re-scheduling
+- `setImmediate` or `queueMicrotask` (covered by `promise-microtask-chain`)
+
 ## Coverage notes
 
 Each benchmark in this directory is intentionally narrow.

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -102,9 +102,15 @@ case "$BENCHMARK" in
     BUN_CMD="$BUN_BIN benchmarks/workloads/http-loopback.js"
     DENO_CMD="$DENO_BIN run --allow-net=127.0.0.1 benchmarks/workloads/http-loopback.js"
     ;;
+  timers-settimeout-chain)
+    EDGE_CMD="$EDGE_BIN benchmarks/workloads/timers-settimeout-chain.js"
+    NODE_CMD="$NODE_BIN benchmarks/workloads/timers-settimeout-chain.js"
+    BUN_CMD="$BUN_BIN benchmarks/workloads/timers-settimeout-chain.js"
+    DENO_CMD="$DENO_BIN run benchmarks/workloads/timers-settimeout-chain.js"
+    ;;
   *)
     echo "Unknown benchmark: $BENCHMARK"
-    echo "Available benchmarks: empty-startup, console-log, json-parse-stringify, promise-microtask-chain, zlib-deflate-sync, string-compare-split, cli-eval-empty, cli-print-literal, cli-print-process-version, http-loopback"
+    echo "Available benchmarks: empty-startup, console-log, json-parse-stringify, promise-microtask-chain, zlib-deflate-sync, string-compare-split, cli-eval-empty, cli-print-literal, cli-print-process-version, http-loopback, timers-settimeout-chain"
     exit 1
     ;;
 esac

--- a/benchmarks/workloads/timers-settimeout-chain.js
+++ b/benchmarks/workloads/timers-settimeout-chain.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// Chain N sequential setTimeout(fn, 0) calls.
+// Each callback fires, increments a counter, and schedules the next one.
+// The chain runs to completion and exits.
+//
+// What it measures:
+// - per-setTimeout dispatch cost in the event loop timer phase
+// - callback scheduling and execution overhead across N iterations
+//
+// What it does not measure:
+// - concurrent timer scheduling (timers are sequential here)
+// - high-resolution timer behavior
+// - timer cancellation or re-scheduling overhead
+
+const N = 200;
+
+let count = 0;
+let checksum = 0;
+
+function tick() {
+  count += 1;
+  checksum += count;
+  if (count < N) {
+    setTimeout(tick, 0);
+  } else {
+    // Deterministic: sum(1..200) = 20100
+    console.log(String(checksum));
+  }
+}
+
+setTimeout(tick, 0);


### PR DESCRIPTION
## What this adds

A new benchmark workload: `timers-settimeout-chain`.

Chains 200 sequential `setTimeout(fn, 0)` calls. Each callback increments a counter and schedules the next timer. When the chain completes it prints a deterministic checksum (`sum(1..200) = 20100`) for cross-runtime correctness verification.

Runtimes covered: Edge.js, Node.js, Bun, Deno.

## What it isolates

- Per-`setTimeout` dispatch cost in the event loop timer phase
- Callback scheduling and execution overhead across N iterations

## What it does not measure

- Concurrent timer scheduling (timers are sequential here)
- High-resolution timer behavior
- Timer cancellation or re-scheduling overhead
- `setImmediate` or `queueMicrotask` (covered by `promise-microtask-chain`)

## Why N=200

Most runtimes enforce a ~1ms minimum timer delay. N=1000 produces ~1.2s runs that are dominated by the minimum-delay floor rather than dispatch overhead. N=200 keeps the run time reasonable while still covering enough iterations to make scheduling cost observable.

## Files

- `benchmarks/workloads/timers-settimeout-chain.js` — new workload
- `benchmarks/run.sh` — added `timers-settimeout-chain` case for all four runtimes
- `benchmarks/README.md` — added workload description

## Run it

```bash
EDGE_BIN=./build-edge/edge NODE_BIN=node BUN_BIN=bun DENO_BIN=deno \
  ./benchmarks/run.sh timers-settimeout-chain
```

This continues the benchmark expansion from the roadmap's timers lane (#8) and the methodology discussion in #44.