### PR TITLE
Edge only solution to follow symlinks

### DIFF
--- a/plans/quickjs-wasm/development/troubleshooting/wasmer-deploy/006_wasix_symlink_component_fs_ops.md
+++ b/plans/quickjs-wasm/development/troubleshooting/wasmer-deploy/006_wasix_symlink_component_fs_ops.md
@@ -1,0 +1,145 @@
+# Wasmer Deploy: WASIX symlink component fs operations
+
+| | | Remarks |
+| --- | --- | --- |
+| **Status** | 🟢 | Fixed by canonicalizing follow-style raw filesystem operations and `process.chdir(...)` before passing paths to libuv. |
+| **Severity** | High | Next.js bundle aliases such as `[id].rsc.func -> [id].func` cannot be read through the symlink path in WASIX. |
+| **Last Updated (Created)** | 2026-05-20 (2026-05-20) | Added `process.chdir(...)` coverage after verifying `server.mjs` route handling under Wasmer. |
+
+## Reproduction
+
+Wasmer can resolve and stat symlinked directory paths, but the raw filesystem
+operation that follows still receives `ENOENT`:
+
+```sh
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir/hello.txt
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir/hello-link
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); fs.accessSync('/tmp/linked-dir/hello.txt'); const fd=fs.openSync('/tmp/linked-dir/hello.txt','r'); fs.closeSync(fd); console.log('open/access ok')"
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); process.chdir('/tmp/linked-dir'); console.log(process.cwd()); console.log(fs.readFileSync('hello-link','utf8').trim());"
+wasmer run --volume quickjs-wasm/test/:/test --volume /Users/sadhbh/src/ImperfectProtocol/private-poker/.next-bundle:/app --net quickjs-wasm -- /app/server.mjs
+```
+
+The diagnostic output shows:
+
+- `lstat('/tmp/linked-dir')` observes the symlink.
+- `realpath('/tmp/linked-dir')` returns `/tmp/orig-dir`.
+- `stat('/tmp/linked-dir')` follows the symlink and succeeds.
+- `readdir('/tmp/linked-dir')` fails with `ENOENT`.
+- `readFile('/tmp/linked-dir/hello.txt')` fails with `ENOENT`.
+- `readFile('/tmp/linked-dir/hello-link')` fails with `ENOENT`.
+- `process.chdir('/app/functions/...symlinked.func')` fails with `ENOENT`
+  while the Next.js `server.mjs` adapter enters function directories.
+
+Native Node and the native Edge QuickJS CLI both succeed for the same paths.
+
+## Action plan
+
+1. Keep `lstat` and `readlink` using the literal path, because they must report
+   the symlink itself.
+2. For filesystem operations that normally follow symlinks, canonicalize the
+   existing path before passing it to libuv.
+3. For `open`-style operations that may create a missing final path, canonicalize
+   the parent path and append the final component.
+4. Patch the raw Edge filesystem binding used by `readFileUtf8`, `readdir`,
+   `open`, `writeFileUtf8`, and `access`.
+5. Patch `process.chdir(...)`, because server adapters enter function
+   directories before requiring function handlers.
+6. Rebuild the QuickJS WASIX package and verify the focused Wasmer symlink probes
+   plus the Next.js `server.mjs` route paths.
+
+## Resolution
+
+`src/edge_fs.cc` now resolves paths for follow-style operations before calling
+libuv. Existing paths use `realpath` directly. Paths with missing components
+resolve the nearest existing ancestor and append the original remaining path.
+Open operations skip this resolver when `O_NOFOLLOW` is set.
+
+`src/internal_binding/binding_fs.cc` applies the same destination-resolution rule
+to `fs.mkdirSync(...)`, `fs.mkdir(..., cb)`, `fs.symlinkSync(...)`, and the async
+symlink binding path, so creating directories and symlinks inside a symlinked
+directory works too. The symlink target remains unchanged because relative
+symlink targets are interpreted relative to the link path.
+
+`src/edge_process.cc` resolves `process.chdir(...)` destinations before calling
+`uv_chdir(...)`. Errors still report the originally requested destination.
+
+Literal symlink APIs still use the original path:
+
+- `lstat`
+- `readlink`
+
+Creation APIs resolve only the destination parent:
+
+- `mkdir`
+- `symlink`
+
+Process state APIs resolve the destination directory:
+
+- `process.chdir`
+
+## Verification
+
+Native QuickJS CLI:
+
+```sh
+./build-edge-quickjs-cli/edge quickjs-wasm/test/check-readfile.js quickjs-wasm/tmp/linked-dir
+./build-edge-quickjs-cli/edge quickjs-wasm/test/check-readfile.js quickjs-wasm/tmp/linked-dir/hello.txt
+./build-edge-quickjs-cli/edge quickjs-wasm/test/check-readfile.js quickjs-wasm/tmp/linked-dir/hello-link
+```
+
+QuickJS WASIX rebuild:
+
+```sh
+cd /Users/sadhbh/src/dev/edgejs/quickjs-wasm/ && ./build.sh
+```
+
+Focused Wasmer probes:
+
+```sh
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/orig-dir
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/orig-dir/hello.txt
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir/hello.txt
+wasmer run --volume quickjs-wasm/test/:/test --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- /test/check-readfile.js /tmp/linked-dir/hello-link
+```
+
+Symlink creation through a linked directory:
+
+```sh
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); const rm=p=>{try{fs.unlinkSync(p)}catch{}}; rm('/tmp/orig-dir/wasm-made-file-link'); rm('/tmp/orig-dir/wasm-made-dir-link'); fs.mkdirSync('/tmp/orig-dir/wasm-child-dir',{recursive:true}); fs.writeFileSync('/tmp/orig-dir/wasm-child-dir/nested.txt','Nested!'); fs.symlinkSync('hello.txt','/tmp/linked-dir/wasm-made-file-link'); fs.symlinkSync('wasm-child-dir','/tmp/linked-dir/wasm-made-dir-link','dir'); console.log(JSON.stringify({ fileLink: fs.readlinkSync('/tmp/linked-dir/wasm-made-file-link'), fileText: fs.readFileSync('/tmp/linked-dir/wasm-made-file-link','utf8').trim(), dirLink: fs.readlinkSync('/tmp/linked-dir/wasm-made-dir-link'), dirEntries: fs.readdirSync('/tmp/linked-dir/wasm-made-dir-link') }));"
+```
+
+Creation through a linked directory:
+
+```sh
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); try{fs.unlinkSync('/tmp/orig-dir/wasm-created.txt')}catch{}; fs.writeFileSync('/tmp/linked-dir/wasm-created.txt','Created!'); console.log(fs.readFileSync('/tmp/orig-dir/wasm-created.txt','utf8'));"
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); try{fs.rmdirSync('/tmp/orig-dir/wasm-created-dir')}catch{}; fs.mkdirSync('/tmp/linked-dir/wasm-created-dir'); console.log(fs.statSync('/tmp/orig-dir/wasm-created-dir').isDirectory());"
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); try{fs.rmdirSync('/tmp/orig-dir/wasm-recursive-dir/leaf')}catch{}; try{fs.rmdirSync('/tmp/orig-dir/wasm-recursive-dir')}catch{}; fs.mkdirSync('/tmp/linked-dir/wasm-recursive-dir/leaf',{recursive:true}); console.log(fs.statSync('/tmp/orig-dir/wasm-recursive-dir/leaf').isDirectory());"
+```
+
+Changing directory through a linked directory:
+
+```sh
+wasmer run --volume quickjs-wasm/tmp/:/tmp quickjs-wasm -- -e "const fs=require('fs'); process.chdir('/tmp/linked-dir'); console.log(process.cwd()); console.log(fs.readFileSync('hello-link','utf8').trim());"
+```
+
+Next.js bundle shape:
+
+```sh
+wasmer run --volume quickjs-wasm/test/:/test --volume /Users/sadhbh/src/ImperfectProtocol/private-poker/.next-bundle:/app ./quickjs-wasm -- /test/check-readfile.js '/app/functions/lobby/[id].rsc.func/'
+wasmer run --volume quickjs-wasm/test/:/test --volume /Users/sadhbh/src/ImperfectProtocol/private-poker/.next-bundle:/app ./quickjs-wasm -- /test/check-readfile.js '/app/functions/lobby/[id].rsc.func/.vc-config.json'
+```
+
+Next.js `server.mjs` function entry:
+
+```sh
+wasmer run --volume quickjs-wasm/test/:/test --volume /Users/sadhbh/src/ImperfectProtocol/private-poker/.next-bundle:/app --net quickjs-wasm -- /app/server.mjs
+curl -sS -o /dev/null -w '/ %{http_code} %{content_type}\n' http://127.0.0.1:3000/
+curl -sS -o /dev/null -w '/about %{http_code} %{content_type}\n' http://127.0.0.1:3000/about
+curl -sS -o /dev/null -w '/leaderboard %{http_code} %{content_type}\n' http://127.0.0.1:3000/leaderboard
+curl -sS -o /dev/null -w '/main-lobby %{http_code} %{content_type}\n' http://127.0.0.1:3000/main-lobby
+curl -sS -o /dev/null -w '/lobby/1 %{http_code} %{content_type}\n' http://127.0.0.1:3000/lobby/1
+```
+
+All of the focused probes passed after the rebuild.

