### PR TITLE
add simple http server example

### DIFF
--- a/examples/simple-server.js
+++ b/examples/simple-server.js
@@ -1,0 +1,11 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello from Edge.js running in WebAssembly!\n');
+});
+
+const PORT = 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}/`);
+});


### PR DESCRIPTION
I've added a basic HTTP server example to the examples folder. This demonstrates how to use the standard http module within the Edge.js environment, providing a helpful starting point for new users