### PR TITLE
test: re-enable TLS compatibility checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-wasix-napi-cli:
 	printf '%s\n' "$$output" | grep -Fx "hello world!"
 
 test-wasix-safe-mode:
-	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)"
+	python3 ./scripts/test-wasix-safe-mode.py --wasmer-bin "$(WASMER_BIN)" --package-dir "$(WASIX_PACKAGE_DIR)" $(WASIX_SAFE_MODE_ARGS)
 
 $(EDGE_BINARY):
 	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test: build test-only
 test-only:
 	NODE_TEST_RUNNER=$(EDGE_BINARY) ./test/nodejs_test_harness --category=node:buffer,node:console,node:dgram,node:diagnostics_channel,node:dns,node:events,node:http,node:https,node:os,node:path,node:punycode,node:querystring,node:stream,node:string_decoder,node:tty,node:url,node:zlib,node:crypto,node:domain,node:http2,node:tls,node:sys \
 	  -j $(TEST_JOBS) \
-	  --skip-tests=known_issues/test-stdin-is-always-net.socket.js,parallel/test-dns-perf_hooks.js,parallel/test-dns-channel-timeout.js,parallel/test-http-server-headers-timeout-keepalive.js,parallel/test-http-server-request-timeout-keepalive.js,parallel/test-http2-client-jsstream-destroy.js,parallel/test-tls-connect-abort-controller.js,parallel/test-tls-alert-handling.js,parallel/test-tls-close-notify.js,parallel/test-strace-openat-openssl.js,parallel/test-domain-no-error-handler-abort-on-uncaught-0.js,parallel/test-domain-no-error-handler-abort-on-uncaught-1.js,parallel/test-domain-no-error-handler-abort-on-uncaught-2.js,parallel/test-domain-no-error-handler-abort-on-uncaught-3.js,parallel/test-domain-no-error-handler-abort-on-uncaught-4.js,parallel/test-domain-no-error-handler-abort-on-uncaught-5.js,parallel/test-domain-no-error-handler-abort-on-uncaught-6.js,parallel/test-domain-no-error-handler-abort-on-uncaught-7.js,parallel/test-domain-no-error-handler-abort-on-uncaught-8.js,parallel/test-domain-no-error-handler-abort-on-uncaught-9.js,parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js,parallel/test-domain-with-abort-on-uncaught-exception.js,parallel/test-http2-forget-closed-streams.js,parallel/test-http2-pipe.js,abort/test-http-parser-consume.js,abort/test-zlib-invalid-internals-usage.js
+	  --skip-tests=known_issues/test-stdin-is-always-net.socket.js,parallel/test-dns-perf_hooks.js,parallel/test-dns-channel-timeout.js,parallel/test-http-server-headers-timeout-keepalive.js,parallel/test-http-server-request-timeout-keepalive.js,parallel/test-http2-client-jsstream-destroy.js,parallel/test-strace-openat-openssl.js,parallel/test-domain-no-error-handler-abort-on-uncaught-0.js,parallel/test-domain-no-error-handler-abort-on-uncaught-1.js,parallel/test-domain-no-error-handler-abort-on-uncaught-2.js,parallel/test-domain-no-error-handler-abort-on-uncaught-3.js,parallel/test-domain-no-error-handler-abort-on-uncaught-4.js,parallel/test-domain-no-error-handler-abort-on-uncaught-5.js,parallel/test-domain-no-error-handler-abort-on-uncaught-6.js,parallel/test-domain-no-error-handler-abort-on-uncaught-7.js,parallel/test-domain-no-error-handler-abort-on-uncaught-8.js,parallel/test-domain-no-error-handler-abort-on-uncaught-9.js,parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js,parallel/test-domain-with-abort-on-uncaught-exception.js,parallel/test-http2-forget-closed-streams.js,parallel/test-http2-pipe.js,abort/test-http-parser-consume.js,abort/test-zlib-invalid-internals-usage.js
 
 # 	Tests not working on linux
 
@@ -84,9 +84,6 @@ test-only:
 # 	/parallel/test-http-server-request-timeout-keepalive.js
 # 	/parallel/test-http2-client-jsstream-destroy.js
 # 	/parallel/test-http2-pipe.js
-# 	/parallel/test-tls-alert-handling.js
-# 	/parallel/test-tls-close-notify.js
-# 	/parallel/test-tls-connect-abort-controller.js
 # 	/parallel/test-strace-openat-openssl.js
 # 	/parallel/test-domain-no-error-handler-abort-on-uncaught-0.js
 # 	/parallel/test-domain-no-error-handler-abort-on-uncaught-1.js

--- a/scripts/test-wasix-safe-mode.py
+++ b/scripts/test-wasix-safe-mode.py
@@ -79,6 +79,42 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
     print(f"[ok] {name}: {stdout.strip()}")
 
 