--- a/src/edge_fs.cc
+++ b/src/edge_fs.cc
@@ -115,6 +115,52 @@ bool PathFromValueStrict(napi_env env, napi_value value, std::string* out) {
   return true;
 }
 
+bool TryRealpath(const std::string& path, std::string* out) {
+  if (out == nullptr || path.empty()) return false;
+
+  uv_fs_t req;
+  const std::string namespaced = edge_path::ToNamespacedPath(path);
+  int err = uv_fs_realpath(nullptr, &req, namespaced.c_str(), nullptr);
+  if (err < 0 || req.ptr == nullptr) {
+    uv_fs_req_cleanup(&req);
+    return false;
+  }
+
+  *out = edge_path::FromNamespacedPath(static_cast<const char*>(req.ptr));
+  uv_fs_req_cleanup(&req);
+  return true;
+}
+
+std::string ResolvePathForFollowOperation(const std::string& path) {
+  std::string resolved;
+  if (TryRealpath(path, &resolved)) return resolved;
+
+  std::filesystem::path current(path);
+  std::vector<std::filesystem::path> tail;
+  while (!current.empty()) {
+    const std::filesystem::path parent = current.parent_path();
+    const std::filesystem::path filename = current.filename();
+    if (filename.empty() || parent == current) break;
+
+    tail.push_back(filename);
+    current = parent;
+    if (TryRealpath(current.string(), &resolved)) {
+      std::filesystem::path out(resolved);
+      for (auto it = tail.rbegin(); it != tail.rend(); ++it) out /= *it;
+      return out.string();
+    }
+  }
+
+  return path;
+}
+
+bool ShouldResolveOpenPath(int32_t flags) {
+#if UV_FS_O_NOFOLLOW != 0
+  if ((flags & UV_FS_O_NOFOLLOW) != 0) return false;
+#endif
+  return true;
+}
+
 bool ValueToBool(napi_env env, napi_value value, bool* out) {
   if (out == nullptr) return false;
   if (napi_get_value_bool(env, value, out) == napi_ok) return true;
@@ -349,8 +395,11 @@ napi_value BindingReadFileUtf8(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
+  const std::string open_path = ShouldResolveOpenPath(flags)
+                                    ? ResolvePathForFollowOperation(path)
+                                    : path;
   uv_fs_t req;
-  uv_file file = uv_fs_open(nullptr, &req, path.c_str(), flags, 0666, nullptr);
+  uv_file file = uv_fs_open(nullptr, &req, open_path.c_str(), flags, 0666, nullptr);
   uv_fs_req_cleanup(&req);
   if (file < 0) {
     ThrowUVException(env, static_cast<int>(file), "open", path.c_str());
@@ -433,7 +482,10 @@ napi_value BindingWriteFileUtf8(napi_env env, napi_callback_info info) {
   if (path_is_fd) {
     file = static_cast<uv_file>(fd);
   } else {
-    file = uv_fs_open(nullptr, &req, path.c_str(), flags, mode, nullptr);
+    const std::string open_path = ShouldResolveOpenPath(flags)
+                                      ? ResolvePathForFollowOperation(path)
+                                      : path;
+    file = uv_fs_open(nullptr, &req, open_path.c_str(), flags, mode, nullptr);
     uv_fs_req_cleanup(&req);
     if (file < 0) {
       ThrowUVException(env, static_cast<int>(file), "open", path.c_str());
@@ -554,10 +606,11 @@ napi_value BindingMkdir(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
+  const std::string mkdir_path = ResolvePathForFollowOperation(path);
   if (recursive) {
     std::string first_path;
     int err = 0;
-    if (!MkdirpSync(path, mode, &first_path, &err)) {
+    if (!MkdirpSync(mkdir_path, mode, &first_path, &err)) {
       ThrowUVException(env, err, "mkdir", path.c_str());
       return nullptr;
     }
@@ -572,7 +625,7 @@ napi_value BindingMkdir(napi_env env, napi_callback_info info) {
   }
 
   uv_fs_t req;
-  int err = uv_fs_mkdir(nullptr, &req, path.c_str(), mode, nullptr);
+  int err = uv_fs_mkdir(nullptr, &req, mkdir_path.c_str(), mode, nullptr);
   uv_fs_req_cleanup(&req);
   if (err < 0) {
     ThrowUVException(env, err, "mkdir", path.c_str());
@@ -713,8 +766,9 @@ napi_value BindingReaddir(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
+  const std::string scan_path = ResolvePathForFollowOperation(path);
   uv_fs_t req;
-  int err = uv_fs_scandir(nullptr, &req, path.c_str(), 0, nullptr);
+  int err = uv_fs_scandir(nullptr, &req, scan_path.c_str(), 0, nullptr);
   if (err < 0) {
     uv_fs_req_cleanup(&req);
     ThrowUVException(env, err, "scandir", path.c_str());
@@ -936,8 +990,9 @@ napi_value BindingExistsSync(napi_env env, napi_callback_info info) {
     if (napi_get_boolean(env, false, &false_val) == napi_ok) return false_val;
     return nullptr;
   }
+  const std::string access_path = ResolvePathForFollowOperation(path);
   uv_fs_t req;
-  int err = uv_fs_access(nullptr, &req, path.c_str(), 0, nullptr);
+  int err = uv_fs_access(nullptr, &req, access_path.c_str(), 0, nullptr);
   uv_fs_req_cleanup(&req);
   napi_value result = nullptr;
   if (napi_get_boolean(env, err == 0, &result) != napi_ok) return nullptr;
@@ -958,8 +1013,9 @@ napi_value BindingAccessSync(napi_env env, napi_callback_info info) {
       napi_get_value_int32(env, argv[1], &mode) != napi_ok) {
     return nullptr;
   }
+  const std::string access_path = ResolvePathForFollowOperation(path);
   uv_fs_t req;
-  int err = uv_fs_access(nullptr, &req, path.c_str(), mode, nullptr);
+  int err = uv_fs_access(nullptr, &req, access_path.c_str(), mode, nullptr);
   uv_fs_req_cleanup(&req);
   if (err < 0) {
     ThrowUVException(env, err, "access", path.c_str());
@@ -985,8 +1041,11 @@ napi_value BindingOpen(napi_env env, napi_callback_info info) {
   if (argc >= 3 && napi_get_value_int32(env, argv[2], &mode) != napi_ok) {
     return nullptr;
   }
+  const std::string open_path = ShouldResolveOpenPath(flags)
+                                    ? ResolvePathForFollowOperation(path)
+                                    : path;
   uv_fs_t req;
-  uv_file file = uv_fs_open(nullptr, &req, path.c_str(), flags, mode, nullptr);
+  uv_file file = uv_fs_open(nullptr, &req, open_path.c_str(), flags, mode, nullptr);
   uv_fs_req_cleanup(&req);
   if (file < 0) {
     ThrowUVException(env, static_cast<int>(file), "open", path.c_str());
@@ -1422,8 +1481,9 @@ napi_value BindingSymlink(napi_env env, napi_callback_info info) {
     if (napi_get_value_int32(env, argv[2], &flags) != napi_ok) return nullptr;
   }
 #if defined(_WIN32)
+  const std::string link_path = ResolvePathForFollowOperation(path);
   uv_fs_t req;
-  int err = uv_fs_symlink(nullptr, &req, target.c_str(), path.c_str(), flags, nullptr);
+  int err = uv_fs_symlink(nullptr, &req, target.c_str(), link_path.c_str(), flags, nullptr);
   uv_fs_req_cleanup(&req);
   if (err < 0) {
     ThrowUVException(env, err, "symlink", path.c_str());
@@ -1431,7 +1491,8 @@ napi_value BindingSymlink(napi_env env, napi_callback_info info) {
   }
 #else
   (void)flags;
-  if (::symlink(target.c_str(), path.c_str()) != 0) {
+  const std::string link_path = ResolvePathForFollowOperation(path);
+  if (::symlink(target.c_str(), link_path.c_str()) != 0) {
     ThrowErrnoException(env, errno, "symlink", strerror(errno), path.c_str());
     return nullptr;
   }
@@ -1728,8 +1789,9 @@ napi_value BindingAccess(napi_env env, napi_callback_info info) {
       napi_get_value_int32(env, argv[1], &mode) != napi_ok) {
     return nullptr;
   }
+  const std::string access_path = ResolvePathForFollowOperation(path);
   uv_fs_t req;
-  int err = uv_fs_access(nullptr, &req, path.c_str(), mode, nullptr);
+  int err = uv_fs_access(nullptr, &req, access_path.c_str(), mode, nullptr);
   uv_fs_req_cleanup(&req);
   if (err < 0) {
     ThrowUVException(env, err, "access", path.c_str());

--- a/src/edge_process.cc
+++ b/src/edge_process.cc
@@ -3,6 +3,7 @@
 #include "edge_env_loop.h"
 #include "edge_module_loader.h"
 #include "edge_option_helpers.h"
+#include "edge_path.h"
 #include "edge_runtime.h"
 #include "edge_worker_env.h"
 #include "edge_environment.h"
@@ -257,6 +258,45 @@ bool TryGetCurrentWorkingDirectoryString(std::string* out, int* uv_error_out = n
     cwd_len += 1;
   }
   return false;
+}
+
+bool TryRealpath(const std::string& path, std::string* out) {
+  if (out == nullptr || path.empty()) return false;
+
+  uv_fs_t req;
+  const std::string namespaced = edge_path::ToNamespacedPath(path);
+  int err = uv_fs_realpath(nullptr, &req, namespaced.c_str(), nullptr);
+  if (err < 0 || req.ptr == nullptr) {
+    uv_fs_req_cleanup(&req);
+    return false;
+  }
+
+  *out = edge_path::FromNamespacedPath(static_cast<const char*>(req.ptr));
+  uv_fs_req_cleanup(&req);
+  return true;
+}
+
+std::string ResolvePathForFollowOperation(const std::string& path) {
+  std::string resolved;
+  if (TryRealpath(path, &resolved)) return resolved;
+
+  std::filesystem::path current(path);
+  std::vector<std::filesystem::path> tail;
+  while (!current.empty()) {
+    const std::filesystem::path parent = current.parent_path();
+    const std::filesystem::path filename = current.filename();
+    if (filename.empty() || parent == current) break;
+
+    tail.push_back(filename);
+    current = parent;
+    if (TryRealpath(current.string(), &resolved)) {
+      std::filesystem::path out(resolved);
+      for (auto it = tail.rbegin(); it != tail.rend(); ++it) out /= *it;
+      return out.string();
+    }
+  }
+
+  return path;
 }
 
 void DeleteRefIfPresent(napi_env env, napi_ref* ref) {
@@ -3477,7 +3517,8 @@ napi_value ProcessChdirCallback(napi_env env, napi_callback_info info) {
   if (napi_get_value_string_utf8(env, args[0], buf.data(), buf.size(), &copied) != napi_ok) return nullptr;
   const std::string dest(buf.data(), copied);
   const std::string oldcwd = GetCurrentWorkingDirectoryForErrors();
-  const int rc = uv_chdir(dest.c_str());
+  const std::string chdir_dest = ResolvePathForFollowOperation(dest);
+  const int rc = uv_chdir(chdir_dest.c_str());
   if (rc != 0) {
     const char* code = uv_err_name(rc);
     if (code == nullptr) code = "UNKNOWN";

--- a/src/internal_binding/binding_fs.cc
+++ b/src/internal_binding/binding_fs.cc
@@ -112,6 +112,45 @@ std::filesystem::path ResolveSymlinkComponentsForModuleResolution(const std::fil
   return current.lexically_normal();
 }
 
+bool TryRealpath(const std::string& path, std::string* out) {
+  if (out == nullptr || path.empty()) return false;
+
+  uv_fs_t req;
+  const std::string namespaced = edge_path::ToNamespacedPath(path);
+  int err = uv_fs_realpath(nullptr, &req, namespaced.c_str(), nullptr);
+  if (err < 0 || req.ptr == nullptr) {
+    uv_fs_req_cleanup(&req);
+    return false;
+  }
+
+  *out = edge_path::FromNamespacedPath(static_cast<const char*>(req.ptr));
+  uv_fs_req_cleanup(&req);
+  return true;
+}
+
+std::string ResolvePathForFollowOperation(const std::string& path) {
+  std::string resolved;
+  if (TryRealpath(path, &resolved)) return resolved;
+
+  std::filesystem::path current(path);
+  std::vector<std::filesystem::path> tail;
+  while (!current.empty()) {
+    const std::filesystem::path parent = current.parent_path();
+    const std::filesystem::path filename = current.filename();
+    if (filename.empty() || parent == current) break;
+
+    tail.push_back(filename);
+    current = parent;
+    if (TryRealpath(current.string(), &resolved)) {
+      std::filesystem::path out(resolved);
+      for (auto it = tail.rbegin(); it != tail.rend(); ++it) out /= *it;
+      return out.string();
+    }
+  }
+
+  return path;
+}
+
 napi_value GetRefValue(napi_env env, napi_ref ref) {
   if (ref == nullptr) return nullptr;
   napi_value out = nullptr;
@@ -3027,7 +3066,7 @@ napi_value FsMkdir(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  path = edge_path::ToNamespacedPath(path);
+  path = edge_path::ToNamespacedPath(ResolvePathForFollowOperation(path));
   int32_t mode = 0;
   bool recursive = false;
   if (argc >= 2 && argv[1] != nullptr) napi_get_value_int32(env, argv[1], &mode);
@@ -3202,7 +3241,7 @@ napi_value FsSymlink(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  path = edge_path::ToNamespacedPath(path);
+  path = edge_path::ToNamespacedPath(ResolvePathForFollowOperation(path));
   int32_t flags = 0;
   if (argc >= 3 && argv[2] != nullptr) napi_get_value_int32(env, argv[2], &flags);
 


### PR DESCRIPTION
- Follow symbolic links for file operations in Edge only

This is Edge only solution, which does not require wasmer re-deployment.

Symlinks are resolved and followed directly with Edge runtime. 

*TODO* Update WASMER to follow symlinks instead. Such change would require re-deployment of WASMER to wasmer.io.