### PR TITLE
Fix unescaped and ignored values returned

### DIFF
--- a/plans/quickjs-wasm/development/troubleshooting/node-test/006_eventemitter_asyncresource_private_fields.md
+++ b/plans/quickjs-wasm/development/troubleshooting/node-test/006_eventemitter_asyncresource_private_fields.md
@@ -41,6 +41,51 @@ cmake --build build-edge-quickjs-cli --target edge -j4
 build-edge-quickjs-cli/edge test/parallel/test-eventemitter-asyncresource.js
 ```
 
+## 2026-05-19 Debug Teardown Assertion
+
+A Debug build later reproduced a different failure after the test body passed:
+
+```text
+Assertion failed: (!block->is_free(slot)), function unsafe_owner, file napi_allocator.h
+```
+
+LLDB showed the crash during `napi_env__::prepare_teardown()`.
+`clear_refs_for_teardown()` freed all env-owned `napi_ref` allocator slots before
+`root_scope->close()` and `JS_RunGC(...)`. QuickJS GC then finalized an
+async-wrap destroy-hook external; `DestroyHookFinalizer(...)` called
+`IsDestroyHookAlreadyHandled(...)`, which attempted
+`napi_get_reference_value(...)` on `DestroyHookData::destroyed_ref`. That raw
+`napi_ref` handle pointed at a slot already returned to the free list.
+
+Action plan before code changes:
+
+1. Keep env-owned `napi_ref` slots allocated through QuickJS finalization.
+2. Clear their JS ownership before GC so strong values and weak links do not
+   keep objects alive during teardown.
+3. Let late finalizer calls observe cleared refs as empty/inactive handles
+   instead of freed allocator storage.
+4. Rerun the focused EventEmitterAsyncResource test and a focused native
+   QuickJS reference/teardown test.
+
+Implemented by changing `napi_env__::clear_refs_for_teardown()` to iterate the
+env-owned ref allocator and call `clear_for_teardown()` without returning slots
+to the allocator free list before QuickJS GC.
+
+Verification:
+
+```sh
+cmake --build build-edge-quickjs-cli --target edge -j4
+build-edge-quickjs-cli/edge test/parallel/test-eventemitter-asyncresource.js
+cd napi && make build-native-quickjs
+napi/build-napi-quickjs/quickjs/tests/napi_quickjs_test_16_reference
+napi/build-napi-quickjs/quickjs/tests/napi_quickjs_test_37_reference_double_free
+napi/build-napi-quickjs/quickjs/tests/napi_quickjs_test_38_finalizer
+```
+
+The focused commands passed. A broader `make test-quickjs-only TEST_JOBS=4`
+run was stopped after it became dominated by sandbox-local `bind/listen EPERM`
+network failures; no allocator assertion recurred before it was terminated.
+
 ## How Should We Fix It
 
 Keep this as a vendored QuickJS compatibility patch. The failing Node API reaches

--- a/plans/quickjs-wasm/development/troubleshooting/node-test/017_http2_native_lifecycle_crashes.md
+++ b/plans/quickjs-wasm/development/troubleshooting/node-test/017_http2_native_lifecycle_crashes.md
@@ -177,3 +177,64 @@ Full QuickJS result returned to the earlier baseline:
 ```
 
 The three regression-only failures were absent from the final failed-test list.
