### PR TITLE
Upload WASIX safe-mode smoke artifacts

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -464,6 +464,14 @@ jobs:
           set -euo pipefail
           make test-wasix-safe-mode WASMER_BIN=wasmer WASIX_PACKAGE_DIR="$(pwd)/dist"
 
+      - name: Upload WASIX safe-mode smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasix-safe-mode-smoke-linux
+          path: artifacts/wasix-safe-mode
+          if-no-files-found: ignore
+
       - name: Upload artifact edge
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ v8-*.tar.xz
 benchmarks/results/*.json
 benchmarks/results/*.csv
 benchmarks/results/*.md
+/artifacts/wasix-safe-mode/

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ WASIX_EDGEJS_WASM ?= ./build-wasix/edgejs.wasm
 WASIX_NAPI_SMOKE_JS ?= console.log('hello world!');
 WASMER_BIN ?= wasmer
 WASIX_PACKAGE_DIR ?= $(CURDIR)
+WASIX_SAFE_MODE_ARTIFACT_DIR ?= artifacts/wasix-safe-mode
 WASIX_SSL_CERTS_DIR ?= ssl-certs
 EDGE_VERSION_MAJOR := $(shell awk '$$2 == "EDGE_MAJOR_VERSION" {print $$3; exit}' src/edge_version.h)
 EDGE_VERSION_MINOR := $(shell awk '$$2 == "EDGE_MINOR_VERSION" {print $$3; exit}' src/edge_version.h)
@@ -65,7 +66,7 @@ test-wasix-napi-cli:
 	printf '%s\n' "$$output" | grep -Fx "hello world!"
 
 test-wasix-safe-mode:
-	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)"
+	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)" --artifact-dir "$(WASIX_SAFE_MODE_ARTIFACT_DIR)"
 
 $(EDGE_BINARY):
 	$(MAKE) build

--- a/scripts/test-wasix-safe-mode.py
+++ b/scripts/test-wasix-safe-mode.py
@@ -5,6 +5,8 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -23,8 +25,42 @@ def sanitize_stderr(stderr: str) -> str:
     return "\n".join(lines)
 
 
+@dataclass
+class CaseResult:
+    name: str
+    passed: bool
+    log_name: str
+    message: str
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-").lower() or "case"
+
+
+def write_log(log_path: Path, cmd: list[str], stdout: str, stderr: str, returncode: int,
+              message: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join([
+            f"command: {' '.join(cmd)}",
+            f"exit_code: {returncode}",
+            "",
+            "stdout:",
+            stdout,
+            "",
+            "stderr:",
+            stderr,
+            "",
+            "message:",
+            message,
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
 def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script: str,
-             expected_stdout: str) -> None:
+             expected_stdout: str, log_path: Path) -> CaseResult:
     cmd = [
         wasmer_bin,
         "run",
@@ -46,37 +82,72 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"{name} timed out after {timeout}s\n"
-            f"stdout: {exc.stdout or ''}\n"
-            f"stderr: {exc.stderr or ''}"
-        ) from exc
+        stdout = exc.stdout or ""
+        stderr = sanitize_stderr(exc.stderr or "")
+        message = f"{name} timed out after {timeout}s"
+        write_log(log_path, cmd, stdout, stderr, 124, message)
+        return CaseResult(name, False, log_path.name, message)
 
     stdout = completed.stdout
     stderr = sanitize_stderr(completed.stderr)
 
     if completed.returncode != 0:
-        raise RuntimeError(
-            f"{name} exited with {completed.returncode}\n"
-            f"stdout: {stdout}\n"
-            f"stderr: {stderr}"
-        )
+        message = f"{name} exited with {completed.returncode}"
+        write_log(log_path, cmd, stdout, stderr, completed.returncode, message)
+        return CaseResult(name, False, log_path.name, message)
 
     if stdout != expected_stdout:
-        raise RuntimeError(
-            f"{name} stdout mismatch\n"
-            f"expected: {expected_stdout!r}\n"
-            f"actual:   {stdout!r}\n"
-            f"stderr: {stderr}"
+        message = (
+            f"{name} stdout mismatch; expected {expected_stdout!r}, "
+            f"actual {stdout!r}"
         )
+        write_log(log_path, cmd, stdout, stderr, completed.returncode, message)
+        return CaseResult(name, False, log_path.name, message)
 
     if stderr:
-        raise RuntimeError(
-            f"{name} emitted unexpected stderr\n"
-            f"stderr: {stderr}"
-        )
+        message = f"{name} emitted unexpected stderr"
+        write_log(log_path, cmd, stdout, stderr, completed.returncode, message)
+        return CaseResult(name, False, log_path.name, message)
 
+    write_log(log_path, cmd, stdout, stderr, completed.returncode, "passed")
     print(f"[ok] {name}: {stdout.strip()}")
+    return CaseResult(name, True, log_path.name, "passed")
+
+
+def write_summary(summary_path: Path, package_dir: Path, wasmer_bin: str, host: str,
+                  results: list[CaseResult]) -> None:
+    passed = sum(1 for result in results if result.passed)
+    failed = len(results) - passed
+    lines = [
+        "# WASIX Safe-Mode Smoke Report",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Generated | `{datetime.now(timezone.utc).isoformat()}` |",
+        f"| Package dir | `{package_dir}` |",
+        f"| Wasmer binary | `{wasmer_bin}` |",
+        f"| HTTPS host | `{host}` |",
+        "",
+        "## Results",
+        "",
+        "| Case | Status | Log | Message |",
+        "|---|---|---|---|",
+    ]
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        lines.append(
+            f"| `{result.name}` | {status} | `{result.log_name}` | {result.message} |"
+        )
+    lines.extend([
+        "",
+        "## Summary",
+        "",
+        f"- Passed: {passed}",
+        f"- Failed: {failed}",
+        "",
+    ])
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def main() -> int:
@@ -102,12 +173,20 @@ def main() -> int:
         default="example.com",
         help="Host used for verified HTTPS/TLS smoke coverage.",
     )
+    parser.add_argument(
+        "--artifact-dir",
+        default=os.environ.get("WASIX_SAFE_MODE_ARTIFACT_DIR", "artifacts/wasix-safe-mode"),
+        help="Directory where markdown summary and per-case logs are written.",
+    )
     args = parser.parse_args()
 
     package_dir = Path(args.package_dir).resolve()
     if not (package_dir / "wasmer.toml").is_file():
         raise RuntimeError(f"missing wasmer.toml in {package_dir}")
     host = args.https_host
+    artifact_dir = Path(args.artifact_dir).resolve()
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = artifact_dir / run_id
 
     cases = [
         (
@@ -142,8 +221,28 @@ def main() -> int:
         ),
     ]
 
-    for name, script, expected_stdout in cases:
-        run_case(args.wasmer_bin, package_dir, args.timeout, name, script, expected_stdout)
+    results = []
+    for index, (name, script, expected_stdout) in enumerate(cases, start=1):
+        log_path = run_dir / f"{index:02d}-{slugify(name)}.log"
+        result = run_case(
+            args.wasmer_bin,
+            package_dir,
+            args.timeout,
+            name,
+            script,
+            expected_stdout,
+            log_path,
+        )
+        results.append(result)
+        if not result.passed:
+            print(f"[fail] {name}: {result.message}", file=sys.stderr)
+
+    summary_path = run_dir / "summary.md"
+    write_summary(summary_path, package_dir, args.wasmer_bin, host, results)
+    print(f"WASIX safe-mode smoke report: {summary_path}")
+
+    if any(not result.passed for result in results):
+        return 1
 
     print("All WASIX safe-mode smoke tests passed.")
     return 0


### PR DESCRIPTION
This is a small follow-up to make the existing WASIX safe-mode smoke checks produce durable evidence in CI. It does not add new runtime behavior or expand the safe-mode test surface; it just makes the current validation easier to review after a run.

The script now writes a timestamped Markdown summary and per-case logs under `artifacts/wasix-safe-mode/`, and the WASIX CI job uploads those files as `wasix-safe-mode-smoke-linux`. I also added `WASIX_SAFE_MODE_ARTIFACT_DIR` so the output location can be overridden from Make.

I verified the script path locally with:

```bash
python3 scripts/test-wasix-safe-mode.py --help
python3 -m py_compile scripts/test-wasix-safe-mode.py
git diff --check
```

I did not run the live WASIX safe-mode tests locally; the existing WASIX CI job is the intended environment for the Wasmer/package smoke path.