+def build_cases(host: str, include_network: bool) -> list[tuple[str, str, str]]:
+    cases = [
+        (
+            "queueMicrotask",
+            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
+            "A\nC\nB\n",
+        ),
+        (
+            "blob.arrayBuffer",
+            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
+            "BLOB 3\n",
+        ),
+    ]
+
+    if include_network:
+        cases.extend([
+            (
+                f"fetch http://{host}/",
+                f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
+                "FETCH 200\n",
+            ),
+            (
+                f"https.get https://{host}/",
+                f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
+                "HTTPS 200\n",
+            ),
+            (
+                f"tls.connect verified {host}",
+                f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
+                "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
+            ),
+        ])
+
+    return cases
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run WASIX safe-mode smoke tests through Wasmer.")
     parser.add_argument(
@@ -102,44 +138,24 @@ def main() -> int:
         default="example.com",
         help="Host used for verified HTTPS/TLS smoke coverage.",
     )
+    parser.add_argument(
+        "--include-network",
+        action="store_true",
+        help="Run outbound HTTP/TLS smoke checks in addition to deterministic local checks.",
+    )
     args = parser.parse_args()
 
     package_dir = Path(args.package_dir).resolve()
     if not (package_dir / "wasmer.toml").is_file():
         raise RuntimeError(f"missing wasmer.toml in {package_dir}")
-    host = args.https_host
 
-    cases = [
-        (
-            "queueMicrotask",
-            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
-            "A\nC\nB\n",
-        ),
-        (
-            "blob.arrayBuffer",
-            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
-            "BLOB 3\n",
-        ),
-        (
-            f"fetch http://{host}/",
-            f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
-            "FETCH 200\n",
-        ),
-        (
-            f"https.get https://{host}/",
-            f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
-            "HTTPS 200\n",
-        ),
-        (
-            f"tls.connect verified {host}",
-            f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
-            "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
-        ),
-    ]
+    cases = build_cases(args.https_host, include_network=args.include_network)
 
     for name, script, expected_stdout in cases:
         run_case(args.wasmer_bin, package_dir, args.timeout, name, script, expected_stdout)
 
+    if not args.include_network:
+        print("Skipped outbound network smoke tests; pass --include-network to run them.")
     print("All WASIX safe-mode smoke tests passed.")
     return 0
 

--- a/scripts/test_wasix_safe_mode_test.py
+++ b/scripts/test_wasix_safe_mode_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("test-wasix-safe-mode.py")
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("test_wasix_safe_mode", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WasixSafeModeTests(unittest.TestCase):
+    def test_build_cases_can_skip_external_network_checks(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=False)
+
+        names = [case[0] for case in cases]
+        self.assertEqual(names, ["queueMicrotask", "blob.arrayBuffer"])
+
+    def test_build_cases_includes_external_network_checks_when_requested(self):
+        module = load_script()
+
+        cases = module.build_cases("example.com", include_network=True)
+
+        names = [case[0] for case in cases]
+        self.assertIn("fetch http://example.com/", names)
+        self.assertIn("https.get https://example.com/", names)
+        self.assertIn("tls.connect verified example.com", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is the first follow-up from #75.

The TLS cases that were skipped during CI stabilization now pass locally when run directly, under repeated harness runs, under the full `node:tls` category, and through `make test-only` with the rest of the current skip list still applied.

This PR removes only those TLS cases from the skip list so CI can validate the macOS runner path again.

CI also caught the existing WASIX safe-mode smoke issue where outbound `example.com` HTTPS checks can make `build-wasix-linux` nondeterministic. I carried over the deterministic safe-mode split here so the default CI target keeps local WASIX smoke coverage, while external network checks remain available with `WASIX_SAFE_MODE_ARGS=--include-network`.

Verification run locally:

```sh
./build-edge/edge test/parallel/test-tls-alert-handling.js
./build-edge/edge test/parallel/test-tls-close-notify.js
./build-edge/edge test/parallel/test-tls-connect-abort-controller.js
python3 test/tools/test.py --timeout 10 --test-root test --shell ./build-edge/edge -j 1 --repeat 30 parallel/test-tls-alert-handling.js
python3 test/tools/test.py --timeout 10 --test-root test --shell ./build-edge/edge -j 1 --repeat 30 parallel/test-tls-close-notify.js
python3 test/tools/test.py --timeout 10 --test-root test --shell ./build-edge/edge -j 1 --repeat 30 parallel/test-tls-connect-abort-controller.js
NODE_TEST_RUNNER=./build-edge/edge ./test/nodejs_test_harness --category=node:tls -j 0 --timeout 10
make test-only EDGE_BINARY=./build-edge/edge TEST_JOBS=4
python3 -m unittest scripts/test_wasix_safe_mode_test.py
python3 -m py_compile scripts/test-wasix-safe-mode.py scripts/test_wasix_safe_mode_test.py
make -n test-wasix-safe-mode WASMER_BIN=wasmer WASIX_SAFE_MODE_ARGS=--include-network
git diff --check
```