+
+## 2026-05-19 Debug `test-http2-status-code` Handle Scope Assertion
+
+Debug QuickJS builds reproduced another allocator assertion in:
+
+```text
+test/parallel/test-http2-status-code.js
+Assertion failed: (!block->is_free(slot)), function unsafe_owner, file napi_allocator.h
+```
+
+Sandboxed reproduction stops earlier with `listen EPERM`, so the focused repro
+must run outside the sandbox or in the normal local terminal.
+
+LLDB showed a stale local `napi_value`, not a stale `napi_ref`:
+
+```text
+napi_allocator__<napi_value__, napi_scope__>::unsafe_owner(...)
+  napi_env__::value_from_handle(...)
+  napi_typeof(...)
+  InvokeStreamCloseCallback(...)
+  OnStreamClose(...)
+  nghttp2_session_mem_send(...)
+  FlushSessionOutput(...)
+  RunDeferredSessionFlushTask(...)
+```
+
+Root cause: `CallCallbackRef(...)` opens an `edge::HandleScope`, calls
+`EdgeAsyncWrapMakeCallback(...)`, stores the callback return value in an output
+`napi_value`, then returns to its caller after the helper scope has closed.
+`InvokeStreamCloseCallback(...)` then calls `napi_typeof(...)` on that returned
+local handle.
+
+Action plan before code changes:
+
+1. Keep HTTP/2 native callback dispatch scoped.
+2. When `CallCallbackRef(...)` or `CallCallbackRefWithResource(...)` has an
+   output result, use an escapable scope and escape exactly that result to the
+   caller's outer scope.
+3. Leave no-result callback dispatch on plain `edge::HandleScope`.
+4. Rebuild the QuickJS Edge CLI and rerun `test-http2-status-code` outside the
+   sandbox, plus the earlier `test-eventemitter-asyncresource` crash repro.
+
+Implemented in `src/internal_binding/binding_http2.cc`: HTTP/2 callback
+dispatch now uses `edge::EscapableHandleScope` and only escapes the callback
+return value when the caller supplied a result out-parameter.
+
+Verification:
+
+```sh
+cmake --build build-edge-quickjs-cli --target edge -j4
+build-edge-quickjs-cli/edge test/parallel/test-http2-status-code.js
+build-edge-quickjs-cli/edge test/parallel/test-eventemitter-asyncresource.js
+python3 test/tools/test.py --timeout 30 --test-root ./test \
+  --shell ./build-edge-quickjs-cli/edge -j 1 \
+  parallel/test-http2-status-code \
+  parallel/test-http2-close-while-writing \
+  parallel/test-http2-create-client-connect \
+  parallel/test-http2-client-jsstream-destroy
+```
+
+The focused HTTP/2 cluster passed `+4 -0`.

--- a/src/internal_binding/binding_http2.cc
+++ b/src/internal_binding/binding_http2.cc
@@ -1258,14 +1258,18 @@ bool CallCallbackRef(napi_env env,
                      napi_value* argv,
                      napi_value* result = nullptr) {
   if (env == nullptr) return false;
-  edge::HandleScope scope(env);
+  if (result != nullptr) *result = nullptr;
+  edge::EscapableHandleScope scope(env);
   if (!scope.is_open()) return false;
   napi_value callback = GetRefValue(env, callback_ref);
   if (!IsFunction(env, callback) || recv == nullptr) return false;
-  napi_value ignored = nullptr;
-  napi_value* out = result != nullptr ? result : &ignored;
-  return EdgeAsyncWrapMakeCallback(
-             env, async_id, recv, recv, callback, argc, argv, out, kEdgeMakeCallbackNone) == napi_ok;
+  napi_value local_result = nullptr;
+  const bool ok = EdgeAsyncWrapMakeCallback(
+                      env, async_id, recv, recv, callback, argc, argv, &local_result, kEdgeMakeCallbackNone) == napi_ok;
+  if (ok && result != nullptr && local_result != nullptr) {
+    *result = scope.Escape(local_result);
+  }
+  return ok;
 }
 
 bool CallCallbackRefWithResource(napi_env env,
@@ -1277,23 +1281,27 @@ bool CallCallbackRefWithResource(napi_env env,
                                  napi_value* argv,
                                  napi_value* result = nullptr) {
   if (env == nullptr) return false;
-  edge::HandleScope scope(env);
+  if (result != nullptr) *result = nullptr;
+  edge::EscapableHandleScope scope(env);
   if (!scope.is_open()) return false;
   napi_value callback = GetRefValue(env, callback_ref);
   napi_value resource = GetRefValue(env, resource_ref);
   napi_value effective_recv = recv != nullptr ? recv : resource;
   if (!IsFunction(env, callback) || effective_recv == nullptr) return false;
-  napi_value ignored = nullptr;
-  napi_value* out = result != nullptr ? result : &ignored;
-  return EdgeAsyncWrapMakeCallback(env,
-                                  async_id,
-                                  resource != nullptr ? resource : effective_recv,
-                                  effective_recv,
-                                  callback,
-                                  argc,
-                                  argv,
-                                  out,
-                                  kEdgeMakeCallbackNone) == napi_ok;
+  napi_value local_result = nullptr;
+  const bool ok = EdgeAsyncWrapMakeCallback(env,
+                                           async_id,
+                                           resource != nullptr ? resource : effective_recv,
+                                           effective_recv,
+                                           callback,
+                                           argc,
+                                           argv,
+                                           &local_result,
+                                           kEdgeMakeCallbackNone) == napi_ok;
+  if (ok && result != nullptr && local_result != nullptr) {
+    *result = scope.Escape(local_result);
+  }
+  return ok;
 }
 
 bool CallNamedIntMethod(napi_env env,


### PR DESCRIPTION
When value is returned from current scope it needs to be escaped. If value is ignored, then no point escaping it.