### PR TITLE
Precompilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ benchmarks/results/**/*.json
 benchmarks/results/**/*.csv
 benchmarks/results/**/*.md
 benchmarks/results/baselines/**/*.txt
+benchmarks/workloads/bytecode-cache/gen/
 
 /AGENTS.md
 /claude.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ benchmarks/results/**/*.csv
 benchmarks/results/**/*.md
 benchmarks/results/baselines/**/*.txt
 benchmarks/workloads/bytecode-cache/gen/
+benchmarks/workloads/bytecode-cache/gen-esm/
 
 /AGENTS.md
 /claude.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,25 @@ if(DEFINED NAPI_V8_INCLUDE_DIR AND EXISTS "${NAPI_V8_INCLUDE_DIR}/v8-version.h")
   endif()
 endif()
 
+set(EDGE_EMBEDDED_QUICKJS_VERSION "0.0.0")
+if(EDGE_NAPI_PROVIDER STREQUAL "quickjs" AND EXISTS "${EDGE_QUICKJS_ROOT}/quickjs.h")
+  file(STRINGS "${EDGE_QUICKJS_ROOT}/quickjs.h" _qjs_major_line
+       REGEX "^#define QJS_VERSION_MAJOR [0-9]+$")
+  file(STRINGS "${EDGE_QUICKJS_ROOT}/quickjs.h" _qjs_minor_line
+       REGEX "^#define QJS_VERSION_MINOR [0-9]+$")
+  file(STRINGS "${EDGE_QUICKJS_ROOT}/quickjs.h" _qjs_patch_line
+       REGEX "^#define QJS_VERSION_PATCH [0-9]+$")
+  if(_qjs_major_line AND _qjs_minor_line AND _qjs_patch_line)
+    string(REGEX REPLACE "^#define QJS_VERSION_MAJOR ([0-9]+)$" "\\1"
+           _qjs_major "${_qjs_major_line}")
+    string(REGEX REPLACE "^#define QJS_VERSION_MINOR ([0-9]+)$" "\\1"
+           _qjs_minor "${_qjs_minor_line}")
+    string(REGEX REPLACE "^#define QJS_VERSION_PATCH ([0-9]+)$" "\\1"
+           _qjs_patch "${_qjs_patch_line}")
+    set(EDGE_EMBEDDED_QUICKJS_VERSION "${_qjs_major}.${_qjs_minor}.${_qjs_patch}")
+  endif()
+endif()
+
 add_library(edge_node_api STATIC
   src/node_api.cc
   src/edge_napi_embedder_hooks.cc
@@ -210,6 +229,7 @@ function(edge_apply_runtime_compile_surface target_name)
       EDGE_ENABLE_TRACE_DIAGNOSTICS=$<IF:$<CONFIG:Debug>,1,0>
       EDGE_NODE_SHARED_OPENSSL=${EDGE_NODE_SHARED_OPENSSL}
       EDGE_EMBEDDED_V8_VERSION="${EDGE_EMBEDDED_V8_VERSION}"
+      EDGE_EMBEDDED_QUICKJS_VERSION="${EDGE_EMBEDDED_QUICKJS_VERSION}"
       EDGE_VERSION_COMMIT="${EDGE_VERSION_COMMIT}"
       EDGE_VERSION_SUFFIX="${EDGE_VERSION_SUFFIX}"
   )

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,20 @@ test-bytecode-cache:
 test-bytecode-cache-quickjs:
 	EDGE_BIN=$(BUILD_EDGE_QUICKJS_CLI_DIR)/edge ./scripts/test-bytecode-cache.sh
 
+# Generate the shippable builtins (lib/) bytecode cache next to each binary
+# (<binary>.builtins.v8b / .qjsb). The builtins cache is on by default, so a
+# representative run populates it; ship the produced file alongside the binary
+# so opt-in users (and read-only installs) get the builtin startup win from the
+# first run. Re-run after rebuilding (the engine tag invalidates a stale cache).
+PRECOMPILE_BUILTINS_DRIVER ?= ./benchmarks/precompile-builtins-driver.mjs
+precompile-builtins:
+	@for bin in $(EDGE_BINARY) $(BUILD_EDGE_QUICKJS_CLI_DIR)/edge; do \
+		[ -x "$$bin" ] || continue; \
+		rm -f "$$bin".builtins.*; \
+		"$$bin" "$(PRECOMPILE_BUILTINS_DRIVER)" >/dev/null 2>&1 || true; \
+		ls -la "$$bin".builtins.* 2>/dev/null || echo "no builtins cache produced for $$bin"; \
+	done
+
 clean-edge-quickjs-cli:
 	rm -rf $(BUILD_EDGE_QUICKJS_CLI_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -182,14 +182,20 @@ $(EDGE_BINARY):
 test: build test-only
 
 test-only:
-	NODE_TEST_RUNNER=$(EDGE_BINARY) ./test/nodejs_test_harness --category=node:buffer,node:console,node:dgram,node:diagnostics_channel,node:dns,node:events,node:http,node:https,node:os,node:path,node:punycode,node:querystring,node:stream,node:string_decoder,node:tty,node:url,node:zlib,node:crypto,node:domain,node:http2,node:tls,node:sys \
+	EDGE_BYTECODE_CACHE=0 NODE_TEST_RUNNER=$(EDGE_BINARY) ./test/nodejs_test_harness --category=node:buffer,node:console,node:dgram,node:diagnostics_channel,node:dns,node:events,node:http,node:https,node:os,node:path,node:punycode,node:querystring,node:stream,node:string_decoder,node:tty,node:url,node:zlib,node:crypto,node:domain,node:http2,node:tls,node:sys \
 	  --skip-tests=$(EDGE_NODE_TEST_SKIP_TESTS) \
 	  -j $(TEST_JOBS)
 
 test-quickjs-only:
-	NODE_TEST_RUNNER=$(BUILD_EDGE_QUICKJS_CLI_DIR)/edge ./test/nodejs_test_harness --category=node:buffer,node:console,node:dgram,node:diagnostics_channel,node:dns,node:events,node:http,node:https,node:os,node:path,node:punycode,node:querystring,node:stream,node:string_decoder,node:tty,node:url,node:zlib,node:crypto,node:domain,node:http2,node:tls,node:sys \
+	EDGE_BYTECODE_CACHE=0 NODE_TEST_RUNNER=$(BUILD_EDGE_QUICKJS_CLI_DIR)/edge ./test/nodejs_test_harness --category=node:buffer,node:console,node:dgram,node:diagnostics_channel,node:dns,node:events,node:http,node:https,node:os,node:path,node:punycode,node:querystring,node:stream,node:string_decoder,node:tty,node:url,node:zlib,node:crypto,node:domain,node:http2,node:tls,node:sys \
 	  --skip-tests=$(QUICKJS_SKIP_TESTS) \
 	  -j $(TEST_JOBS)
+
+test-bytecode-cache:
+	EDGE_BIN=$(EDGE_BINARY) ./scripts/test-bytecode-cache.sh
+
+test-bytecode-cache-quickjs:
+	EDGE_BIN=$(BUILD_EDGE_QUICKJS_CLI_DIR)/edge ./scripts/test-bytecode-cache.sh
 
 clean-edge-quickjs-cli:
 	rm -rf $(BUILD_EDGE_QUICKJS_CLI_DIR)

--- a/benchmarks/bench-bytecode-cache.sh
+++ b/benchmarks/bench-bytecode-cache.sh
@@ -35,16 +35,17 @@ mkdir -p "$RESULTS_DIR"
 echo "=== Generating workloads ==="
 "$NODE_BIN" benchmarks/generate-bytecode-workload.mjs
 
-# Identify the engine by the sidecar suffix it writes.
+# Identify the engine by the tag the precompile cache writes. User-file caches
+# now live in per-directory __edgecache__ subdirs (__edgecache__/<stem>.<tag>.jsc).
 "$EDGE_BIN" --precompile "$GEN_BASE/gen" >/dev/null
-if compgen -G "$GEN_BASE/gen/*.v8b" >/dev/null; then
+if compgen -G "$GEN_BASE/gen/__edgecache__/*.v8-*.jsc" >/dev/null; then
   LABEL="v8"
   SUFFIX=".v8b"
-elif compgen -G "$GEN_BASE/gen/*.qjsb" >/dev/null; then
+elif compgen -G "$GEN_BASE/gen/__edgecache__/*.qjs-*.jsc" >/dev/null; then
   LABEL="quickjs"
   SUFFIX=".qjsb"
 else
-  echo "error: precompile produced no sidecars in $GEN_BASE/gen" >&2
+  echo "error: precompile produced no __edgecache__/*.jsc in $GEN_BASE/gen" >&2
   exit 1
 fi
 
@@ -53,7 +54,7 @@ run_lane() {
   local gen_dir="$2"
   local main="$3"
 
-  local clean_sidecars="find $gen_dir -name '*$SUFFIX' -delete"
+  local clean_sidecars="find $gen_dir -type d -name __edgecache__ -exec rm -rf {} +"
   local precompile="$EDGE_BIN --precompile $gen_dir >/dev/null"
   local json_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.json"
   local csv_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.csv"
@@ -70,9 +71,9 @@ run_lane() {
     --prepare "$clean_sidecars" \
     --command-name "cold (no cache)" "$EDGE_BIN --no-bytecode-cache $gen_dir/$main" \
     --prepare "$clean_sidecars" \
-    --command-name "first run (writes sidecars)" "$EDGE_BIN $gen_dir/$main" \
+    --command-name "first run (writes sidecars)" "$EDGE_BIN --bytecode-cache $gen_dir/$main" \
     --prepare "$precompile" \
-    --command-name "warm (precompiled sidecars)" "$EDGE_BIN $gen_dir/$main"
+    --command-name "warm (precompiled sidecars)" "$EDGE_BIN --bytecode-cache $gen_dir/$main"
 
   "$NODE_BIN" - "$json_out" "$LABEL/$lane" <<'EOF'
 const { readFileSync } = require('node:fs');

--- a/benchmarks/bench-bytecode-cache.sh
+++ b/benchmarks/bench-bytecode-cache.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Startup benchmark for bytecode sidecar caches: cold compile vs precompiled.
+#
+# Usage:
+#   EDGE_BIN=./build-edge/edge ./benchmarks/bench-bytecode-cache.sh
+#   EDGE_BIN=./build-edge-quickjs-cli/edge ./benchmarks/bench-bytecode-cache.sh
+set -euo pipefail
+
+EDGE_BIN="${EDGE_BIN:-./build-edge/edge}"
+NODE_BIN="${NODE_BIN:-node}"
+WARMUP="${WARMUP:-3}"
+RUNS="${RUNS:-20}"
+RESULTS_DIR="${RESULTS_DIR:-benchmarks/results}"
+GEN_DIR="benchmarks/workloads/bytecode-cache/gen"
+
+command -v hyperfine >/dev/null 2>&1 || {
+  echo "Missing dependency: hyperfine"
+  echo "Install it first, then re-run this script."
+  exit 1
+}
+
+[[ -x "$EDGE_BIN" ]] || {
+  echo "Missing edge binary: $EDGE_BIN"
+  echo "Build Edge first with: make build (or make build-edge-quickjs-cli)"
+  exit 1
+}
+
+command -v "$NODE_BIN" >/dev/null 2>&1 || {
+  echo "Missing node binary: $NODE_BIN (used to generate the workload)"
+  exit 1
+}
+
+mkdir -p "$RESULTS_DIR"
+
+echo "=== Generating workload ==="
+"$NODE_BIN" benchmarks/generate-bytecode-workload.mjs
+
+# Identify the engine by the sidecar suffix it writes.
+"$EDGE_BIN" --precompile "$GEN_DIR" >/dev/null
+if compgen -G "$GEN_DIR/*.v8b" >/dev/null; then
+  LABEL="v8"
+  SUFFIX=".v8b"
+elif compgen -G "$GEN_DIR/*.qjsb" >/dev/null; then
+  LABEL="quickjs"
+  SUFFIX=".qjsb"
+else
+  echo "error: precompile produced no sidecars in $GEN_DIR" >&2
+  exit 1
+fi
+
+CLEAN_SIDECARS="find $GEN_DIR -name '*$SUFFIX' -delete"
+PRECOMPILE="$EDGE_BIN --precompile $GEN_DIR >/dev/null"
+
+JSON_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.json"
+CSV_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.csv"
+MD_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.md"
+
+echo
+echo "=== Benchmarking ($LABEL, warmup=$WARMUP, runs=$RUNS) ==="
+hyperfine \
+  --warmup "$WARMUP" \
+  --runs "$RUNS" \
+  --export-json "$JSON_OUT" \
+  --export-csv "$CSV_OUT" \
+  --export-markdown "$MD_OUT" \
+  --prepare "$CLEAN_SIDECARS" \
+  --command-name "cold (no cache)" "$EDGE_BIN --no-bytecode-cache $GEN_DIR/main.js" \
+  --prepare "$CLEAN_SIDECARS" \
+  --command-name "first run (writes sidecars)" "$EDGE_BIN $GEN_DIR/main.js" \
+  --prepare "$PRECOMPILE" \
+  --command-name "warm (precompiled sidecars)" "$EDGE_BIN $GEN_DIR/main.js"
+
+"$NODE_BIN" - "$JSON_OUT" "$LABEL" <<'EOF'
+const { readFileSync } = require('node:fs');
+const [jsonPath, label] = process.argv.slice(2);
+const results = JSON.parse(readFileSync(jsonPath, 'utf8')).results;
+const byName = Object.fromEntries(results.map((r) => [r.command, r]));
+const cold = results.find((r) => r.command.startsWith('cold'));
+const firstRun = results.find((r) => r.command.startsWith('first run'));
+const warm = results.find((r) => r.command.startsWith('warm'));
+const ms = (s) => (s * 1000).toFixed(1);
+console.log('');
+console.log(`=== Bytecode cache startup summary (${label}) ===`);
+console.log(`cold (compile from source):   ${ms(cold.mean)} ms ± ${ms(cold.stddev)} ms`);
+console.log(`first run (compile + write):  ${ms(firstRun.mean)} ms ± ${ms(firstRun.stddev)} ms`);
+console.log(`warm (load sidecars):         ${ms(warm.mean)} ms ± ${ms(warm.stddev)} ms`);
+console.log('');
+console.log(`startup speedup (cold -> warm): ${(cold.mean / warm.mean).toFixed(2)}x`);
+console.log(`time saved per start:           ${ms(cold.mean - warm.mean)} ms`);
+console.log(`first-run write overhead:       ${ms(firstRun.mean - cold.mean)} ms`);
+EOF
+
+echo
+echo "Exported:"
+echo "  $JSON_OUT"
+echo "  $CSV_OUT"
+echo "  $MD_OUT"

--- a/benchmarks/bench-bytecode-cache.sh
+++ b/benchmarks/bench-bytecode-cache.sh
@@ -11,7 +11,7 @@ NODE_BIN="${NODE_BIN:-node}"
 WARMUP="${WARMUP:-3}"
 RUNS="${RUNS:-20}"
 RESULTS_DIR="${RESULTS_DIR:-benchmarks/results}"
-GEN_DIR="benchmarks/workloads/bytecode-cache/gen"
+GEN_BASE="benchmarks/workloads/bytecode-cache"
 
 command -v hyperfine >/dev/null 2>&1 || {
   echo "Missing dependency: hyperfine"
@@ -32,49 +32,52 @@ command -v "$NODE_BIN" >/dev/null 2>&1 || {
 
 mkdir -p "$RESULTS_DIR"
 
-echo "=== Generating workload ==="
+echo "=== Generating workloads ==="
 "$NODE_BIN" benchmarks/generate-bytecode-workload.mjs
 
 # Identify the engine by the sidecar suffix it writes.
-"$EDGE_BIN" --precompile "$GEN_DIR" >/dev/null
-if compgen -G "$GEN_DIR/*.v8b" >/dev/null; then
+"$EDGE_BIN" --precompile "$GEN_BASE/gen" >/dev/null
+if compgen -G "$GEN_BASE/gen/*.v8b" >/dev/null; then
   LABEL="v8"
   SUFFIX=".v8b"
-elif compgen -G "$GEN_DIR/*.qjsb" >/dev/null; then
+elif compgen -G "$GEN_BASE/gen/*.qjsb" >/dev/null; then
   LABEL="quickjs"
   SUFFIX=".qjsb"
 else
-  echo "error: precompile produced no sidecars in $GEN_DIR" >&2
+  echo "error: precompile produced no sidecars in $GEN_BASE/gen" >&2
   exit 1
 fi
 
-CLEAN_SIDECARS="find $GEN_DIR -name '*$SUFFIX' -delete"
-PRECOMPILE="$EDGE_BIN --precompile $GEN_DIR >/dev/null"
+run_lane() {
+  local lane="$1"   # cjs | esm
+  local gen_dir="$2"
+  local main="$3"
 
-JSON_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.json"
-CSV_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.csv"
-MD_OUT="$RESULTS_DIR/bytecode-cache-$LABEL.md"
+  local clean_sidecars="find $gen_dir -name '*$SUFFIX' -delete"
+  local precompile="$EDGE_BIN --precompile $gen_dir >/dev/null"
+  local json_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.json"
+  local csv_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.csv"
+  local md_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.md"
 
-echo
-echo "=== Benchmarking ($LABEL, warmup=$WARMUP, runs=$RUNS) ==="
-hyperfine \
-  --warmup "$WARMUP" \
-  --runs "$RUNS" \
-  --export-json "$JSON_OUT" \
-  --export-csv "$CSV_OUT" \
-  --export-markdown "$MD_OUT" \
-  --prepare "$CLEAN_SIDECARS" \
-  --command-name "cold (no cache)" "$EDGE_BIN --no-bytecode-cache $GEN_DIR/main.js" \
-  --prepare "$CLEAN_SIDECARS" \
-  --command-name "first run (writes sidecars)" "$EDGE_BIN $GEN_DIR/main.js" \
-  --prepare "$PRECOMPILE" \
-  --command-name "warm (precompiled sidecars)" "$EDGE_BIN $GEN_DIR/main.js"
+  echo
+  echo "=== Benchmarking ($LABEL, $lane, warmup=$WARMUP, runs=$RUNS) ==="
+  hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --export-json "$json_out" \
+    --export-csv "$csv_out" \
+    --export-markdown "$md_out" \
+    --prepare "$clean_sidecars" \
+    --command-name "cold (no cache)" "$EDGE_BIN --no-bytecode-cache $gen_dir/$main" \
+    --prepare "$clean_sidecars" \
+    --command-name "first run (writes sidecars)" "$EDGE_BIN $gen_dir/$main" \
+    --prepare "$precompile" \
+    --command-name "warm (precompiled sidecars)" "$EDGE_BIN $gen_dir/$main"
 
-"$NODE_BIN" - "$JSON_OUT" "$LABEL" <<'EOF'
+  "$NODE_BIN" - "$json_out" "$LABEL/$lane" <<'EOF'
 const { readFileSync } = require('node:fs');
 const [jsonPath, label] = process.argv.slice(2);
 const results = JSON.parse(readFileSync(jsonPath, 'utf8')).results;
-const byName = Object.fromEntries(results.map((r) => [r.command, r]));
 const cold = results.find((r) => r.command.startsWith('cold'));
 const firstRun = results.find((r) => r.command.startsWith('first run'));
 const warm = results.find((r) => r.command.startsWith('warm'));
@@ -90,8 +93,12 @@ console.log(`time saved per start:           ${ms(cold.mean - warm.mean)} ms`);
 console.log(`first-run write overhead:       ${ms(firstRun.mean - cold.mean)} ms`);
 EOF
 
-echo
-echo "Exported:"
-echo "  $JSON_OUT"
-echo "  $CSV_OUT"
-echo "  $MD_OUT"
+  echo
+  echo "Exported:"
+  echo "  $json_out"
+  echo "  $csv_out"
+  echo "  $md_out"
+}
+
+run_lane "cjs" "$GEN_BASE/gen" "main.js"
+run_lane "esm" "$GEN_BASE/gen-esm" "main.mjs"

--- a/benchmarks/bench-bytecode-cache.sh
+++ b/benchmarks/bench-bytecode-cache.sh
@@ -102,3 +102,62 @@ EOF
 
 run_lane "cjs" "$GEN_BASE/gen" "main.js"
 run_lane "esm" "$GEN_BASE/gen-esm" "main.mjs"
+
+# --- builtins consolidated cache: empty-startup lane -------------------------------
+# The builtins cache lands next to the binary, so the lane runs a COPY of the
+# binary in a scratch dir (copy, not symlink: exec-path resolution follows
+# symlinks back to the original).
+run_builtins_lane() {
+  local lane="builtins-empty"
+  local dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/edge-builtins-bench.XXXXXX")"
+  trap 'rm -rf "$dir"' RETURN
+  cp "$EDGE_BIN" "$dir/edge"
+  echo 'console.log(1 + 1);' > "$dir/app.js"
+  local builtins_file="$dir/edge.builtins$SUFFIX"
+
+  local json_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.json"
+  local csv_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.csv"
+  local md_out="$RESULTS_DIR/bytecode-cache-$LABEL-$lane.md"
+
+  echo
+  echo "=== Benchmarking ($LABEL, $lane, warmup=$WARMUP, runs=$RUNS) ==="
+  hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --export-json "$json_out" \
+    --export-csv "$csv_out" \
+    --export-markdown "$md_out" \
+    --prepare "true" \
+    --command-name "disabled (compile builtins from source)" "$dir/edge --no-bytecode-cache $dir/app.js" \
+    --prepare "rm -f $builtins_file" \
+    --command-name "first run (writes builtins cache)" "$dir/edge $dir/app.js" \
+    --prepare "$dir/edge $dir/app.js >/dev/null 2>&1" \
+    --command-name "warm (builtins cache)" "$dir/edge $dir/app.js"
+
+  "$NODE_BIN" - "$json_out" "$LABEL/$lane" <<'EOF'
+const { readFileSync } = require('node:fs');
+const [jsonPath, label] = process.argv.slice(2);
+const results = JSON.parse(readFileSync(jsonPath, 'utf8')).results;
+const disabled = results.find((r) => r.command.startsWith('disabled'));
+const firstRun = results.find((r) => r.command.startsWith('first run'));
+const warm = results.find((r) => r.command.startsWith('warm'));
+const ms = (s) => (s * 1000).toFixed(1);
+console.log('');
+console.log(`=== Builtins bytecode cache summary (${label}) ===`);
+console.log(`disabled (compile builtins):  ${ms(disabled.mean)} ms ± ${ms(disabled.stddev)} ms`);
+console.log(`first run (compile + write):  ${ms(firstRun.mean)} ms ± ${ms(firstRun.stddev)} ms`);
+console.log(`warm (builtins cache):        ${ms(warm.mean)} ms ± ${ms(warm.stddev)} ms`);
+console.log('');
+console.log(`empty-startup speedup (disabled -> warm): ${(disabled.mean / warm.mean).toFixed(2)}x`);
+console.log(`time saved per start:                     ${ms(disabled.mean - warm.mean)} ms`);
+EOF
+
+  echo
+  echo "Exported:"
+  echo "  $json_out"
+  echo "  $csv_out"
+  echo "  $md_out"
+}
+
+run_builtins_lane

--- a/benchmarks/generate-bytecode-workload.mjs
+++ b/benchmarks/generate-bytecode-workload.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-// Generates a deterministic synthetic CJS app used by bench-bytecode-cache.sh:
+// Generates deterministic synthetic apps used by bench-bytecode-cache.sh:
 // many small modules plus one large vendor bundle, so engine parse/compile
 // time dominates startup and the bytecode-cache effect is measurable.
+// Emits a CJS app under gen/ and an equivalent ESM app under gen-esm/.
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'workloads', 'bytecode-cache', 'gen');
+const BASE_DIR = join(dirname(fileURLToPath(import.meta.url)), 'workloads', 'bytecode-cache');
 const MODULE_COUNT = 150;
 const VENDOR_FUNCTIONS = 2600; // ~1.5 MB of source
 
@@ -23,7 +24,7 @@ function mulberry32(seed) {
   };
 }
 
-const rand = mulberry32(0xedbe11);
+let rand = mulberry32(0xedbe11);
 
 function pick(items) {
   return items[Math.floor(rand() * items.length)];
@@ -52,8 +53,8 @@ function makeFunction(name) {
   return lines.join('\n');
 }
 
-function generateVendor() {
-  const parts = ["'use strict';", ''];
+function generateVendor(esm) {
+  const parts = esm ? [] : ["'use strict';", ''];
   const names = [];
   for (let i = 0; i < VENDOR_FUNCTIONS; i++) {
     const name = `vendorFn${i}`;
@@ -61,22 +62,28 @@ function generateVendor() {
     parts.push(makeFunction(name));
     parts.push('');
   }
-  parts.push('module.exports = {');
-  parts.push(`  size: ${names.length},`);
-  parts.push('  run(seed) {');
+  if (esm) {
+    parts.push(`export const size = ${names.length};`);
+    parts.push('export function run(seed) {');
+  } else {
+    parts.push('module.exports = {');
+    parts.push(`  size: ${names.length},`);
+    parts.push('  run(seed) {');
+  }
   parts.push('    let acc = seed | 0;');
   // Touch a sample of functions so lazy compilation engines do some real work.
   for (let i = 0; i < VENDOR_FUNCTIONS; i += 50) {
     parts.push(`    acc = vendorFn${i}(acc, ${i});`);
   }
   parts.push('    return acc;');
-  parts.push('  },');
-  parts.push('};');
+  parts.push(esm ? '}' : '  },');
+  if (!esm) parts.push('};');
   return parts.join('\n');
 }
 
-function generateModule(index) {
-  const parts = ["'use strict';", ''];
+function generateModule(index, esm) {
+  const ext = esm ? 'mjs' : 'js';
+  const parts = esm ? [] : ["'use strict';", ''];
   const deps = [];
   for (let d = 1; d <= 3; d++) {
     const target = index - d * (1 + Math.floor(rand() * 4));
@@ -84,7 +91,8 @@ function generateModule(index) {
   }
   const uniqueDeps = [...new Set(deps)];
   for (const dep of uniqueDeps) {
-    parts.push(`const dep${dep} = require('./mod_${String(dep).padStart(3, '0')}.js');`);
+    const spec = `./mod_${String(dep).padStart(3, '0')}.${ext}`;
+    parts.push(esm ? `import * as dep${dep} from '${spec}';` : `const dep${dep} = require('${spec}');`);
   }
   parts.push('');
   const fnCount = 8 + Math.floor(rand() * 5);
@@ -95,8 +103,12 @@ function generateModule(index) {
   // Memoized: the dep graph is a DAG and compute() must walk it once, not
   // exponentially.
   parts.push('let cachedResult = null;');
-  parts.push('module.exports = {');
-  parts.push('  compute(seed) {');
+  if (esm) {
+    parts.push('export function compute(seed) {');
+  } else {
+    parts.push('module.exports = {');
+    parts.push('  compute(seed) {');
+  }
   parts.push('    if (cachedResult !== null) return cachedResult;');
   parts.push('    let acc = seed | 0;');
   for (let f = 0; f < fnCount; f++) {
@@ -107,38 +119,58 @@ function generateModule(index) {
   }
   parts.push('    cachedResult = acc;');
   parts.push('    return acc;');
-  parts.push('  },');
-  parts.push('};');
+  if (esm) {
+    parts.push('}');
+  } else {
+    parts.push('  },');
+    parts.push('};');
+  }
   return parts.join('\n');
 }
 
-rmSync(OUT_DIR, { recursive: true, force: true });
-mkdirSync(OUT_DIR, { recursive: true });
+function generateApp(outDir, esm) {
+  // Re-seed per app so both variants carry identical function bodies.
+  rand = mulberry32(0xedbe11);
+  const ext = esm ? 'mjs' : 'js';
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
 
-let totalBytes = 0;
-const vendor = generateVendor();
-writeFileSync(join(OUT_DIR, 'vendor.js'), vendor);
-totalBytes += vendor.length;
+  let totalBytes = 0;
+  const vendor = generateVendor(esm);
+  writeFileSync(join(outDir, `vendor.${ext}`), vendor);
+  totalBytes += vendor.length;
 
-for (let i = 0; i < MODULE_COUNT; i++) {
-  const source = generateModule(i);
-  writeFileSync(join(OUT_DIR, `mod_${String(i).padStart(3, '0')}.js`), source);
-  totalBytes += source.length;
+  for (let i = 0; i < MODULE_COUNT; i++) {
+    const source = generateModule(i, esm);
+    writeFileSync(join(outDir, `mod_${String(i).padStart(3, '0')}.${ext}`), source);
+    totalBytes += source.length;
+  }
+
+  const mainLines = [];
+  if (esm) {
+    mainLines.push(`import * as vendor from './vendor.${ext}';`);
+    for (let i = 0; i < MODULE_COUNT; i++) {
+      mainLines.push(`import * as mod${i} from './mod_${String(i).padStart(3, '0')}.${ext}';`);
+    }
+  } else {
+    mainLines.push("'use strict';", `const vendor = require('./vendor.${ext}');`);
+    for (let i = 0; i < MODULE_COUNT; i++) {
+      mainLines.push(`const mod${i} = require('./mod_${String(i).padStart(3, '0')}.${ext}');`);
+    }
+  }
+  mainLines.push('let acc = vendor.run(1);');
+  for (let i = 0; i < MODULE_COUNT; i++) {
+    mainLines.push(`acc = (acc + mod${i}.compute(acc)) & 0x7fffffff;`);
+  }
+  mainLines.push("console.log('checksum:' + acc);");
+  const main = mainLines.join('\n');
+  writeFileSync(join(outDir, `main.${ext}`), main);
+  totalBytes += main.length;
+
+  console.log(
+    `generated ${MODULE_COUNT + 2} ${esm ? 'ESM' : 'CJS'} files, ${(totalBytes / 1024 / 1024).toFixed(2)} MB at ${outDir}`,
+  );
 }
 
-const mainLines = ["'use strict';", "const vendor = require('./vendor.js');"];
-for (let i = 0; i < MODULE_COUNT; i++) {
-  mainLines.push(`const mod${i} = require('./mod_${String(i).padStart(3, '0')}.js');`);
-}
-mainLines.push('let acc = vendor.run(1);');
-for (let i = 0; i < MODULE_COUNT; i++) {
-  mainLines.push(`acc = (acc + mod${i}.compute(acc)) & 0x7fffffff;`);
-}
-mainLines.push("console.log('checksum:' + acc);");
-const main = mainLines.join('\n');
-writeFileSync(join(OUT_DIR, 'main.js'), main);
-totalBytes += main.length;
-
-console.log(
-  `generated ${MODULE_COUNT + 2} files, ${(totalBytes / 1024 / 1024).toFixed(2)} MB at ${OUT_DIR}`,
-);
+generateApp(join(BASE_DIR, 'gen'), false);
+generateApp(join(BASE_DIR, 'gen-esm'), true);

--- a/benchmarks/generate-bytecode-workload.mjs
+++ b/benchmarks/generate-bytecode-workload.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Generates a deterministic synthetic CJS app used by bench-bytecode-cache.sh:
+// many small modules plus one large vendor bundle, so engine parse/compile
+// time dominates startup and the bytecode-cache effect is measurable.
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'workloads', 'bytecode-cache', 'gen');
+const MODULE_COUNT = 150;
+const VENDOR_FUNCTIONS = 2600; // ~1.5 MB of source
+
+// Deterministic PRNG (mulberry32) — the workload must be byte-identical
+// across runs so sidecar caches stay valid between benchmark lanes.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rand = mulberry32(0xedbe11);
+
+function pick(items) {
+  return items[Math.floor(rand() * items.length)];
+}
+
+function makeFunction(name) {
+  const ops = ['+', '-', '*', '^', '|'];
+  const lines = [];
+  lines.push(`function ${name}(input, factor) {`);
+  lines.push('  let acc = (input | 0) + 1;');
+  const steps = 6 + Math.floor(rand() * 6);
+  for (let i = 0; i < steps; i++) {
+    const op = pick(ops);
+    const k = Math.floor(rand() * 0xffff);
+    lines.push(`  acc = ((acc ${op} ${k}) ${pick(ops)} (factor | ${i})) & 0x7fffffff;`);
+    if (rand() < 0.3) {
+      lines.push(`  if (acc % ${2 + Math.floor(rand() * 11)} === 0) { acc = (acc >> 1) + ${k}; }`);
+    }
+    if (rand() < 0.2) {
+      lines.push(`  const slice_${i} = String(acc).split('').reverse().join('');`);
+      lines.push(`  acc = (acc + slice_${i}.length) & 0x7fffffff;`);
+    }
+  }
+  lines.push('  return acc;');
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function generateVendor() {
+  const parts = ["'use strict';", ''];
+  const names = [];
+  for (let i = 0; i < VENDOR_FUNCTIONS; i++) {
+    const name = `vendorFn${i}`;
+    names.push(name);
+    parts.push(makeFunction(name));
+    parts.push('');
+  }
+  parts.push('module.exports = {');
+  parts.push(`  size: ${names.length},`);
+  parts.push('  run(seed) {');
+  parts.push('    let acc = seed | 0;');
+  // Touch a sample of functions so lazy compilation engines do some real work.
+  for (let i = 0; i < VENDOR_FUNCTIONS; i += 50) {
+    parts.push(`    acc = vendorFn${i}(acc, ${i});`);
+  }
+  parts.push('    return acc;');
+  parts.push('  },');
+  parts.push('};');
+  return parts.join('\n');
+}
+
+function generateModule(index) {
+  const parts = ["'use strict';", ''];
+  const deps = [];
+  for (let d = 1; d <= 3; d++) {
+    const target = index - d * (1 + Math.floor(rand() * 4));
+    if (target >= 0) deps.push(target);
+  }
+  const uniqueDeps = [...new Set(deps)];
+  for (const dep of uniqueDeps) {
+    parts.push(`const dep${dep} = require('./mod_${String(dep).padStart(3, '0')}.js');`);
+  }
+  parts.push('');
+  const fnCount = 8 + Math.floor(rand() * 5);
+  for (let f = 0; f < fnCount; f++) {
+    parts.push(makeFunction(`helper${index}_${f}`));
+    parts.push('');
+  }
+  // Memoized: the dep graph is a DAG and compute() must walk it once, not
+  // exponentially.
+  parts.push('let cachedResult = null;');
+  parts.push('module.exports = {');
+  parts.push('  compute(seed) {');
+  parts.push('    if (cachedResult !== null) return cachedResult;');
+  parts.push('    let acc = seed | 0;');
+  for (let f = 0; f < fnCount; f++) {
+    parts.push(`    acc = helper${index}_${f}(acc, ${index});`);
+  }
+  for (const dep of uniqueDeps) {
+    parts.push(`    acc = (acc + dep${dep}.compute(acc)) & 0x7fffffff;`);
+  }
+  parts.push('    cachedResult = acc;');
+  parts.push('    return acc;');
+  parts.push('  },');
+  parts.push('};');
+  return parts.join('\n');
+}
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+let totalBytes = 0;
+const vendor = generateVendor();
+writeFileSync(join(OUT_DIR, 'vendor.js'), vendor);
+totalBytes += vendor.length;
+
+for (let i = 0; i < MODULE_COUNT; i++) {
+  const source = generateModule(i);
+  writeFileSync(join(OUT_DIR, `mod_${String(i).padStart(3, '0')}.js`), source);
+  totalBytes += source.length;
+}
+
+const mainLines = ["'use strict';", "const vendor = require('./vendor.js');"];
+for (let i = 0; i < MODULE_COUNT; i++) {
+  mainLines.push(`const mod${i} = require('./mod_${String(i).padStart(3, '0')}.js');`);
+}
+mainLines.push('let acc = vendor.run(1);');
+for (let i = 0; i < MODULE_COUNT; i++) {
+  mainLines.push(`acc = (acc + mod${i}.compute(acc)) & 0x7fffffff;`);
+}
+mainLines.push("console.log('checksum:' + acc);");
+const main = mainLines.join('\n');
+writeFileSync(join(OUT_DIR, 'main.js'), main);
+totalBytes += main.length;
+
+console.log(
+  `generated ${MODULE_COUNT + 2} files, ${(totalBytes / 1024 / 1024).toFixed(2)} MB at ${OUT_DIR}`,
+);

--- a/benchmarks/precompile-builtins-driver.mjs
+++ b/benchmarks/precompile-builtins-driver.mjs
@@ -1,0 +1,28 @@
+// Touches a representative spread of node: builtins so a single run populates
+// the consolidated builtins bytecode cache (<binary>.builtins.<engine-tag>)
+// broadly, not just the bootstrap set every process already loads. Run via
+// `make precompile-builtins`; the produced file is shipped next to the binary.
+//
+// The builtins cache is keyed by engine tag + per-builtin source hash, so this
+// driver never needs updating when builtins change — only the set it touches
+// bounds how much of the cache is pre-populated.
+const builtins = [
+  'assert', 'async_hooks', 'buffer', 'child_process', 'console', 'crypto',
+  'dgram', 'diagnostics_channel', 'dns', 'events', 'fs', 'fs/promises',
+  'http', 'http2', 'https', 'net', 'os', 'path', 'perf_hooks', 'process',
+  'punycode', 'querystring', 'readline', 'stream', 'stream/promises',
+  'string_decoder', 'timers', 'timers/promises', 'tls', 'tty', 'url', 'util',
+  'v8', 'vm', 'worker_threads', 'zlib',
+];
+
+let loaded = 0;
+for (const name of builtins) {
+  try {
+    await import(`node:${name}`);
+    loaded++;
+  } catch {
+    // A builtin missing on one engine/build is fine; keep going.
+  }
+}
+
+console.log(`precompile-builtins: touched ${loaded}/${builtins.length} builtins`);

--- a/deps/xxhash/xxhash.h
+++ b/deps/xxhash/xxhash.h
@@ -1,0 +1,6773 @@
+/*
+ * xxHash - Extremely Fast Hash algorithm
+ * Header File
+ * Copyright (C) 2012-2021 Yann Collet
+ *
+ * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * You can contact the author at:
+ *   - xxHash homepage: https://www.xxhash.com
+ *   - xxHash source repository: https://github.com/Cyan4973/xxHash
+ */
+
+/*!
+ * @mainpage xxHash
+ *
+ * xxHash is an extremely fast non-cryptographic hash algorithm, working at RAM speed
+ * limits.
+ *
+ * It is proposed in four flavors, in three families:
+ * 1. @ref XXH32_family
+ *   - Classic 32-bit hash function. Simple, compact, and runs on almost all
+ *     32-bit and 64-bit systems.
+ * 2. @ref XXH64_family
+ *   - Classic 64-bit adaptation of XXH32. Just as simple, and runs well on most
+ *     64-bit systems (but _not_ 32-bit systems).
+ * 3. @ref XXH3_family
+ *   - Modern 64-bit and 128-bit hash function family which features improved
+ *     strength and performance across the board, especially on smaller data.
+ *     It benefits greatly from SIMD and 64-bit without requiring it.
+ *
+ * Benchmarks
+ * ---
+ * The reference system uses an Intel i7-9700K CPU, and runs Ubuntu x64 20.04.
+ * The open source benchmark program is compiled with clang v10.0 using -O3 flag.
+ *
+ * | Hash Name            | ISA ext | Width | Large Data Speed | Small Data Velocity |
+ * | -------------------- | ------- | ----: | ---------------: | ------------------: |
+ * | XXH3_64bits()        | @b AVX2 |    64 |        59.4 GB/s |               133.1 |
+ * | MeowHash             | AES-NI  |   128 |        58.2 GB/s |                52.5 |
+ * | XXH3_128bits()       | @b AVX2 |   128 |        57.9 GB/s |               118.1 |
+ * | CLHash               | PCLMUL  |    64 |        37.1 GB/s |                58.1 |
+ * | XXH3_64bits()        | @b SSE2 |    64 |        31.5 GB/s |               133.1 |
+ * | XXH3_128bits()       | @b SSE2 |   128 |        29.6 GB/s |               118.1 |
+ * | RAM sequential read  |         |   N/A |        28.0 GB/s |                 N/A |
+ * | ahash                | AES-NI  |    64 |        22.5 GB/s |               107.2 |
+ * | City64               |         |    64 |        22.0 GB/s |                76.6 |
+ * | T1ha2                |         |    64 |        22.0 GB/s |                99.0 |
+ * | City128              |         |   128 |        21.7 GB/s |                57.7 |
+ * | FarmHash             | AES-NI  |    64 |        21.3 GB/s |                71.9 |
+ * | XXH64()              |         |    64 |        19.4 GB/s |                71.0 |
+ * | SpookyHash           |         |    64 |        19.3 GB/s |                53.2 |
+ * | Mum                  |         |    64 |        18.0 GB/s |                67.0 |
+ * | CRC32C               | SSE4.2  |    32 |        13.0 GB/s |                57.9 |
+ * | XXH32()              |         |    32 |         9.7 GB/s |                71.9 |
+ * | City32               |         |    32 |         9.1 GB/s |                66.0 |
+ * | Blake3*              | @b AVX2 |   256 |         4.4 GB/s |                 8.1 |
+ * | Murmur3              |         |    32 |         3.9 GB/s |                56.1 |
+ * | SipHash*             |         |    64 |         3.0 GB/s |                43.2 |
+ * | Blake3*              | @b SSE2 |   256 |         2.4 GB/s |                 8.1 |
+ * | HighwayHash          |         |    64 |         1.4 GB/s |                 6.0 |
+ * | FNV64                |         |    64 |         1.2 GB/s |                62.7 |
+ * | Blake2*              |         |   256 |         1.1 GB/s |                 5.1 |
+ * | SHA1*                |         |   160 |         0.8 GB/s |                 5.6 |
+ * | MD5*                 |         |   128 |         0.6 GB/s |                 7.8 |
+ * @note
+ *   - Hashes which require a specific ISA extension are noted. SSE2 is also noted,
+ *     even though it is mandatory on x64.
+ *   - Hashes with an asterisk are cryptographic. Note that MD5 is non-cryptographic
+ *     by modern standards.
+ *   - Small data velocity is a rough average of algorithm's efficiency for small
+ *     data. For more accurate information, see the wiki.
+ *   - More benchmarks and strength tests are found on the wiki:
+ *         https://github.com/Cyan4973/xxHash/wiki
+ *
+ * Usage
+ * ------
+ * All xxHash variants use a similar API. Changing the algorithm is a trivial
+ * substitution.
+ *
+ * @pre
+ *    For functions which take an input and length parameter, the following
+ *    requirements are assumed:
+ *    - The range from [`input`, `input + length`) is valid, readable memory.
+ *      - The only exception is if the `length` is `0`, `input` may be `NULL`.
+ *    - For C++, the objects must have the *TriviallyCopyable* property, as the
+ *      functions access bytes directly as if it was an array of `unsigned char`.
+ *
+ * @anchor single_shot_example
+ * **Single Shot**
+ *
+ * These functions are stateless functions which hash a contiguous block of memory,
+ * immediately returning the result. They are the easiest and usually the fastest
+ * option.
+ *
+ * XXH32(), XXH64(), XXH3_64bits(), XXH3_128bits()
+ *
+ * @code{.c}
+ *   #include <string.h>
+ *   #include "xxhash.h"
+ *
+ *   // Example for a function which hashes a null terminated string with XXH32().
+ *   XXH32_hash_t hash_string(const char* string, XXH32_hash_t seed)
+ *   {
+ *       // NULL pointers are only valid if the length is zero
+ *       size_t length = (string == NULL) ? 0 : strlen(string);
+ *       return XXH32(string, length, seed);
+ *   }
+ * @endcode
+ *
+ * @anchor streaming_example
+ * **Streaming**
+ *
+ * These groups of functions allow incremental hashing of unknown size, even
+ * more than what would fit in a size_t.
+ *
+ * XXH32_reset(), XXH64_reset(), XXH3_64bits_reset(), XXH3_128bits_reset()
+ *
+ * @code{.c}
+ *   #include <stdio.h>
+ *   #include <assert.h>
+ *   #include "xxhash.h"
+ *   // Example for a function which hashes a FILE incrementally with XXH3_64bits().
+ *   XXH64_hash_t hashFile(FILE* f)
+ *   {
+ *       // Allocate a state struct. Do not just use malloc() or new.
+ *       XXH3_state_t* state = XXH3_createState();
+ *       assert(state != NULL && "Out of memory!");
+ *       // Reset the state to start a new hashing session.
+ *       XXH3_64bits_reset(state);
+ *       char buffer[4096];
+ *       size_t count;
+ *       // Read the file in chunks
+ *       while ((count = fread(buffer, 1, sizeof(buffer), f)) != 0) {
+ *           // Run update() as many times as necessary to process the data
+ *           XXH3_64bits_update(state, buffer, count);
+ *       }
+ *       // Retrieve the finalized hash. This will not change the state.
+ *       XXH64_hash_t result = XXH3_64bits_digest(state);
+ *       // Free the state. Do not use free().
+ *       XXH3_freeState(state);
+ *       return result;
+ *   }
+ * @endcode
+ *
+ * @file xxhash.h
+ * xxHash prototypes and implementation
+ */
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+/* ****************************
+ *  INLINE mode
+ ******************************/
+/*!
+ * @defgroup public Public API
+ * Contains details on the public xxHash functions.
+ * @{
+ */
+#ifdef XXH_DOXYGEN
+/*!
+ * @brief Gives access to internal state declaration, required for static allocation.
+ *
+ * Incompatible with dynamic linking, due to risks of ABI changes.
+ *
+ * Usage:
+ * @code{.c}
+ *     #define XXH_STATIC_LINKING_ONLY
+ *     #include "xxhash.h"
+ * @endcode
+ */
+#  define XXH_STATIC_LINKING_ONLY
+/* Do not undef XXH_STATIC_LINKING_ONLY for Doxygen */
+
+/*!
+ * @brief Gives access to internal definitions.
+ *
+ * Usage:
+ * @code{.c}
+ *     #define XXH_STATIC_LINKING_ONLY
+ *     #define XXH_IMPLEMENTATION
+ *     #include "xxhash.h"
+ * @endcode
+ */
+#  define XXH_IMPLEMENTATION
+/* Do not undef XXH_IMPLEMENTATION for Doxygen */
+
+/*!
+ * @brief Exposes the implementation and marks all functions as `inline`.
+ *
+ * Use these build macros to inline xxhash into the target unit.
+ * Inlining improves performance on small inputs, especially when the length is
+ * expressed as a compile-time constant:
+ *
+ *  https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html
+ *
+ * It also keeps xxHash symbols private to the unit, so they are not exported.
+ *
+ * Usage:
+ * @code{.c}
+ *     #define XXH_INLINE_ALL
+ *     #include "xxhash.h"
+ * @endcode
+ * Do not compile and link xxhash.o as a separate object, as it is not useful.
+ */
+#  define XXH_INLINE_ALL
+#  undef XXH_INLINE_ALL
+/*!
+ * @brief Exposes the implementation without marking functions as inline.
+ */
+#  define XXH_PRIVATE_API
+#  undef XXH_PRIVATE_API
+/*!
+ * @brief Emulate a namespace by transparently prefixing all symbols.
+ *
+ * If you want to include _and expose_ xxHash functions from within your own
+ * library, but also want to avoid symbol collisions with other libraries which
+ * may also include xxHash, you can use @ref XXH_NAMESPACE to automatically prefix
+ * any public symbol from xxhash library with the value of @ref XXH_NAMESPACE
+ * (therefore, avoid empty or numeric values).
+ *
+ * Note that no change is required within the calling program as long as it
+ * includes `xxhash.h`: Regular symbol names will be automatically translated
+ * by this header.
+ */
+#  define XXH_NAMESPACE /* YOUR NAME HERE */
+#  undef XXH_NAMESPACE
+#endif
+
+#if (defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)) \
+    && !defined(XXH_INLINE_ALL_31684351384)
+   /* this section should be traversed only once */
+#  define XXH_INLINE_ALL_31684351384
+   /* give access to the advanced API, required to compile implementations */
+#  undef XXH_STATIC_LINKING_ONLY   /* avoid macro redef */
+#  define XXH_STATIC_LINKING_ONLY
+   /* make all functions private */
+#  undef XXH_PUBLIC_API
+#  if defined(__GNUC__)
+#    define XXH_PUBLIC_API static __inline __attribute__((unused))
+#  elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#    define XXH_PUBLIC_API static inline
+#  elif defined(_MSC_VER)
+#    define XXH_PUBLIC_API static __inline
+#  else
+     /* note: this version may generate warnings for unused static functions */
+#    define XXH_PUBLIC_API static
+#  endif
+
+   /*
+    * This part deals with the special case where a unit wants to inline xxHash,
+    * but "xxhash.h" has previously been included without XXH_INLINE_ALL,
+    * such as part of some previously included *.h header file.
+    * Without further action, the new include would just be ignored,
+    * and functions would effectively _not_ be inlined (silent failure).
+    * The following macros solve this situation by prefixing all inlined names,
+    * avoiding naming collision with previous inclusions.
+    */
+   /* Before that, we unconditionally #undef all symbols,
+    * in case they were already defined with XXH_NAMESPACE.
+    * They will then be redefined for XXH_INLINE_ALL
+    */
+#  undef XXH_versionNumber
+    /* XXH32 */
+#  undef XXH32
+#  undef XXH32_createState
+#  undef XXH32_freeState
+#  undef XXH32_reset
+#  undef XXH32_update
+#  undef XXH32_digest
+#  undef XXH32_copyState
+#  undef XXH32_canonicalFromHash
+#  undef XXH32_hashFromCanonical
+    /* XXH64 */
+#  undef XXH64
+#  undef XXH64_createState
+#  undef XXH64_freeState
+#  undef XXH64_reset
+#  undef XXH64_update
+#  undef XXH64_digest
+#  undef XXH64_copyState
+#  undef XXH64_canonicalFromHash
+#  undef XXH64_hashFromCanonical
+    /* XXH3_64bits */
+#  undef XXH3_64bits
+#  undef XXH3_64bits_withSecret
+#  undef XXH3_64bits_withSeed
+#  undef XXH3_64bits_withSecretandSeed
+#  undef XXH3_createState
+#  undef XXH3_freeState
+#  undef XXH3_copyState
+#  undef XXH3_64bits_reset
+#  undef XXH3_64bits_reset_withSeed
+#  undef XXH3_64bits_reset_withSecret
+#  undef XXH3_64bits_update
+#  undef XXH3_64bits_digest
+#  undef XXH3_generateSecret
+    /* XXH3_128bits */
+#  undef XXH128
+#  undef XXH3_128bits
+#  undef XXH3_128bits_withSeed
+#  undef XXH3_128bits_withSecret
+#  undef XXH3_128bits_reset
+#  undef XXH3_128bits_reset_withSeed
+#  undef XXH3_128bits_reset_withSecret
+#  undef XXH3_128bits_reset_withSecretandSeed
+#  undef XXH3_128bits_update
+#  undef XXH3_128bits_digest
+#  undef XXH128_isEqual
+#  undef XXH128_cmp
+#  undef XXH128_canonicalFromHash
+#  undef XXH128_hashFromCanonical
+    /* Finally, free the namespace itself */
+#  undef XXH_NAMESPACE
+
+    /* employ the namespace for XXH_INLINE_ALL */
+#  define XXH_NAMESPACE XXH_INLINE_
+   /*
+    * Some identifiers (enums, type names) are not symbols,
+    * but they must nonetheless be renamed to avoid redeclaration.
+    * Alternative solution: do not redeclare them.
+    * However, this requires some #ifdefs, and has a more dispersed impact.
+    * Meanwhile, renaming can be achieved in a single place.
+    */
+#  define XXH_IPREF(Id)   XXH_NAMESPACE ## Id
+#  define XXH_OK XXH_IPREF(XXH_OK)
+#  define XXH_ERROR XXH_IPREF(XXH_ERROR)
+#  define XXH_errorcode XXH_IPREF(XXH_errorcode)
+#  define XXH32_canonical_t  XXH_IPREF(XXH32_canonical_t)
+#  define XXH64_canonical_t  XXH_IPREF(XXH64_canonical_t)
+#  define XXH128_canonical_t XXH_IPREF(XXH128_canonical_t)
+#  define XXH32_state_s XXH_IPREF(XXH32_state_s)
+#  define XXH32_state_t XXH_IPREF(XXH32_state_t)
+#  define XXH64_state_s XXH_IPREF(XXH64_state_s)
+#  define XXH64_state_t XXH_IPREF(XXH64_state_t)
+#  define XXH3_state_s  XXH_IPREF(XXH3_state_s)
+#  define XXH3_state_t  XXH_IPREF(XXH3_state_t)
+#  define XXH128_hash_t XXH_IPREF(XXH128_hash_t)
+   /* Ensure the header is parsed again, even if it was previously included */
+#  undef XXHASH_H_5627135585666179
+#  undef XXHASH_H_STATIC_13879238742
+#endif /* XXH_INLINE_ALL || XXH_PRIVATE_API */
+
+/* ****************************************************************
+ *  Stable API
+ *****************************************************************/
+#ifndef XXHASH_H_5627135585666179
+#define XXHASH_H_5627135585666179 1
+
+/*! @brief Marks a global symbol. */
+#if !defined(XXH_INLINE_ALL) && !defined(XXH_PRIVATE_API)
+#  if defined(WIN32) && defined(_MSC_VER) && (defined(XXH_IMPORT) || defined(XXH_EXPORT))
+#    ifdef XXH_EXPORT
+#      define XXH_PUBLIC_API __declspec(dllexport)
+#    elif XXH_IMPORT
+#      define XXH_PUBLIC_API __declspec(dllimport)
+#    endif
+#  else
+#    define XXH_PUBLIC_API   /* do nothing */
+#  endif
+#endif
+
+#ifdef XXH_NAMESPACE
+#  define XXH_CAT(A,B) A##B
+#  define XXH_NAME2(A,B) XXH_CAT(A,B)
+#  define XXH_versionNumber XXH_NAME2(XXH_NAMESPACE, XXH_versionNumber)
+/* XXH32 */
+#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#  define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
+#  define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
+#  define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
+#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#  define XXH32_copyState XXH_NAME2(XXH_NAMESPACE, XXH32_copyState)
+#  define XXH32_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH32_canonicalFromHash)
+#  define XXH32_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH32_hashFromCanonical)
+/* XXH64 */
+#  define XXH64 XXH_NAME2(XXH_NAMESPACE, XXH64)
+#  define XXH64_createState XXH_NAME2(XXH_NAMESPACE, XXH64_createState)
+#  define XXH64_freeState XXH_NAME2(XXH_NAMESPACE, XXH64_freeState)
+#  define XXH64_reset XXH_NAME2(XXH_NAMESPACE, XXH64_reset)
+#  define XXH64_update XXH_NAME2(XXH_NAMESPACE, XXH64_update)
+#  define XXH64_digest XXH_NAME2(XXH_NAMESPACE, XXH64_digest)
+#  define XXH64_copyState XXH_NAME2(XXH_NAMESPACE, XXH64_copyState)
+#  define XXH64_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH64_canonicalFromHash)
+#  define XXH64_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH64_hashFromCanonical)
+/* XXH3_64bits */
+#  define XXH3_64bits XXH_NAME2(XXH_NAMESPACE, XXH3_64bits)
+#  define XXH3_64bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecret)
+#  define XXH3_64bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSeed)
+#  define XXH3_64bits_withSecretandSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_withSecretandSeed)
+#  define XXH3_createState XXH_NAME2(XXH_NAMESPACE, XXH3_createState)
+#  define XXH3_freeState XXH_NAME2(XXH_NAMESPACE, XXH3_freeState)
+#  define XXH3_copyState XXH_NAME2(XXH_NAMESPACE, XXH3_copyState)
+#  define XXH3_64bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset)
+#  define XXH3_64bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSeed)
+#  define XXH3_64bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSecret)
+#  define XXH3_64bits_reset_withSecretandSeed XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_reset_withSecretandSeed)
+#  define XXH3_64bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_update)
+#  define XXH3_64bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_64bits_digest)
+#  define XXH3_generateSecret XXH_NAME2(XXH_NAMESPACE, XXH3_generateSecret)
+#  define XXH3_generateSecret_fromSeed XXH_NAME2(XXH_NAMESPACE, XXH3_generateSecret_fromSeed)
+/* XXH3_128bits */
+#  define XXH128 XXH_NAME2(XXH_NAMESPACE, XXH128)
+#  define XXH3_128bits XXH_NAME2(XXH_NAMESPACE, XXH3_128bits)
+#  define XXH3_128bits_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSeed)
+#  define XXH3_128bits_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecret)
+#  define XXH3_128bits_withSecretandSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_withSecretandSeed)
+#  define XXH3_128bits_reset XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset)
+#  define XXH3_128bits_reset_withSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSeed)
+#  define XXH3_128bits_reset_withSecret XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecret)
+#  define XXH3_128bits_reset_withSecretandSeed XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_reset_withSecretandSeed)
+#  define XXH3_128bits_update XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_update)
+#  define XXH3_128bits_digest XXH_NAME2(XXH_NAMESPACE, XXH3_128bits_digest)
+#  define XXH128_isEqual XXH_NAME2(XXH_NAMESPACE, XXH128_isEqual)
+#  define XXH128_cmp     XXH_NAME2(XXH_NAMESPACE, XXH128_cmp)
+#  define XXH128_canonicalFromHash XXH_NAME2(XXH_NAMESPACE, XXH128_canonicalFromHash)
+#  define XXH128_hashFromCanonical XXH_NAME2(XXH_NAMESPACE, XXH128_hashFromCanonical)
+#endif
+
+
+/* *************************************
+*  Compiler specifics
+***************************************/
+
+/* specific declaration modes for Windows */
+#if !defined(XXH_INLINE_ALL) && !defined(XXH_PRIVATE_API)
+#  if defined(WIN32) && defined(_MSC_VER) && (defined(XXH_IMPORT) || defined(XXH_EXPORT))
+#    ifdef XXH_EXPORT
+#      define XXH_PUBLIC_API __declspec(dllexport)
+#    elif XXH_IMPORT
+#      define XXH_PUBLIC_API __declspec(dllimport)
+#    endif
+#  else
+#    define XXH_PUBLIC_API   /* do nothing */
+#  endif
+#endif
+
+#if defined (__GNUC__)
+# define XXH_CONSTF  __attribute__((const))
+# define XXH_PUREF   __attribute__((pure))
+# define XXH_MALLOCF __attribute__((malloc))
+#else
+# define XXH_CONSTF  /* disable */
+# define XXH_PUREF
+# define XXH_MALLOCF
+#endif
+
+/* *************************************
+*  Version
+***************************************/
+#define XXH_VERSION_MAJOR    0
+#define XXH_VERSION_MINOR    8
+#define XXH_VERSION_RELEASE  2
+/*! @brief Version number, encoded as two digits each */
+#define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
+
+/*!
+ * @brief Obtains the xxHash version.
+ *
+ * This is mostly useful when xxHash is compiled as a shared library,
+ * since the returned value comes from the library, as opposed to header file.
+ *
+ * @return @ref XXH_VERSION_NUMBER of the invoked library.
+ */
+XXH_PUBLIC_API XXH_CONSTF unsigned XXH_versionNumber (void);
+
+
+/* ****************************
+*  Common basic types
+******************************/
+#include <stddef.h>   /* size_t */
+/*!
+ * @brief Exit code for the streaming API.
+ */
+typedef enum {
+    XXH_OK = 0, /*!< OK */
+    XXH_ERROR   /*!< Error */
+} XXH_errorcode;
+
+
+/*-**********************************************************************
+*  32-bit hash
+************************************************************************/
+#if defined(XXH_DOXYGEN) /* Don't show <stdint.h> include */
+/*!
+ * @brief An unsigned 32-bit integer.
+ *
+ * Not necessarily defined to `uint32_t` but functionally equivalent.
+ */
+typedef uint32_t XXH32_hash_t;
+
+#elif !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef uint32_t XXH32_hash_t;
+
+#else
+#   include <limits.h>
+#   if UINT_MAX == 0xFFFFFFFFUL
+      typedef unsigned int XXH32_hash_t;
+#   elif ULONG_MAX == 0xFFFFFFFFUL
+      typedef unsigned long XXH32_hash_t;
+#   else
+#     error "unsupported platform: need a 32-bit type"
+#   endif
+#endif
+
+/*!
+ * @}
+ *
+ * @defgroup XXH32_family XXH32 family
+ * @ingroup public
+ * Contains functions used in the classic 32-bit xxHash algorithm.
+ *
+ * @note
+ *   XXH32 is useful for older platforms, with no or poor 64-bit performance.
+ *   Note that the @ref XXH3_family provides competitive speed for both 32-bit
+ *   and 64-bit systems, and offers true 64/128 bit hash results.
+ *
+ * @see @ref XXH64_family, @ref XXH3_family : Other xxHash families
+ * @see @ref XXH32_impl for implementation details
+ * @{
+ */
+
+/*!
+ * @brief Calculates the 32-bit hash of @p input using xxHash32.
+ *
+ * Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark): 5.4 GB/s
+ *
+ * See @ref single_shot_example "Single Shot Example" for an example.
+ *
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ * @param seed The 32-bit seed to alter the hash's output predictably.
+ *
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return The calculated 32-bit hash value.
+ *
+ * @see
+ *    XXH64(), XXH3_64bits_withSeed(), XXH3_128bits_withSeed(), XXH128():
+ *    Direct equivalents for the other variants of xxHash.
+ * @see
+ *    XXH32_createState(), XXH32_update(), XXH32_digest(): Streaming version.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32 (const void* input, size_t length, XXH32_hash_t seed);
+
+#ifndef XXH_NO_STREAM
+/*!
+ * Streaming functions generate the xxHash value from an incremental input.
+ * This method is slower than single-call functions, due to state management.
+ * For small inputs, prefer `XXH32()` and `XXH64()`, which are better optimized.
+ *
+ * An XXH state must first be allocated using `XXH*_createState()`.
+ *
+ * Start a new hash by initializing the state with a seed using `XXH*_reset()`.
+ *
+ * Then, feed the hash state by calling `XXH*_update()` as many times as necessary.
+ *
+ * The function returns an error code, with 0 meaning OK, and any other value
+ * meaning there is an error.
+ *
+ * Finally, a hash value can be produced anytime, by using `XXH*_digest()`.
+ * This function returns the nn-bits hash as an int or long long.
+ *
+ * It's still possible to continue inserting input into the hash state after a
+ * digest, and generate new hash values later on by invoking `XXH*_digest()`.
+ *
+ * When done, release the state using `XXH*_freeState()`.
+ *
+ * @see streaming_example at the top of @ref xxhash.h for an example.
+ */
+
+/*!
+ * @typedef struct XXH32_state_s XXH32_state_t
+ * @brief The opaque state struct for the XXH32 streaming API.
+ *
+ * @see XXH32_state_s for details.
+ */
+typedef struct XXH32_state_s XXH32_state_t;
+
+/*!
+ * @brief Allocates an @ref XXH32_state_t.
+ *
+ * Must be freed with XXH32_freeState().
+ * @return An allocated XXH32_state_t on success, `NULL` on failure.
+ */
+XXH_PUBLIC_API XXH_MALLOCF XXH32_state_t* XXH32_createState(void);
+/*!
+ * @brief Frees an @ref XXH32_state_t.
+ *
+ * Must be allocated with XXH32_createState().
+ * @param statePtr A pointer to an @ref XXH32_state_t allocated with @ref XXH32_createState().
+ * @return XXH_OK.
+ */
+XXH_PUBLIC_API XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
+/*!
+ * @brief Copies one @ref XXH32_state_t to another.
+ *
+ * @param dst_state The state to copy to.
+ * @param src_state The state to copy from.
+ * @pre
+ *   @p dst_state and @p src_state must not be `NULL` and must not overlap.
+ */
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state);
+
+/*!
+ * @brief Resets an @ref XXH32_state_t to begin a new hash.
+ *
+ * This function resets and seeds a state. Call it before @ref XXH32_update().
+ *
+ * @param statePtr The state struct to reset.
+ * @param seed The 32-bit seed to alter the hash result predictably.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, XXH32_hash_t seed);
+
+/*!
+ * @brief Consumes a block of @p input to an @ref XXH32_state_t.
+ *
+ * Call this to incrementally consume blocks of data.
+ *
+ * @param statePtr The state struct to update.
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+
+/*!
+ * @brief Returns the calculated hash value from an @ref XXH32_state_t.
+ *
+ * @note
+ *   Calling XXH32_digest() will not affect @p statePtr, so you can update,
+ *   digest, and update again.
+ *
+ * @param statePtr The state struct to calculate the hash from.
+ *
+ * @pre
+ *  @p statePtr must not be `NULL`.
+ *
+ * @return The calculated xxHash32 value from that state.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32_digest (const XXH32_state_t* statePtr);
+#endif /* !XXH_NO_STREAM */
+
+/*******   Canonical representation   *******/
+
+/*
+ * The default return values from XXH functions are unsigned 32 and 64 bit
+ * integers.
+ * This the simplest and fastest format for further post-processing.
+ *
+ * However, this leaves open the question of what is the order on the byte level,
+ * since little and big endian conventions will store the same number differently.
+ *
+ * The canonical representation settles this issue by mandating big-endian
+ * convention, the same convention as human-readable numbers (large digits first).
+ *
+ * When writing hash values to storage, sending them over a network, or printing
+ * them, it's highly recommended to use the canonical representation to ensure
+ * portability across a wider range of systems, present and future.
+ *
+ * The following functions allow transformation of hash values to and from
+ * canonical format.
+ */
+
+/*!
+ * @brief Canonical (big endian) representation of @ref XXH32_hash_t.
+ */
+typedef struct {
+    unsigned char digest[4]; /*!< Hash bytes, big endian */
+} XXH32_canonical_t;
+
+/*!
+ * @brief Converts an @ref XXH32_hash_t to a big endian @ref XXH32_canonical_t.
+ *
+ * @param dst The @ref XXH32_canonical_t pointer to be stored to.
+ * @param hash The @ref XXH32_hash_t to be converted.
+ *
+ * @pre
+ *   @p dst must not be `NULL`.
+ */
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash);
+
+/*!
+ * @brief Converts an @ref XXH32_canonical_t to a native @ref XXH32_hash_t.
+ *
+ * @param src The @ref XXH32_canonical_t to convert.
+ *
+ * @pre
+ *   @p src must not be `NULL`.
+ *
+ * @return The converted hash.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src);
+
+
+/*! @cond Doxygen ignores this part */
+#ifdef __has_attribute
+# define XXH_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+# define XXH_HAS_ATTRIBUTE(x) 0
+#endif
+/*! @endcond */
+
+/*! @cond Doxygen ignores this part */
+/*
+ * C23 __STDC_VERSION__ number hasn't been specified yet. For now
+ * leave as `201711L` (C17 + 1).
+ * TODO: Update to correct value when its been specified.
+ */
+#define XXH_C23_VN 201711L
+/*! @endcond */
+
+/*! @cond Doxygen ignores this part */
+/* C-language Attributes are added in C23. */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= XXH_C23_VN) && defined(__has_c_attribute)
+# define XXH_HAS_C_ATTRIBUTE(x) __has_c_attribute(x)
+#else
+# define XXH_HAS_C_ATTRIBUTE(x) 0
+#endif
+/*! @endcond */
+
+/*! @cond Doxygen ignores this part */
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+# define XXH_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+# define XXH_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+/*! @endcond */
+
+/*! @cond Doxygen ignores this part */
+/*
+ * Define XXH_FALLTHROUGH macro for annotating switch case with the 'fallthrough' attribute
+ * introduced in CPP17 and C23.
+ * CPP17 : https://en.cppreference.com/w/cpp/language/attributes/fallthrough
+ * C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
+ */
+#if XXH_HAS_C_ATTRIBUTE(fallthrough) || XXH_HAS_CPP_ATTRIBUTE(fallthrough)
+# define XXH_FALLTHROUGH [[fallthrough]]
+#elif XXH_HAS_ATTRIBUTE(__fallthrough__)
+# define XXH_FALLTHROUGH __attribute__ ((__fallthrough__))
+#else
+# define XXH_FALLTHROUGH /* fallthrough */
+#endif
+/*! @endcond */
+
+/*! @cond Doxygen ignores this part */
+/*
+ * Define XXH_NOESCAPE for annotated pointers in public API.
+ * https://clang.llvm.org/docs/AttributeReference.html#noescape
+ * As of writing this, only supported by clang.
+ */
+#if XXH_HAS_ATTRIBUTE(noescape)
+# define XXH_NOESCAPE __attribute__((noescape))
+#else
+# define XXH_NOESCAPE
+#endif
+/*! @endcond */
+
+
+/*!
+ * @}
+ * @ingroup public
+ * @{
+ */
+
+#ifndef XXH_NO_LONG_LONG
+/*-**********************************************************************
+*  64-bit hash
+************************************************************************/
+#if defined(XXH_DOXYGEN) /* don't include <stdint.h> */
+/*!
+ * @brief An unsigned 64-bit integer.
+ *
+ * Not necessarily defined to `uint64_t` but functionally equivalent.
+ */
+typedef uint64_t XXH64_hash_t;
+#elif !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#  include <stdint.h>
+   typedef uint64_t XXH64_hash_t;
+#else
+#  include <limits.h>
+#  if defined(__LP64__) && ULONG_MAX == 0xFFFFFFFFFFFFFFFFULL
+     /* LP64 ABI says uint64_t is unsigned long */
+     typedef unsigned long XXH64_hash_t;
+#  else
+     /* the following type must have a width of 64-bit */
+     typedef unsigned long long XXH64_hash_t;
+#  endif
+#endif
+
+/*!
+ * @}
+ *
+ * @defgroup XXH64_family XXH64 family
+ * @ingroup public
+ * @{
+ * Contains functions used in the classic 64-bit xxHash algorithm.
+ *
+ * @note
+ *   XXH3 provides competitive speed for both 32-bit and 64-bit systems,
+ *   and offers true 64/128 bit hash results.
+ *   It provides better speed for systems with vector processing capabilities.
+ */
+
+/*!
+ * @brief Calculates the 64-bit hash of @p input using xxHash64.
+ *
+ * This function usually runs faster on 64-bit systems, but slower on 32-bit
+ * systems (see benchmark).
+ *
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ * @param seed The 64-bit seed to alter the hash's output predictably.
+ *
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return The calculated 64-bit hash.
+ *
+ * @see
+ *    XXH32(), XXH3_64bits_withSeed(), XXH3_128bits_withSeed(), XXH128():
+ *    Direct equivalents for the other variants of xxHash.
+ * @see
+ *    XXH64_createState(), XXH64_update(), XXH64_digest(): Streaming version.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH64(XXH_NOESCAPE const void* input, size_t length, XXH64_hash_t seed);
+
+/*******   Streaming   *******/
+#ifndef XXH_NO_STREAM
+/*!
+ * @brief The opaque state struct for the XXH64 streaming API.
+ *
+ * @see XXH64_state_s for details.
+ */
+typedef struct XXH64_state_s XXH64_state_t;   /* incomplete type */
+
+/*!
+ * @brief Allocates an @ref XXH64_state_t.
+ *
+ * Must be freed with XXH64_freeState().
+ * @return An allocated XXH64_state_t on success, `NULL` on failure.
+ */
+XXH_PUBLIC_API XXH_MALLOCF XXH64_state_t* XXH64_createState(void);
+
+/*!
+ * @brief Frees an @ref XXH64_state_t.
+ *
+ * Must be allocated with XXH64_createState().
+ * @param statePtr A pointer to an @ref XXH64_state_t allocated with @ref XXH64_createState().
+ * @return XXH_OK.
+ */
+XXH_PUBLIC_API XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+
+/*!
+ * @brief Copies one @ref XXH64_state_t to another.
+ *
+ * @param dst_state The state to copy to.
+ * @param src_state The state to copy from.
+ * @pre
+ *   @p dst_state and @p src_state must not be `NULL` and must not overlap.
+ */
+XXH_PUBLIC_API void XXH64_copyState(XXH_NOESCAPE XXH64_state_t* dst_state, const XXH64_state_t* src_state);
+
+/*!
+ * @brief Resets an @ref XXH64_state_t to begin a new hash.
+ *
+ * This function resets and seeds a state. Call it before @ref XXH64_update().
+ *
+ * @param statePtr The state struct to reset.
+ * @param seed The 64-bit seed to alter the hash result predictably.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH64_reset  (XXH_NOESCAPE XXH64_state_t* statePtr, XXH64_hash_t seed);
+
+/*!
+ * @brief Consumes a block of @p input to an @ref XXH64_state_t.
+ *
+ * Call this to incrementally consume blocks of data.
+ *
+ * @param statePtr The state struct to update.
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH64_update (XXH_NOESCAPE XXH64_state_t* statePtr, XXH_NOESCAPE const void* input, size_t length);
+
+/*!
+ * @brief Returns the calculated hash value from an @ref XXH64_state_t.
+ *
+ * @note
+ *   Calling XXH64_digest() will not affect @p statePtr, so you can update,
+ *   digest, and update again.
+ *
+ * @param statePtr The state struct to calculate the hash from.
+ *
+ * @pre
+ *  @p statePtr must not be `NULL`.
+ *
+ * @return The calculated xxHash64 value from that state.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH64_digest (XXH_NOESCAPE const XXH64_state_t* statePtr);
+#endif /* !XXH_NO_STREAM */
+/*******   Canonical representation   *******/
+
+/*!
+ * @brief Canonical (big endian) representation of @ref XXH64_hash_t.
+ */
+typedef struct { unsigned char digest[sizeof(XXH64_hash_t)]; } XXH64_canonical_t;
+
+/*!
+ * @brief Converts an @ref XXH64_hash_t to a big endian @ref XXH64_canonical_t.
+ *
+ * @param dst The @ref XXH64_canonical_t pointer to be stored to.
+ * @param hash The @ref XXH64_hash_t to be converted.
+ *
+ * @pre
+ *   @p dst must not be `NULL`.
+ */
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH_NOESCAPE XXH64_canonical_t* dst, XXH64_hash_t hash);
+
+/*!
+ * @brief Converts an @ref XXH64_canonical_t to a native @ref XXH64_hash_t.
+ *
+ * @param src The @ref XXH64_canonical_t to convert.
+ *
+ * @pre
+ *   @p src must not be `NULL`.
+ *
+ * @return The converted hash.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_canonical_t* src);
+
+#ifndef XXH_NO_XXH3
+
+/*!
+ * @}
+ * ************************************************************************
+ * @defgroup XXH3_family XXH3 family
+ * @ingroup public
+ * @{
+ *
+ * XXH3 is a more recent hash algorithm featuring:
+ *  - Improved speed for both small and large inputs
+ *  - True 64-bit and 128-bit outputs
+ *  - SIMD acceleration
+ *  - Improved 32-bit viability
+ *
+ * Speed analysis methodology is explained here:
+ *
+ *    https://fastcompression.blogspot.com/2019/03/presenting-xxh3.html
+ *
+ * Compared to XXH64, expect XXH3 to run approximately
+ * ~2x faster on large inputs and >3x faster on small ones,
+ * exact differences vary depending on platform.
+ *
+ * XXH3's speed benefits greatly from SIMD and 64-bit arithmetic,
+ * but does not require it.
+ * Most 32-bit and 64-bit targets that can run XXH32 smoothly can run XXH3
+ * at competitive speeds, even without vector support. Further details are
+ * explained in the implementation.
+ *
+ * XXH3 has a fast scalar implementation, but it also includes accelerated SIMD
+ * implementations for many common platforms:
+ *   - AVX512
+ *   - AVX2
+ *   - SSE2
+ *   - ARM NEON
+ *   - WebAssembly SIMD128
+ *   - POWER8 VSX
+ *   - s390x ZVector
+ * This can be controlled via the @ref XXH_VECTOR macro, but it automatically
+ * selects the best version according to predefined macros. For the x86 family, an
+ * automatic runtime dispatcher is included separately in @ref xxh_x86dispatch.c.
+ *
+ * XXH3 implementation is portable:
+ * it has a generic C90 formulation that can be compiled on any platform,
+ * all implementations generate exactly the same hash value on all platforms.
+ * Starting from v0.8.0, it's also labelled "stable", meaning that
+ * any future version will also generate the same hash value.
+ *
+ * XXH3 offers 2 variants, _64bits and _128bits.
+ *
+ * When only 64 bits are needed, prefer invoking the _64bits variant, as it
+ * reduces the amount of mixing, resulting in faster speed on small inputs.
+ * It's also generally simpler to manipulate a scalar return type than a struct.
+ *
+ * The API supports one-shot hashing, streaming mode, and custom secrets.
+ */
+/*-**********************************************************************
+*  XXH3 64-bit variant
+************************************************************************/
+
+/*!
+ * @brief 64-bit unseeded variant of XXH3.
+ *
+ * This is equivalent to @ref XXH3_64bits_withSeed() with a seed of 0, however
+ * it may have slightly better performance due to constant propagation of the
+ * defaults.
+ *
+ * @see
+ *    XXH32(), XXH64(), XXH3_128bits(): equivalent for the other xxHash algorithms
+ * @see
+ *    XXH3_64bits_withSeed(), XXH3_64bits_withSecret(): other seeding variants
+ * @see
+ *    XXH3_64bits_reset(), XXH3_64bits_update(), XXH3_64bits_digest(): Streaming version.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH3_64bits(XXH_NOESCAPE const void* input, size_t length);
+
+/*!
+ * @brief 64-bit seeded variant of XXH3
+ *
+ * This variant generates a custom secret on the fly based on default secret
+ * altered using the `seed` value.
+ *
+ * While this operation is decently fast, note that it's not completely free.
+ *
+ * @note
+ *    seed == 0 produces the same results as @ref XXH3_64bits().
+ *
+ * @param input The data to hash
+ * @param length The length
+ * @param seed The 64-bit seed to alter the state.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH3_64bits_withSeed(XXH_NOESCAPE const void* input, size_t length, XXH64_hash_t seed);
+
+/*!
+ * The bare minimum size for a custom secret.
+ *
+ * @see
+ *  XXH3_64bits_withSecret(), XXH3_64bits_reset_withSecret(),
+ *  XXH3_128bits_withSecret(), XXH3_128bits_reset_withSecret().
+ */
+#define XXH3_SECRET_SIZE_MIN 136
+
+/*!
+ * @brief 64-bit variant of XXH3 with a custom "secret".
+ *
+ * It's possible to provide any blob of bytes as a "secret" to generate the hash.
+ * This makes it more difficult for an external actor to prepare an intentional collision.
+ * The main condition is that secretSize *must* be large enough (>= XXH3_SECRET_SIZE_MIN).
+ * However, the quality of the secret impacts the dispersion of the hash algorithm.
+ * Therefore, the secret _must_ look like a bunch of random bytes.
+ * Avoid "trivial" or structured data such as repeated sequences or a text document.
+ * Whenever in doubt about the "randomness" of the blob of bytes,
+ * consider employing "XXH3_generateSecret()" instead (see below).
+ * It will generate a proper high entropy secret derived from the blob of bytes.
+ * Another advantage of using XXH3_generateSecret() is that
+ * it guarantees that all bits within the initial blob of bytes
+ * will impact every bit of the output.
+ * This is not necessarily the case when using the blob of bytes directly
+ * because, when hashing _small_ inputs, only a portion of the secret is employed.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t XXH3_64bits_withSecret(XXH_NOESCAPE const void* data, size_t len, XXH_NOESCAPE const void* secret, size_t secretSize);
+
+
+/*******   Streaming   *******/
+#ifndef XXH_NO_STREAM
+/*
+ * Streaming requires state maintenance.
+ * This operation costs memory and CPU.
+ * As a consequence, streaming is slower than one-shot hashing.
+ * For better performance, prefer one-shot functions whenever applicable.
+ */
+
+/*!
+ * @brief The state struct for the XXH3 streaming API.
+ *
+ * @see XXH3_state_s for details.
+ */
+typedef struct XXH3_state_s XXH3_state_t;
+XXH_PUBLIC_API XXH_MALLOCF XXH3_state_t* XXH3_createState(void);
+XXH_PUBLIC_API XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr);
+
+/*!
+ * @brief Copies one @ref XXH3_state_t to another.
+ *
+ * @param dst_state The state to copy to.
+ * @param src_state The state to copy from.
+ * @pre
+ *   @p dst_state and @p src_state must not be `NULL` and must not overlap.
+ */
+XXH_PUBLIC_API void XXH3_copyState(XXH_NOESCAPE XXH3_state_t* dst_state, XXH_NOESCAPE const XXH3_state_t* src_state);
+
+/*!
+ * @brief Resets an @ref XXH3_state_t to begin a new hash.
+ *
+ * This function resets `statePtr` and generate a secret with default parameters. Call it before @ref XXH3_64bits_update().
+ * Digest will be equivalent to `XXH3_64bits()`.
+ *
+ * @param statePtr The state struct to reset.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ *
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset(XXH_NOESCAPE XXH3_state_t* statePtr);
+
+/*!
+ * @brief Resets an @ref XXH3_state_t with 64-bit seed to begin a new hash.
+ *
+ * This function resets `statePtr` and generate a secret from `seed`. Call it before @ref XXH3_64bits_update().
+ * Digest will be equivalent to `XXH3_64bits_withSeed()`.
+ *
+ * @param statePtr The state struct to reset.
+ * @param seed     The 64-bit seed to alter the state.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ *
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH64_hash_t seed);
+
+/*!
+ * XXH3_64bits_reset_withSecret():
+ * `secret` is referenced, it _must outlive_ the hash streaming session.
+ * Similar to one-shot API, `secretSize` must be >= `XXH3_SECRET_SIZE_MIN`,
+ * and the quality of produced hash values depends on secret's entropy
+ * (secret's content should look like a bunch of random bytes).
+ * When in doubt about the randomness of a candidate `secret`,
+ * consider employing `XXH3_generateSecret()` instead (see below).
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_reset_withSecret(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize);
+
+/*!
+ * @brief Consumes a block of @p input to an @ref XXH3_state_t.
+ *
+ * Call this to incrementally consume blocks of data.
+ *
+ * @param statePtr The state struct to update.
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_64bits_update (XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* input, size_t length);
+
+/*!
+ * @brief Returns the calculated XXH3 64-bit hash value from an @ref XXH3_state_t.
+ *
+ * @note
+ *   Calling XXH3_64bits_digest() will not affect @p statePtr, so you can update,
+ *   digest, and update again.
+ *
+ * @param statePtr The state struct to calculate the hash from.
+ *
+ * @pre
+ *  @p statePtr must not be `NULL`.
+ *
+ * @return The calculated XXH3 64-bit hash value from that state.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t  XXH3_64bits_digest (XXH_NOESCAPE const XXH3_state_t* statePtr);
+#endif /* !XXH_NO_STREAM */
+
+/* note : canonical representation of XXH3 is the same as XXH64
+ * since they both produce XXH64_hash_t values */
+
+
+/*-**********************************************************************
+*  XXH3 128-bit variant
+************************************************************************/
+
+/*!
+ * @brief The return value from 128-bit hashes.
+ *
+ * Stored in little endian order, although the fields themselves are in native
+ * endianness.
+ */
+typedef struct {
+    XXH64_hash_t low64;   /*!< `value & 0xFFFFFFFFFFFFFFFF` */
+    XXH64_hash_t high64;  /*!< `value >> 64` */
+} XXH128_hash_t;
+
+/*!
+ * @brief Unseeded 128-bit variant of XXH3
+ *
+ * The 128-bit variant of XXH3 has more strength, but it has a bit of overhead
+ * for shorter inputs.
+ *
+ * This is equivalent to @ref XXH3_128bits_withSeed() with a seed of 0, however
+ * it may have slightly better performance due to constant propagation of the
+ * defaults.
+ *
+ * @see
+ *    XXH32(), XXH64(), XXH3_64bits(): equivalent for the other xxHash algorithms
+ * @see
+ *    XXH3_128bits_withSeed(), XXH3_128bits_withSecret(): other seeding variants
+ * @see
+ *    XXH3_128bits_reset(), XXH3_128bits_update(), XXH3_128bits_digest(): Streaming version.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH3_128bits(XXH_NOESCAPE const void* data, size_t len);
+/*! @brief Seeded 128-bit variant of XXH3. @see XXH3_64bits_withSeed(). */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH3_128bits_withSeed(XXH_NOESCAPE const void* data, size_t len, XXH64_hash_t seed);
+/*! @brief Custom secret 128-bit variant of XXH3. @see XXH3_64bits_withSecret(). */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH3_128bits_withSecret(XXH_NOESCAPE const void* data, size_t len, XXH_NOESCAPE const void* secret, size_t secretSize);
+
+/*******   Streaming   *******/
+#ifndef XXH_NO_STREAM
+/*
+ * Streaming requires state maintenance.
+ * This operation costs memory and CPU.
+ * As a consequence, streaming is slower than one-shot hashing.
+ * For better performance, prefer one-shot functions whenever applicable.
+ *
+ * XXH3_128bits uses the same XXH3_state_t as XXH3_64bits().
+ * Use already declared XXH3_createState() and XXH3_freeState().
+ *
+ * All reset and streaming functions have same meaning as their 64-bit counterpart.
+ */
+
+/*!
+ * @brief Resets an @ref XXH3_state_t to begin a new hash.
+ *
+ * This function resets `statePtr` and generate a secret with default parameters. Call it before @ref XXH3_128bits_update().
+ * Digest will be equivalent to `XXH3_128bits()`.
+ *
+ * @param statePtr The state struct to reset.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ *
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset(XXH_NOESCAPE XXH3_state_t* statePtr);
+
+/*!
+ * @brief Resets an @ref XXH3_state_t with 64-bit seed to begin a new hash.
+ *
+ * This function resets `statePtr` and generate a secret from `seed`. Call it before @ref XXH3_128bits_update().
+ * Digest will be equivalent to `XXH3_128bits_withSeed()`.
+ *
+ * @param statePtr The state struct to reset.
+ * @param seed     The 64-bit seed to alter the state.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ *
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH64_hash_t seed);
+/*! @brief Custom secret 128-bit variant of XXH3. @see XXH_64bits_reset_withSecret(). */
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_reset_withSecret(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize);
+
+/*!
+ * @brief Consumes a block of @p input to an @ref XXH3_state_t.
+ *
+ * Call this to incrementally consume blocks of data.
+ *
+ * @param statePtr The state struct to update.
+ * @param input The block of data to be hashed, at least @p length bytes in size.
+ * @param length The length of @p input, in bytes.
+ *
+ * @pre
+ *   @p statePtr must not be `NULL`.
+ * @pre
+ *   The memory between @p input and @p input + @p length must be valid,
+ *   readable, contiguous memory. However, if @p length is `0`, @p input may be
+ *   `NULL`. In C++, this also must be *TriviallyCopyable*.
+ *
+ * @return @ref XXH_OK on success, @ref XXH_ERROR on failure.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_128bits_update (XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* input, size_t length);
+
+/*!
+ * @brief Returns the calculated XXH3 128-bit hash value from an @ref XXH3_state_t.
+ *
+ * @note
+ *   Calling XXH3_128bits_digest() will not affect @p statePtr, so you can update,
+ *   digest, and update again.
+ *
+ * @param statePtr The state struct to calculate the hash from.
+ *
+ * @pre
+ *  @p statePtr must not be `NULL`.
+ *
+ * @return The calculated XXH3 128-bit hash value from that state.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH3_128bits_digest (XXH_NOESCAPE const XXH3_state_t* statePtr);
+#endif /* !XXH_NO_STREAM */
+
+/* Following helper functions make it possible to compare XXH128_hast_t values.
+ * Since XXH128_hash_t is a structure, this capability is not offered by the language.
+ * Note: For better performance, these functions can be inlined using XXH_INLINE_ALL */
+
+/*!
+ * XXH128_isEqual():
+ * Return: 1 if `h1` and `h2` are equal, 0 if they are not.
+ */
+XXH_PUBLIC_API XXH_PUREF int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2);
+
+/*!
+ * @brief Compares two @ref XXH128_hash_t
+ * This comparator is compatible with stdlib's `qsort()`/`bsearch()`.
+ *
+ * @return: >0 if *h128_1  > *h128_2
+ *          =0 if *h128_1 == *h128_2
+ *          <0 if *h128_1  < *h128_2
+ */
+XXH_PUBLIC_API XXH_PUREF int XXH128_cmp(XXH_NOESCAPE const void* h128_1, XXH_NOESCAPE const void* h128_2);
+
+
+/*******   Canonical representation   *******/
+typedef struct { unsigned char digest[sizeof(XXH128_hash_t)]; } XXH128_canonical_t;
+
+
+/*!
+ * @brief Converts an @ref XXH128_hash_t to a big endian @ref XXH128_canonical_t.
+ *
+ * @param dst The @ref XXH128_canonical_t pointer to be stored to.
+ * @param hash The @ref XXH128_hash_t to be converted.
+ *
+ * @pre
+ *   @p dst must not be `NULL`.
+ */
+XXH_PUBLIC_API void XXH128_canonicalFromHash(XXH_NOESCAPE XXH128_canonical_t* dst, XXH128_hash_t hash);
+
+/*!
+ * @brief Converts an @ref XXH128_canonical_t to a native @ref XXH128_hash_t.
+ *
+ * @param src The @ref XXH128_canonical_t to convert.
+ *
+ * @pre
+ *   @p src must not be `NULL`.
+ *
+ * @return The converted hash.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH128_hashFromCanonical(XXH_NOESCAPE const XXH128_canonical_t* src);
+
+
+#endif  /* !XXH_NO_XXH3 */
+#endif  /* XXH_NO_LONG_LONG */
+
+/*!
+ * @}
+ */
+#endif /* XXHASH_H_5627135585666179 */
+
+
+
+#if defined(XXH_STATIC_LINKING_ONLY) && !defined(XXHASH_H_STATIC_13879238742)
+#define XXHASH_H_STATIC_13879238742
+/* ****************************************************************************
+ * This section contains declarations which are not guaranteed to remain stable.
+ * They may change in future versions, becoming incompatible with a different
+ * version of the library.
+ * These declarations should only be used with static linking.
+ * Never use them in association with dynamic linking!
+ ***************************************************************************** */
+
+/*
+ * These definitions are only present to allow static allocation
+ * of XXH states, on stack or in a struct, for example.
+ * Never **ever** access their members directly.
+ */
+
+/*!
+ * @internal
+ * @brief Structure for XXH32 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined. Otherwise it is
+ * an opaque type. This allows fields to safely be changed.
+ *
+ * Typedef'd to @ref XXH32_state_t.
+ * Do not access the members of this struct directly.
+ * @see XXH64_state_s, XXH3_state_s
+ */
+struct XXH32_state_s {
+   XXH32_hash_t total_len_32; /*!< Total length hashed, modulo 2^32 */
+   XXH32_hash_t large_len;    /*!< Whether the hash is >= 16 (handles @ref total_len_32 overflow) */
+   XXH32_hash_t v[4];         /*!< Accumulator lanes */
+   XXH32_hash_t mem32[4];     /*!< Internal buffer for partial reads. Treated as unsigned char[16]. */
+   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem32 */
+   XXH32_hash_t reserved;     /*!< Reserved field. Do not read nor write to it. */
+};   /* typedef'd to XXH32_state_t */
+
+
+#ifndef XXH_NO_LONG_LONG  /* defined when there is no 64-bit support */
+
+/*!
+ * @internal
+ * @brief Structure for XXH64 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined. Otherwise it is
+ * an opaque type. This allows fields to safely be changed.
+ *
+ * Typedef'd to @ref XXH64_state_t.
+ * Do not access the members of this struct directly.
+ * @see XXH32_state_s, XXH3_state_s
+ */
+struct XXH64_state_s {
+   XXH64_hash_t total_len;    /*!< Total length hashed. This is always 64-bit. */
+   XXH64_hash_t v[4];         /*!< Accumulator lanes */
+   XXH64_hash_t mem64[4];     /*!< Internal buffer for partial reads. Treated as unsigned char[32]. */
+   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem64 */
+   XXH32_hash_t reserved32;   /*!< Reserved field, needed for padding anyways*/
+   XXH64_hash_t reserved64;   /*!< Reserved field. Do not read or write to it. */
+};   /* typedef'd to XXH64_state_t */
+
+#ifndef XXH_NO_XXH3
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
+#  include <stdalign.h>
+#  define XXH_ALIGN(n)      alignas(n)
+#elif defined(__cplusplus) && (__cplusplus >= 201103L) /* >= C++11 */
+/* In C++ alignas() is a keyword */
+#  define XXH_ALIGN(n)      alignas(n)
+#elif defined(__GNUC__)
+#  define XXH_ALIGN(n)      __attribute__ ((aligned(n)))
+#elif defined(_MSC_VER)
+#  define XXH_ALIGN(n)      __declspec(align(n))
+#else
+#  define XXH_ALIGN(n)   /* disabled */
+#endif
+
+/* Old GCC versions only accept the attribute after the type in structures. */
+#if !(defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))   /* C11+ */ \
+    && ! (defined(__cplusplus) && (__cplusplus >= 201103L)) /* >= C++11 */ \
+    && defined(__GNUC__)
+#   define XXH_ALIGN_MEMBER(align, type) type XXH_ALIGN(align)
+#else
+#   define XXH_ALIGN_MEMBER(align, type) XXH_ALIGN(align) type
+#endif
+
+/*!
+ * @brief The size of the internal XXH3 buffer.
+ *
+ * This is the optimal update size for incremental hashing.
+ *
+ * @see XXH3_64b_update(), XXH3_128b_update().
+ */
+#define XXH3_INTERNALBUFFER_SIZE 256
+
+/*!
+ * @internal
+ * @brief Default size of the secret buffer (and @ref XXH3_kSecret).
+ *
+ * This is the size used in @ref XXH3_kSecret and the seeded functions.
+ *
+ * Not to be confused with @ref XXH3_SECRET_SIZE_MIN.
+ */
+#define XXH3_SECRET_DEFAULT_SIZE 192
+
+/*!
+ * @internal
+ * @brief Structure for XXH3 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined.
+ * Otherwise it is an opaque type.
+ * Never use this definition in combination with dynamic library.
+ * This allows fields to safely be changed in the future.
+ *
+ * @note ** This structure has a strict alignment requirement of 64 bytes!! **
+ * Do not allocate this with `malloc()` or `new`,
+ * it will not be sufficiently aligned.
+ * Use @ref XXH3_createState() and @ref XXH3_freeState(), or stack allocation.
+ *
+ * Typedef'd to @ref XXH3_state_t.
+ * Do never access the members of this struct directly.
+ *
+ * @see XXH3_INITSTATE() for stack initialization.
+ * @see XXH3_createState(), XXH3_freeState().
+ * @see XXH32_state_s, XXH64_state_s
+ */
+struct XXH3_state_s {
+   XXH_ALIGN_MEMBER(64, XXH64_hash_t acc[8]);
+       /*!< The 8 accumulators. See @ref XXH32_state_s::v and @ref XXH64_state_s::v */
+   XXH_ALIGN_MEMBER(64, unsigned char customSecret[XXH3_SECRET_DEFAULT_SIZE]);
+       /*!< Used to store a custom secret generated from a seed. */
+   XXH_ALIGN_MEMBER(64, unsigned char buffer[XXH3_INTERNALBUFFER_SIZE]);
+       /*!< The internal buffer. @see XXH32_state_s::mem32 */
+   XXH32_hash_t bufferedSize;
+       /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
+   XXH32_hash_t useSeed;
+       /*!< Reserved field. Needed for padding on 64-bit. */
+   size_t nbStripesSoFar;
+       /*!< Number or stripes processed. */
+   XXH64_hash_t totalLen;
+       /*!< Total length hashed. 64-bit even on 32-bit targets. */
+   size_t nbStripesPerBlock;
+       /*!< Number of stripes per block. */
+   size_t secretLimit;
+       /*!< Size of @ref customSecret or @ref extSecret */
+   XXH64_hash_t seed;
+       /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
+   XXH64_hash_t reserved64;
+       /*!< Reserved field. */
+   const unsigned char* extSecret;
+       /*!< Reference to an external secret for the _withSecret variants, NULL
+        *   for other variants. */
+   /* note: there may be some padding at the end due to alignment on 64 bytes */
+}; /* typedef'd to XXH3_state_t */
+
+#undef XXH_ALIGN_MEMBER
+
+/*!
+ * @brief Initializes a stack-allocated `XXH3_state_s`.
+ *
+ * When the @ref XXH3_state_t structure is merely emplaced on stack,
+ * it should be initialized with XXH3_INITSTATE() or a memset()
+ * in case its first reset uses XXH3_NNbits_reset_withSeed().
+ * This init can be omitted if the first reset uses default or _withSecret mode.
+ * This operation isn't necessary when the state is created with XXH3_createState().
+ * Note that this doesn't prepare the state for a streaming operation,
+ * it's still necessary to use XXH3_NNbits_reset*() afterwards.
+ */
+#define XXH3_INITSTATE(XXH3_state_ptr)                       \
+    do {                                                     \
+        XXH3_state_t* tmp_xxh3_state_ptr = (XXH3_state_ptr); \
+        tmp_xxh3_state_ptr->seed = 0;                        \
+        tmp_xxh3_state_ptr->extSecret = NULL;                \
+    } while(0)
+
+
+/*!
+ * simple alias to pre-selected XXH3_128bits variant
+ */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH128(XXH_NOESCAPE const void* data, size_t len, XXH64_hash_t seed);
+
+
+/* ===   Experimental API   === */
+/* Symbols defined below must be considered tied to a specific library version. */
+
+/*!
+ * XXH3_generateSecret():
+ *
+ * Derive a high-entropy secret from any user-defined content, named customSeed.
+ * The generated secret can be used in combination with `*_withSecret()` functions.
+ * The `_withSecret()` variants are useful to provide a higher level of protection
+ * than 64-bit seed, as it becomes much more difficult for an external actor to
+ * guess how to impact the calculation logic.
+ *
+ * The function accepts as input a custom seed of any length and any content,
+ * and derives from it a high-entropy secret of length @p secretSize into an
+ * already allocated buffer @p secretBuffer.
+ *
+ * The generated secret can then be used with any `*_withSecret()` variant.
+ * The functions @ref XXH3_128bits_withSecret(), @ref XXH3_64bits_withSecret(),
+ * @ref XXH3_128bits_reset_withSecret() and @ref XXH3_64bits_reset_withSecret()
+ * are part of this list. They all accept a `secret` parameter
+ * which must be large enough for implementation reasons (>= @ref XXH3_SECRET_SIZE_MIN)
+ * _and_ feature very high entropy (consist of random-looking bytes).
+ * These conditions can be a high bar to meet, so @ref XXH3_generateSecret() can
+ * be employed to ensure proper quality.
+ *
+ * @p customSeed can be anything. It can have any size, even small ones,
+ * and its content can be anything, even "poor entropy" sources such as a bunch
+ * of zeroes. The resulting `secret` will nonetheless provide all required qualities.
+ *
+ * @pre
+ *   - @p secretSize must be >= @ref XXH3_SECRET_SIZE_MIN
+ *   - When @p customSeedSize > 0, supplying NULL as customSeed is undefined behavior.
+ *
+ * Example code:
+ * @code{.c}
+ *    #include <stdio.h>
+ *    #include <stdlib.h>
+ *    #include <string.h>
+ *    #define XXH_STATIC_LINKING_ONLY // expose unstable API
+ *    #include "xxhash.h"
+ *    // Hashes argv[2] using the entropy from argv[1].
+ *    int main(int argc, char* argv[])
+ *    {
+ *        char secret[XXH3_SECRET_SIZE_MIN];
+ *        if (argv != 3) { return 1; }
+ *        XXH3_generateSecret(secret, sizeof(secret), argv[1], strlen(argv[1]));
+ *        XXH64_hash_t h = XXH3_64bits_withSecret(
+ *             argv[2], strlen(argv[2]),
+ *             secret, sizeof(secret)
+ *        );
+ *        printf("%016llx\n", (unsigned long long) h);
+ *    }
+ * @endcode
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_generateSecret(XXH_NOESCAPE void* secretBuffer, size_t secretSize, XXH_NOESCAPE const void* customSeed, size_t customSeedSize);
+
+/*!
+ * @brief Generate the same secret as the _withSeed() variants.
+ *
+ * The generated secret can be used in combination with
+ *`*_withSecret()` and `_withSecretandSeed()` variants.
+ *
+ * Example C++ `std::string` hash class:
+ * @code{.cpp}
+ *    #include <string>
+ *    #define XXH_STATIC_LINKING_ONLY // expose unstable API
+ *    #include "xxhash.h"
+ *    // Slow, seeds each time
+ *    class HashSlow {
+ *        XXH64_hash_t seed;
+ *    public:
+ *        HashSlow(XXH64_hash_t s) : seed{s} {}
+ *        size_t operator()(const std::string& x) const {
+ *            return size_t{XXH3_64bits_withSeed(x.c_str(), x.length(), seed)};
+ *        }
+ *    };
+ *    // Fast, caches the seeded secret for future uses.
+ *    class HashFast {
+ *        unsigned char secret[XXH3_SECRET_SIZE_MIN];
+ *    public:
+ *        HashFast(XXH64_hash_t s) {
+ *            XXH3_generateSecret_fromSeed(secret, seed);
+ *        }
+ *        size_t operator()(const std::string& x) const {
+ *            return size_t{
+ *                XXH3_64bits_withSecret(x.c_str(), x.length(), secret, sizeof(secret))
+ *            };
+ *        }
+ *    };
+ * @endcode
+ * @param secretBuffer A writable buffer of @ref XXH3_SECRET_SIZE_MIN bytes
+ * @param seed The seed to seed the state.
+ */
+XXH_PUBLIC_API void XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed);
+
+/*!
+ * These variants generate hash values using either
+ * @p seed for "short" keys (< XXH3_MIDSIZE_MAX = 240 bytes)
+ * or @p secret for "large" keys (>= XXH3_MIDSIZE_MAX).
+ *
+ * This generally benefits speed, compared to `_withSeed()` or `_withSecret()`.
+ * `_withSeed()` has to generate the secret on the fly for "large" keys.
+ * It's fast, but can be perceptible for "not so large" keys (< 1 KB).
+ * `_withSecret()` has to generate the masks on the fly for "small" keys,
+ * which requires more instructions than _withSeed() variants.
+ * Therefore, _withSecretandSeed variant combines the best of both worlds.
+ *
+ * When @p secret has been generated by XXH3_generateSecret_fromSeed(),
+ * this variant produces *exactly* the same results as `_withSeed()` variant,
+ * hence offering only a pure speed benefit on "large" input,
+ * by skipping the need to regenerate the secret for every large input.
+ *
+ * Another usage scenario is to hash the secret to a 64-bit hash value,
+ * for example with XXH3_64bits(), which then becomes the seed,
+ * and then employ both the seed and the secret in _withSecretandSeed().
+ * On top of speed, an added benefit is that each bit in the secret
+ * has a 50% chance to swap each bit in the output, via its impact to the seed.
+ *
+ * This is not guaranteed when using the secret directly in "small data" scenarios,
+ * because only portions of the secret are employed for small data.
+ */
+XXH_PUBLIC_API XXH_PUREF XXH64_hash_t
+XXH3_64bits_withSecretandSeed(XXH_NOESCAPE const void* data, size_t len,
+                              XXH_NOESCAPE const void* secret, size_t secretSize,
+                              XXH64_hash_t seed);
+/*! @copydoc XXH3_64bits_withSecretandSeed() */
+XXH_PUBLIC_API XXH_PUREF XXH128_hash_t
+XXH3_128bits_withSecretandSeed(XXH_NOESCAPE const void* input, size_t length,
+                               XXH_NOESCAPE const void* secret, size_t secretSize,
+                               XXH64_hash_t seed64);
+#ifndef XXH_NO_STREAM
+/*! @copydoc XXH3_64bits_withSecretandSeed() */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
+                                    XXH_NOESCAPE const void* secret, size_t secretSize,
+                                    XXH64_hash_t seed64);
+/*! @copydoc XXH3_64bits_withSecretandSeed() */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
+                                     XXH_NOESCAPE const void* secret, size_t secretSize,
+                                     XXH64_hash_t seed64);
+#endif /* !XXH_NO_STREAM */
+
+#endif  /* !XXH_NO_XXH3 */
+#endif  /* XXH_NO_LONG_LONG */
+#if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
+#  define XXH_IMPLEMENTATION
+#endif
+
+#endif  /* defined(XXH_STATIC_LINKING_ONLY) && !defined(XXHASH_H_STATIC_13879238742) */
+
+
+/* ======================================================================== */
+/* ======================================================================== */
+/* ======================================================================== */
+
+
+/*-**********************************************************************
+ * xxHash implementation
+ *-**********************************************************************
+ * xxHash's implementation used to be hosted inside xxhash.c.
+ *
+ * However, inlining requires implementation to be visible to the compiler,
+ * hence be included alongside the header.
+ * Previously, implementation was hosted inside xxhash.c,
+ * which was then #included when inlining was activated.
+ * This construction created issues with a few build and install systems,
+ * as it required xxhash.c to be stored in /include directory.
+ *
+ * xxHash implementation is now directly integrated within xxhash.h.
+ * As a consequence, xxhash.c is no longer needed in /include.
+ *
+ * xxhash.c is still available and is still useful.
+ * In a "normal" setup, when xxhash is not inlined,
+ * xxhash.h only exposes the prototypes and public symbols,
+ * while xxhash.c can be built into an object file xxhash.o
+ * which can then be linked into the final binary.
+ ************************************************************************/
+
+#if ( defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API) \
+   || defined(XXH_IMPLEMENTATION) ) && !defined(XXH_IMPLEM_13a8737387)
+#  define XXH_IMPLEM_13a8737387
+
+/* *************************************
+*  Tuning parameters
+***************************************/
+
+/*!
+ * @defgroup tuning Tuning parameters
+ * @{
+ *
+ * Various macros to control xxHash's behavior.
+ */
+#ifdef XXH_DOXYGEN
+/*!
+ * @brief Define this to disable 64-bit code.
+ *
+ * Useful if only using the @ref XXH32_family and you have a strict C90 compiler.
+ */
+#  define XXH_NO_LONG_LONG
+#  undef XXH_NO_LONG_LONG /* don't actually */
+/*!
+ * @brief Controls how unaligned memory is accessed.
+ *
+ * By default, access to unaligned memory is controlled by `memcpy()`, which is
+ * safe and portable.
+ *
+ * Unfortunately, on some target/compiler combinations, the generated assembly
+ * is sub-optimal.
+ *
+ * The below switch allow selection of a different access method
+ * in the search for improved performance.
+ *
+ * @par Possible options:
+ *
+ *  - `XXH_FORCE_MEMORY_ACCESS=0` (default): `memcpy`
+ *   @par
+ *     Use `memcpy()`. Safe and portable. Note that most modern compilers will
+ *     eliminate the function call and treat it as an unaligned access.
+ *
+ *  - `XXH_FORCE_MEMORY_ACCESS=1`: `__attribute__((aligned(1)))`
+ *   @par
+ *     Depends on compiler extensions and is therefore not portable.
+ *     This method is safe _if_ your compiler supports it,
+ *     and *generally* as fast or faster than `memcpy`.
+ *
+ *  - `XXH_FORCE_MEMORY_ACCESS=2`: Direct cast
+ *  @par
+ *     Casts directly and dereferences. This method doesn't depend on the
+ *     compiler, but it violates the C standard as it directly dereferences an
+ *     unaligned pointer. It can generate buggy code on targets which do not
+ *     support unaligned memory accesses, but in some circumstances, it's the
+ *     only known way to get the most performance.
+ *
+ *  - `XXH_FORCE_MEMORY_ACCESS=3`: Byteshift
+ *  @par
+ *     Also portable. This can generate the best code on old compilers which don't
+ *     inline small `memcpy()` calls, and it might also be faster on big-endian
+ *     systems which lack a native byteswap instruction. However, some compilers
+ *     will emit literal byteshifts even if the target supports unaligned access.
+ *
+ *
+ * @warning
+ *   Methods 1 and 2 rely on implementation-defined behavior. Use these with
+ *   care, as what works on one compiler/platform/optimization level may cause
+ *   another to read garbage data or even crash.
+ *
+ * See https://fastcompression.blogspot.com/2015/08/accessing-unaligned-memory.html for details.
+ *
+ * Prefer these methods in priority order (0 > 3 > 1 > 2)
+ */
+#  define XXH_FORCE_MEMORY_ACCESS 0
+
+/*!
+ * @def XXH_SIZE_OPT
+ * @brief Controls how much xxHash optimizes for size.
+ *
+ * xxHash, when compiled, tends to result in a rather large binary size. This
+ * is mostly due to heavy usage to forced inlining and constant folding of the
+ * @ref XXH3_family to increase performance.
+ *
+ * However, some developers prefer size over speed. This option can
+ * significantly reduce the size of the generated code. When using the `-Os`
+ * or `-Oz` options on GCC or Clang, this is defined to 1 by default,
+ * otherwise it is defined to 0.
+ *
+ * Most of these size optimizations can be controlled manually.
+ *
+ * This is a number from 0-2.
+ *  - `XXH_SIZE_OPT` == 0: Default. xxHash makes no size optimizations. Speed
+ *    comes first.
+ *  - `XXH_SIZE_OPT` == 1: Default for `-Os` and `-Oz`. xxHash is more
+ *    conservative and disables hacks that increase code size. It implies the
+ *    options @ref XXH_NO_INLINE_HINTS == 1, @ref XXH_FORCE_ALIGN_CHECK == 0,
+ *    and @ref XXH3_NEON_LANES == 8 if they are not already defined.
+ *  - `XXH_SIZE_OPT` == 2: xxHash tries to make itself as small as possible.
+ *    Performance may cry. For example, the single shot functions just use the
+ *    streaming API.
+ */
+#  define XXH_SIZE_OPT 0
+
+/*!
+ * @def XXH_FORCE_ALIGN_CHECK
+ * @brief If defined to non-zero, adds a special path for aligned inputs (XXH32()
+ * and XXH64() only).
+ *
+ * This is an important performance trick for architectures without decent
+ * unaligned memory access performance.
+ *
+ * It checks for input alignment, and when conditions are met, uses a "fast
+ * path" employing direct 32-bit/64-bit reads, resulting in _dramatically
+ * faster_ read speed.
+ *
+ * The check costs one initial branch per hash, which is generally negligible,
+ * but not zero.
+ *
+ * Moreover, it's not useful to generate an additional code path if memory
+ * access uses the same instruction for both aligned and unaligned
+ * addresses (e.g. x86 and aarch64).
+ *
+ * In these cases, the alignment check can be removed by setting this macro to 0.
+ * Then the code will always use unaligned memory access.
+ * Align check is automatically disabled on x86, x64, ARM64, and some ARM chips
+ * which are platforms known to offer good unaligned memory accesses performance.
+ *
+ * It is also disabled by default when @ref XXH_SIZE_OPT >= 1.
+ *
+ * This option does not affect XXH3 (only XXH32 and XXH64).
+ */
+#  define XXH_FORCE_ALIGN_CHECK 0
+
+/*!
+ * @def XXH_NO_INLINE_HINTS
+ * @brief When non-zero, sets all functions to `static`.
+ *
+ * By default, xxHash tries to force the compiler to inline almost all internal
+ * functions.
+ *
+ * This can usually improve performance due to reduced jumping and improved
+ * constant folding, but significantly increases the size of the binary which
+ * might not be favorable.
+ *
+ * Additionally, sometimes the forced inlining can be detrimental to performance,
+ * depending on the architecture.
+ *
+ * XXH_NO_INLINE_HINTS marks all internal functions as static, giving the
+ * compiler full control on whether to inline or not.
+ *
+ * When not optimizing (-O0), using `-fno-inline` with GCC or Clang, or if
+ * @ref XXH_SIZE_OPT >= 1, this will automatically be defined.
+ */
+#  define XXH_NO_INLINE_HINTS 0
+
+/*!
+ * @def XXH3_INLINE_SECRET
+ * @brief Determines whether to inline the XXH3 withSecret code.
+ *
+ * When the secret size is known, the compiler can improve the performance
+ * of XXH3_64bits_withSecret() and XXH3_128bits_withSecret().
+ *
+ * However, if the secret size is not known, it doesn't have any benefit. This
+ * happens when xxHash is compiled into a global symbol. Therefore, if
+ * @ref XXH_INLINE_ALL is *not* defined, this will be defined to 0.
+ *
+ * Additionally, this defaults to 0 on GCC 12+, which has an issue with function pointers
+ * that are *sometimes* force inline on -Og, and it is impossible to automatically
+ * detect this optimization level.
+ */
+#  define XXH3_INLINE_SECRET 0
+
+/*!
+ * @def XXH32_ENDJMP
+ * @brief Whether to use a jump for `XXH32_finalize`.
+ *
+ * For performance, `XXH32_finalize` uses multiple branches in the finalizer.
+ * This is generally preferable for performance,
+ * but depending on exact architecture, a jmp may be preferable.
+ *
+ * This setting is only possibly making a difference for very small inputs.
+ */
+#  define XXH32_ENDJMP 0
+
+/*!
+ * @internal
+ * @brief Redefines old internal names.
+ *
+ * For compatibility with code that uses xxHash's internals before the names
+ * were changed to improve namespacing. There is no other reason to use this.
+ */
+#  define XXH_OLD_NAMES
+#  undef XXH_OLD_NAMES /* don't actually use, it is ugly. */
+
+/*!
+ * @def XXH_NO_STREAM
+ * @brief Disables the streaming API.
+ *
+ * When xxHash is not inlined and the streaming functions are not used, disabling
+ * the streaming functions can improve code size significantly, especially with
+ * the @ref XXH3_family which tends to make constant folded copies of itself.
+ */
+#  define XXH_NO_STREAM
+#  undef XXH_NO_STREAM /* don't actually */
+#endif /* XXH_DOXYGEN */
+/*!
+ * @}
+ */
+
+#ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
+   /* prefer __packed__ structures (method 1) for GCC
+    * < ARMv7 with unaligned access (e.g. Raspbian armhf) still uses byte shifting, so we use memcpy
+    * which for some reason does unaligned loads. */
+#  if defined(__GNUC__) && !(defined(__ARM_ARCH) && __ARM_ARCH < 7 && defined(__ARM_FEATURE_UNALIGNED))
+#    define XXH_FORCE_MEMORY_ACCESS 1
+#  endif
+#endif
+
+#ifndef XXH_SIZE_OPT
+   /* default to 1 for -Os or -Oz */
+#  if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE_SIZE__)
+#    define XXH_SIZE_OPT 1
+#  else
+#    define XXH_SIZE_OPT 0
+#  endif
+#endif
+
+#ifndef XXH_FORCE_ALIGN_CHECK  /* can be defined externally */
+   /* don't check on sizeopt, x86, aarch64, or arm when unaligned access is available */
+#  if XXH_SIZE_OPT >= 1 || \
+      defined(__i386)  || defined(__x86_64__) || defined(__aarch64__) || defined(__ARM_FEATURE_UNALIGNED) \
+   || defined(_M_IX86) || defined(_M_X64)     || defined(_M_ARM64)    || defined(_M_ARM) /* visual */
+#    define XXH_FORCE_ALIGN_CHECK 0
+#  else
+#    define XXH_FORCE_ALIGN_CHECK 1
+#  endif
+#endif
+
+#ifndef XXH_NO_INLINE_HINTS
+#  if XXH_SIZE_OPT >= 1 || defined(__NO_INLINE__)  /* -O0, -fno-inline */
+#    define XXH_NO_INLINE_HINTS 1
+#  else
+#    define XXH_NO_INLINE_HINTS 0
+#  endif
+#endif
+
+#ifndef XXH3_INLINE_SECRET
+#  if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12) \
+     || !defined(XXH_INLINE_ALL)
+#    define XXH3_INLINE_SECRET 0
+#  else
+#    define XXH3_INLINE_SECRET 1
+#  endif
+#endif
+
+#ifndef XXH32_ENDJMP
+/* generally preferable for performance */
+#  define XXH32_ENDJMP 0
+#endif
+
+/*!
+ * @defgroup impl Implementation
+ * @{
+ */
+
+
+/* *************************************
+*  Includes & Memory related functions
+***************************************/
+#if defined(XXH_NO_STREAM)
+/* nothing */
+#elif defined(XXH_NO_STDLIB)
+
+/* When requesting to disable any mention of stdlib,
+ * the library loses the ability to invoked malloc / free.
+ * In practice, it means that functions like `XXH*_createState()`
+ * will always fail, and return NULL.
+ * This flag is useful in situations where
+ * xxhash.h is integrated into some kernel, embedded or limited environment
+ * without access to dynamic allocation.
+ */
+
+static XXH_CONSTF void* XXH_malloc(size_t s) { (void)s; return NULL; }
+static void XXH_free(void* p) { (void)p; }
+
+#else
+
+/*
+ * Modify the local functions below should you wish to use
+ * different memory routines for malloc() and free()
+ */
+#include <stdlib.h>
+
+/*!
+ * @internal
+ * @brief Modify this function to use a different routine than malloc().
+ */
+static XXH_MALLOCF void* XXH_malloc(size_t s) { return malloc(s); }
+
+/*!
+ * @internal
+ * @brief Modify this function to use a different routine than free().
+ */
+static void XXH_free(void* p) { free(p); }
+
+#endif  /* XXH_NO_STDLIB */
+
+#include <string.h>
+
+/*!
+ * @internal
+ * @brief Modify this function to use a different routine than memcpy().
+ */
+static void* XXH_memcpy(void* dest, const void* src, size_t size)
+{
+    return memcpy(dest,src,size);
+}
+
+#include <limits.h>   /* ULLONG_MAX */
+
+
+/* *************************************
+*  Compiler Specific Options
+***************************************/
+#ifdef _MSC_VER /* Visual Studio warning fix */
+#  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
+#endif
+
+#if XXH_NO_INLINE_HINTS  /* disable inlining hints */
+#  if defined(__GNUC__) || defined(__clang__)
+#    define XXH_FORCE_INLINE static __attribute__((unused))
+#  else
+#    define XXH_FORCE_INLINE static
+#  endif
+#  define XXH_NO_INLINE static
+/* enable inlining hints */
+#elif defined(__GNUC__) || defined(__clang__)
+#  define XXH_FORCE_INLINE static __inline__ __attribute__((always_inline, unused))
+#  define XXH_NO_INLINE static __attribute__((noinline))
+#elif defined(_MSC_VER)  /* Visual Studio */
+#  define XXH_FORCE_INLINE static __forceinline
+#  define XXH_NO_INLINE static __declspec(noinline)
+#elif defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))   /* C99 */
+#  define XXH_FORCE_INLINE static inline
+#  define XXH_NO_INLINE static
+#else
+#  define XXH_FORCE_INLINE static
+#  define XXH_NO_INLINE static
+#endif
+
+#if XXH3_INLINE_SECRET
+#  define XXH3_WITH_SECRET_INLINE XXH_FORCE_INLINE
+#else
+#  define XXH3_WITH_SECRET_INLINE XXH_NO_INLINE
+#endif
+
+
+/* *************************************
+*  Debug
+***************************************/
+/*!
+ * @ingroup tuning
+ * @def XXH_DEBUGLEVEL
+ * @brief Sets the debugging level.
+ *
+ * XXH_DEBUGLEVEL is expected to be defined externally, typically via the
+ * compiler's command line options. The value must be a number.
+ */
+#ifndef XXH_DEBUGLEVEL
+#  ifdef DEBUGLEVEL /* backwards compat */
+#    define XXH_DEBUGLEVEL DEBUGLEVEL
+#  else
+#    define XXH_DEBUGLEVEL 0
+#  endif
+#endif
+
+#if (XXH_DEBUGLEVEL>=1)
+#  include <assert.h>   /* note: can still be disabled with NDEBUG */
+#  define XXH_ASSERT(c)   assert(c)
+#else
+#  if defined(__INTEL_COMPILER)
+#    define XXH_ASSERT(c)   XXH_ASSUME((unsigned char) (c))
+#  else
+#    define XXH_ASSERT(c)   XXH_ASSUME(c)
+#  endif
+#endif
+
+/* note: use after variable declarations */
+#ifndef XXH_STATIC_ASSERT
+#  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { _Static_assert((c),m); } while(0)
+#  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
+#  else
+#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { struct xxh_sa { char x[(c) ? 1 : -1]; }; } while(0)
+#  endif
+#  define XXH_STATIC_ASSERT(c) XXH_STATIC_ASSERT_WITH_MESSAGE((c),#c)
+#endif
+
+/*!
+ * @internal
+ * @def XXH_COMPILER_GUARD(var)
+ * @brief Used to prevent unwanted optimizations for @p var.
+ *
+ * It uses an empty GCC inline assembly statement with a register constraint
+ * which forces @p var into a general purpose register (eg eax, ebx, ecx
+ * on x86) and marks it as modified.
+ *
+ * This is used in a few places to avoid unwanted autovectorization (e.g.
+ * XXH32_round()). All vectorization we want is explicit via intrinsics,
+ * and _usually_ isn't wanted elsewhere.
+ *
+ * We also use it to prevent unwanted constant folding for AArch64 in
+ * XXH3_initCustomSecret_scalar().
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#  define XXH_COMPILER_GUARD(var) __asm__("" : "+r" (var))
+#else
+#  define XXH_COMPILER_GUARD(var) ((void)0)
+#endif
+
+/* Specifically for NEON vectors which use the "w" constraint, on
+ * Clang. */
+#if defined(__clang__) && defined(__ARM_ARCH) && !defined(__wasm__)
+#  define XXH_COMPILER_GUARD_CLANG_NEON(var) __asm__("" : "+w" (var))
+#else
+#  define XXH_COMPILER_GUARD_CLANG_NEON(var) ((void)0)
+#endif
+
+/* *************************************
+*  Basic Types
+***************************************/
+#if !defined (__VMS) \
+ && (defined (__cplusplus) \
+ || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+# include <stdint.h>
+  typedef uint8_t xxh_u8;
+#else
+  typedef unsigned char xxh_u8;
+#endif
+typedef XXH32_hash_t xxh_u32;
+
+#ifdef XXH_OLD_NAMES
+#  warning "XXH_OLD_NAMES is planned to be removed starting v0.9. If the program depends on it, consider moving away from it by employing newer type names directly"
+#  define BYTE xxh_u8
+#  define U8   xxh_u8
+#  define U32  xxh_u32
+#endif
+
+/* ***   Memory access   *** */
+
+/*!
+ * @internal
+ * @fn xxh_u32 XXH_read32(const void* ptr)
+ * @brief Reads an unaligned 32-bit integer from @p ptr in native endianness.
+ *
+ * Affected by @ref XXH_FORCE_MEMORY_ACCESS.
+ *
+ * @param ptr The pointer to read from.
+ * @return The 32-bit native endian integer from the bytes at @p ptr.
+ */
+
+/*!
+ * @internal
+ * @fn xxh_u32 XXH_readLE32(const void* ptr)
+ * @brief Reads an unaligned 32-bit little endian integer from @p ptr.
+ *
+ * Affected by @ref XXH_FORCE_MEMORY_ACCESS.
+ *
+ * @param ptr The pointer to read from.
+ * @return The 32-bit little endian integer from the bytes at @p ptr.
+ */
+
+/*!
+ * @internal
+ * @fn xxh_u32 XXH_readBE32(const void* ptr)
+ * @brief Reads an unaligned 32-bit big endian integer from @p ptr.
+ *
+ * Affected by @ref XXH_FORCE_MEMORY_ACCESS.
+ *
+ * @param ptr The pointer to read from.
+ * @return The 32-bit big endian integer from the bytes at @p ptr.
+ */
+
+/*!
+ * @internal
+ * @fn xxh_u32 XXH_readLE32_align(const void* ptr, XXH_alignment align)
+ * @brief Like @ref XXH_readLE32(), but has an option for aligned reads.
+ *
+ * Affected by @ref XXH_FORCE_MEMORY_ACCESS.
+ * Note that when @ref XXH_FORCE_ALIGN_CHECK == 0, the @p align parameter is
+ * always @ref XXH_alignment::XXH_unaligned.
+ *
+ * @param ptr The pointer to read from.
+ * @param align Whether @p ptr is aligned.
+ * @pre
+ *   If @p align == @ref XXH_alignment::XXH_aligned, @p ptr must be 4 byte
+ *   aligned.
+ * @return The 32-bit little endian integer from the bytes at @p ptr.
+ */
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==3))
+/*
+ * Manual byteshift. Best for old compilers which don't inline memcpy.
+ * We actually directly use XXH_readLE32 and XXH_readBE32.
+ */
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/*
+ * Force direct memory access. Only works on CPU which support unaligned memory
+ * access in hardware.
+ */
+static xxh_u32 XXH_read32(const void* memPtr) { return *(const xxh_u32*) memPtr; }
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/*
+ * __attribute__((aligned(1))) is supported by gcc and clang. Originally the
+ * documentation claimed that it only increased the alignment, but actually it
+ * can decrease it on gcc, clang, and icc:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69502,
+ * https://gcc.godbolt.org/z/xYez1j67Y.
+ */
+#ifdef XXH_OLD_NAMES
+typedef union { xxh_u32 u32; } __attribute__((packed)) unalign;
+#endif
+static xxh_u32 XXH_read32(const void* ptr)
+{
+    typedef __attribute__((aligned(1))) xxh_u32 xxh_unalign32;
+    return *((const xxh_unalign32*)ptr);
+}
+
+#else
+
+/*
+ * Portable and safe solution. Generally efficient.
+ * see: https://fastcompression.blogspot.com/2015/08/accessing-unaligned-memory.html
+ */
+static xxh_u32 XXH_read32(const void* memPtr)
+{
+    xxh_u32 val;
+    XXH_memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+
+/* ***   Endianness   *** */
+
+/*!
+ * @ingroup tuning
+ * @def XXH_CPU_LITTLE_ENDIAN
+ * @brief Whether the target is little endian.
+ *
+ * Defined to 1 if the target is little endian, or 0 if it is big endian.
+ * It can be defined externally, for example on the compiler command line.
+ *
+ * If it is not defined,
+ * a runtime check (which is usually constant folded) is used instead.
+ *
+ * @note
+ *   This is not necessarily defined to an integer constant.
+ *
+ * @see XXH_isLittleEndian() for the runtime check.
+ */
+#ifndef XXH_CPU_LITTLE_ENDIAN
+/*
+ * Try to detect endianness automatically, to avoid the nonstandard behavior
+ * in `XXH_isLittleEndian()`
+ */
+#  if defined(_WIN32) /* Windows is always little endian */ \
+     || defined(__LITTLE_ENDIAN__) \
+     || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#    define XXH_CPU_LITTLE_ENDIAN 1
+#  elif defined(__BIG_ENDIAN__) \
+     || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#    define XXH_CPU_LITTLE_ENDIAN 0
+#  else
+/*!
+ * @internal
+ * @brief Runtime check for @ref XXH_CPU_LITTLE_ENDIAN.
+ *
+ * Most compilers will constant fold this.
+ */
+static int XXH_isLittleEndian(void)
+{
+    /*
+     * Portable and well-defined behavior.
+     * Don't use static: it is detrimental to performance.
+     */
+    const union { xxh_u32 u; xxh_u8 c[4]; } one = { 1 };
+    return one.c[0];
+}
+#   define XXH_CPU_LITTLE_ENDIAN   XXH_isLittleEndian()
+#  endif
+#endif
+
+
+
+
+/* ****************************************
+*  Compiler-specific Functions and Macros
+******************************************/
+#define XXH_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+
+#ifdef __has_builtin
+#  define XXH_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#  define XXH_HAS_BUILTIN(x) 0
+#endif
+
+
+
+/*
+ * C23 and future versions have standard "unreachable()".
+ * Once it has been implemented reliably we can add it as an
+ * additional case:
+ *
+ * ```
+ * #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= XXH_C23_VN)
+ * #  include <stddef.h>
+ * #  ifdef unreachable
+ * #    define XXH_UNREACHABLE() unreachable()
+ * #  endif
+ * #endif
+ * ```
+ *
+ * Note C++23 also has std::unreachable() which can be detected
+ * as follows:
+ * ```
+ * #if defined(__cpp_lib_unreachable) && (__cpp_lib_unreachable >= 202202L)
+ * #  include <utility>
+ * #  define XXH_UNREACHABLE() std::unreachable()
+ * #endif
+ * ```
+ * NB: `__cpp_lib_unreachable` is defined in the `<version>` header.
+ * We don't use that as including `<utility>` in `extern "C"` blocks
+ * doesn't work on GCC12
+ */
+
+#if XXH_HAS_BUILTIN(__builtin_unreachable)
+#  define XXH_UNREACHABLE() __builtin_unreachable()
+
+#elif defined(_MSC_VER)
+#  define XXH_UNREACHABLE() __assume(0)
+
+#else
+#  define XXH_UNREACHABLE()
+#endif
+
+#if XXH_HAS_BUILTIN(__builtin_assume)
+#  define XXH_ASSUME(c) __builtin_assume(c)
+#else
+#  define XXH_ASSUME(c) if (!(c)) { XXH_UNREACHABLE(); }
+#endif
+
+/*!
+ * @internal
+ * @def XXH_rotl32(x,r)
+ * @brief 32-bit rotate left.
+ *
+ * @param x The 32-bit integer to be rotated.
+ * @param r The number of bits to rotate.
+ * @pre
+ *   @p r > 0 && @p r < 32
+ * @note
+ *   @p x and @p r may be evaluated multiple times.
+ * @return The rotated result.
+ */
+#if !defined(NO_CLANG_BUILTIN) && XXH_HAS_BUILTIN(__builtin_rotateleft32) \
+                               && XXH_HAS_BUILTIN(__builtin_rotateleft64)
+#  define XXH_rotl32 __builtin_rotateleft32
+#  define XXH_rotl64 __builtin_rotateleft64
+/* Note: although _rotl exists for minGW (GCC under windows), performance seems poor */
+#elif defined(_MSC_VER)
+#  define XXH_rotl32(x,r) _rotl(x,r)
+#  define XXH_rotl64(x,r) _rotl64(x,r)
+#else
+#  define XXH_rotl32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
+#  define XXH_rotl64(x,r) (((x) << (r)) | ((x) >> (64 - (r))))
+#endif
+
+/*!
+ * @internal
+ * @fn xxh_u32 XXH_swap32(xxh_u32 x)
+ * @brief A 32-bit byteswap.
+ *
+ * @param x The 32-bit integer to byteswap.
+ * @return @p x, byteswapped.
+ */
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap32 _byteswap_ulong
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap32 __builtin_bswap32
+#else
+static xxh_u32 XXH_swap32 (xxh_u32 x)
+{
+    return  ((x << 24) & 0xff000000 ) |
+            ((x <<  8) & 0x00ff0000 ) |
+            ((x >>  8) & 0x0000ff00 ) |
+            ((x >> 24) & 0x000000ff );
+}
+#endif
+
+
+/* ***************************
+*  Memory reads
+*****************************/
+
+/*!
+ * @internal
+ * @brief Enum to indicate whether a pointer is aligned.
+ */
+typedef enum {
+    XXH_aligned,  /*!< Aligned */
+    XXH_unaligned /*!< Possibly unaligned */
+} XXH_alignment;
+
+/*
+ * XXH_FORCE_MEMORY_ACCESS==3 is an endian-independent byteshift load.
+ *
+ * This is ideal for older compilers which don't inline memcpy.
+ */
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==3))
+
+XXH_FORCE_INLINE xxh_u32 XXH_readLE32(const void* memPtr)
+{
+    const xxh_u8* bytePtr = (const xxh_u8 *)memPtr;
+    return bytePtr[0]
+         | ((xxh_u32)bytePtr[1] << 8)
+         | ((xxh_u32)bytePtr[2] << 16)
+         | ((xxh_u32)bytePtr[3] << 24);
+}
+
+XXH_FORCE_INLINE xxh_u32 XXH_readBE32(const void* memPtr)
+{
+    const xxh_u8* bytePtr = (const xxh_u8 *)memPtr;
+    return bytePtr[3]
+         | ((xxh_u32)bytePtr[2] << 8)
+         | ((xxh_u32)bytePtr[1] << 16)
+         | ((xxh_u32)bytePtr[0] << 24);
+}
+
+#else
+XXH_FORCE_INLINE xxh_u32 XXH_readLE32(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+}
+
+static xxh_u32 XXH_readBE32(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+#endif
+
+XXH_FORCE_INLINE xxh_u32
+XXH_readLE32_align(const void* ptr, XXH_alignment align)
+{
+    if (align==XXH_unaligned) {
+        return XXH_readLE32(ptr);
+    } else {
+        return XXH_CPU_LITTLE_ENDIAN ? *(const xxh_u32*)ptr : XXH_swap32(*(const xxh_u32*)ptr);
+    }
+}
+
+
+/* *************************************
+*  Misc
+***************************************/
+/*! @ingroup public */
+XXH_PUBLIC_API unsigned XXH_versionNumber (void) { return XXH_VERSION_NUMBER; }
+
+
+/* *******************************************************************
+*  32-bit hash functions
+*********************************************************************/
+/*!
+ * @}
+ * @defgroup XXH32_impl XXH32 implementation
+ * @ingroup impl
+ *
+ * Details on the XXH32 implementation.
+ * @{
+ */
+ /* #define instead of static const, to be used as initializers */
+#define XXH_PRIME32_1  0x9E3779B1U  /*!< 0b10011110001101110111100110110001 */
+#define XXH_PRIME32_2  0x85EBCA77U  /*!< 0b10000101111010111100101001110111 */
+#define XXH_PRIME32_3  0xC2B2AE3DU  /*!< 0b11000010101100101010111000111101 */
+#define XXH_PRIME32_4  0x27D4EB2FU  /*!< 0b00100111110101001110101100101111 */
+#define XXH_PRIME32_5  0x165667B1U  /*!< 0b00010110010101100110011110110001 */
+
+#ifdef XXH_OLD_NAMES
+#  define PRIME32_1 XXH_PRIME32_1
+#  define PRIME32_2 XXH_PRIME32_2
+#  define PRIME32_3 XXH_PRIME32_3
+#  define PRIME32_4 XXH_PRIME32_4
+#  define PRIME32_5 XXH_PRIME32_5
+#endif
+
+/*!
+ * @internal
+ * @brief Normal stripe processing routine.
+ *
+ * This shuffles the bits so that any bit from @p input impacts several bits in
+ * @p acc.
+ *
+ * @param acc The accumulator lane.
+ * @param input The stripe of input to mix.
+ * @return The mixed accumulator lane.
+ */
+static xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input)
+{
+    acc += input * XXH_PRIME32_2;
+    acc  = XXH_rotl32(acc, 13);
+    acc *= XXH_PRIME32_1;
+#if (defined(__SSE4_1__) || defined(__aarch64__) || defined(__wasm_simd128__)) && !defined(XXH_ENABLE_AUTOVECTORIZE)
+    /*
+     * UGLY HACK:
+     * A compiler fence is the only thing that prevents GCC and Clang from
+     * autovectorizing the XXH32 loop (pragmas and attributes don't work for some
+     * reason) without globally disabling SSE4.1.
+     *
+     * The reason we want to avoid vectorization is because despite working on
+     * 4 integers at a time, there are multiple factors slowing XXH32 down on
+     * SSE4:
+     * - There's a ridiculous amount of lag from pmulld (10 cycles of latency on
+     *   newer chips!) making it slightly slower to multiply four integers at
+     *   once compared to four integers independently. Even when pmulld was
+     *   fastest, Sandy/Ivy Bridge, it is still not worth it to go into SSE
+     *   just to multiply unless doing a long operation.
+     *
+     * - Four instructions are required to rotate,
+     *      movqda tmp,  v // not required with VEX encoding
+     *      pslld  tmp, 13 // tmp <<= 13
+     *      psrld  v,   19 // x >>= 19
+     *      por    v,  tmp // x |= tmp
+     *   compared to one for scalar:
+     *      roll   v, 13    // reliably fast across the board
+     *      shldl  v, v, 13 // Sandy Bridge and later prefer this for some reason
+     *
+     * - Instruction level parallelism is actually more beneficial here because
+     *   the SIMD actually serializes this operation: While v1 is rotating, v2
+     *   can load data, while v3 can multiply. SSE forces them to operate
+     *   together.
+     *
+     * This is also enabled on AArch64, as Clang is *very aggressive* in vectorizing
+     * the loop. NEON is only faster on the A53, and with the newer cores, it is less
+     * than half the speed.
+     *
+     * Additionally, this is used on WASM SIMD128 because it JITs to the same
+     * SIMD instructions and has the same issue.
+     */
+    XXH_COMPILER_GUARD(acc);
+#endif
+    return acc;
+}
+
+/*!
+ * @internal
+ * @brief Mixes all bits to finalize the hash.
+ *
+ * The final mix ensures that all input bits have a chance to impact any bit in
+ * the output digest, resulting in an unbiased distribution.
+ *
+ * @param hash The hash to avalanche.
+ * @return The avalanched hash.
+ */
+static xxh_u32 XXH32_avalanche(xxh_u32 hash)
+{
+    hash ^= hash >> 15;
+    hash *= XXH_PRIME32_2;
+    hash ^= hash >> 13;
+    hash *= XXH_PRIME32_3;
+    hash ^= hash >> 16;
+    return hash;
+}
+
+#define XXH_get32bits(p) XXH_readLE32_align(p, align)
+
+/*!
+ * @internal
+ * @brief Processes the last 0-15 bytes of @p ptr.
+ *
+ * There may be up to 15 bytes remaining to consume from the input.
+ * This final stage will digest them to ensure that all input bytes are present
+ * in the final mix.
+ *
+ * @param hash The hash to finalize.
+ * @param ptr The pointer to the remaining input.
+ * @param len The remaining length, modulo 16.
+ * @param align Whether @p ptr is aligned.
+ * @return The finalized hash.
+ * @see XXH64_finalize().
+ */
+static XXH_PUREF xxh_u32
+XXH32_finalize(xxh_u32 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
+{
+#define XXH_PROCESS1 do {                             \
+    hash += (*ptr++) * XXH_PRIME32_5;                 \
+    hash = XXH_rotl32(hash, 11) * XXH_PRIME32_1;      \
+} while (0)
+
+#define XXH_PROCESS4 do {                             \
+    hash += XXH_get32bits(ptr) * XXH_PRIME32_3;       \
+    ptr += 4;                                         \
+    hash  = XXH_rotl32(hash, 17) * XXH_PRIME32_4;     \
+} while (0)
+
+    if (ptr==NULL) XXH_ASSERT(len == 0);
+
+    /* Compact rerolled version; generally faster */
+    if (!XXH32_ENDJMP) {
+        len &= 15;
+        while (len >= 4) {
+            XXH_PROCESS4;
+            len -= 4;
+        }
+        while (len > 0) {
+            XXH_PROCESS1;
+            --len;
+        }
+        return XXH32_avalanche(hash);
+    } else {
+         switch(len&15) /* or switch(bEnd - p) */ {
+           case 12:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 8:       XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 4:       XXH_PROCESS4;
+                         return XXH32_avalanche(hash);
+
+           case 13:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 9:       XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 5:       XXH_PROCESS4;
+                         XXH_PROCESS1;
+                         return XXH32_avalanche(hash);
+
+           case 14:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 10:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 6:       XXH_PROCESS4;
+                         XXH_PROCESS1;
+                         XXH_PROCESS1;
+                         return XXH32_avalanche(hash);
+
+           case 15:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 11:      XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 7:       XXH_PROCESS4;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 3:       XXH_PROCESS1;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 2:       XXH_PROCESS1;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 1:       XXH_PROCESS1;
+                         XXH_FALLTHROUGH;  /* fallthrough */
+           case 0:       return XXH32_avalanche(hash);
+        }
+        XXH_ASSERT(0);
+        return hash;   /* reaching this point is deemed impossible */
+    }
+}
+
+#ifdef XXH_OLD_NAMES
+#  define PROCESS1 XXH_PROCESS1
+#  define PROCESS4 XXH_PROCESS4
+#else
+#  undef XXH_PROCESS1
+#  undef XXH_PROCESS4
+#endif
+
+/*!
+ * @internal
+ * @brief The implementation for @ref XXH32().
+ *
+ * @param input , len , seed Directly passed from @ref XXH32().
+ * @param align Whether @p input is aligned.
+ * @return The calculated hash.
+ */
+XXH_FORCE_INLINE XXH_PUREF xxh_u32
+XXH32_endian_align(const xxh_u8* input, size_t len, xxh_u32 seed, XXH_alignment align)
+{
+    xxh_u32 h32;
+
+    if (input==NULL) XXH_ASSERT(len == 0);
+
+    if (len>=16) {
+        const xxh_u8* const bEnd = input + len;
+        const xxh_u8* const limit = bEnd - 15;
+        xxh_u32 v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+        xxh_u32 v2 = seed + XXH_PRIME32_2;
+        xxh_u32 v3 = seed + 0;
+        xxh_u32 v4 = seed - XXH_PRIME32_1;
+
+        do {
+            v1 = XXH32_round(v1, XXH_get32bits(input)); input += 4;
+            v2 = XXH32_round(v2, XXH_get32bits(input)); input += 4;
+            v3 = XXH32_round(v3, XXH_get32bits(input)); input += 4;
+            v4 = XXH32_round(v4, XXH_get32bits(input)); input += 4;
+        } while (input < limit);
+
+        h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
+            + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    } else {
+        h32  = seed + XXH_PRIME32_5;
+    }
+
+    h32 += (xxh_u32)len;
+
+    return XXH32_finalize(h32, input, len&15, align);
+}
+
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t len, XXH32_hash_t seed)
+{
+#if !defined(XXH_NO_STREAM) && XXH_SIZE_OPT >= 2
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, (const xxh_u8*)input, len);
+    return XXH32_digest(&state);
+#else
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
+            return XXH32_endian_align((const xxh_u8*)input, len, seed, XXH_aligned);
+    }   }
+
+    return XXH32_endian_align((const xxh_u8*)input, len, seed, XXH_unaligned);
+#endif
+}
+
+
+
+/*******   Hash streaming   *******/
+#ifndef XXH_NO_STREAM
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH32_state_t* XXH32_createState(void)
+{
+    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState)
+{
+    XXH_memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed)
+{
+    XXH_ASSERT(statePtr != NULL);
+    memset(statePtr, 0, sizeof(*statePtr));
+    statePtr->v[0] = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+    statePtr->v[1] = seed + XXH_PRIME32_2;
+    statePtr->v[2] = seed + 0;
+    statePtr->v[3] = seed - XXH_PRIME32_1;
+    return XXH_OK;
+}
+
+
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH32_update(XXH32_state_t* state, const void* input, size_t len)
+{
+    if (input==NULL) {
+        XXH_ASSERT(len == 0);
+        return XXH_OK;
+    }
+
+    {   const xxh_u8* p = (const xxh_u8*)input;
+        const xxh_u8* const bEnd = p + len;
+
+        state->total_len_32 += (XXH32_hash_t)len;
+        state->large_len |= (XXH32_hash_t)((len>=16) | (state->total_len_32>=16));
+
+        if (state->memsize + len < 16)  {   /* fill in tmp buffer */
+            XXH_memcpy((xxh_u8*)(state->mem32) + state->memsize, input, len);
+            state->memsize += (XXH32_hash_t)len;
+            return XXH_OK;
+        }
+
+        if (state->memsize) {   /* some data left from previous update */
+            XXH_memcpy((xxh_u8*)(state->mem32) + state->memsize, input, 16-state->memsize);
+            {   const xxh_u32* p32 = state->mem32;
+                state->v[0] = XXH32_round(state->v[0], XXH_readLE32(p32)); p32++;
+                state->v[1] = XXH32_round(state->v[1], XXH_readLE32(p32)); p32++;
+                state->v[2] = XXH32_round(state->v[2], XXH_readLE32(p32)); p32++;
+                state->v[3] = XXH32_round(state->v[3], XXH_readLE32(p32));
+            }
+            p += 16-state->memsize;
+            state->memsize = 0;
+        }
+
+        if (p <= bEnd-16) {
+            const xxh_u8* const limit = bEnd - 16;
+
+            do {
+                state->v[0] = XXH32_round(state->v[0], XXH_readLE32(p)); p+=4;
+                state->v[1] = XXH32_round(state->v[1], XXH_readLE32(p)); p+=4;
+                state->v[2] = XXH32_round(state->v[2], XXH_readLE32(p)); p+=4;
+                state->v[3] = XXH32_round(state->v[3], XXH_readLE32(p)); p+=4;
+            } while (p<=limit);
+
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem32, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH32_hash_t XXH32_digest(const XXH32_state_t* state)
+{
+    xxh_u32 h32;
+
+    if (state->large_len) {
+        h32 = XXH_rotl32(state->v[0], 1)
+            + XXH_rotl32(state->v[1], 7)
+            + XXH_rotl32(state->v[2], 12)
+            + XXH_rotl32(state->v[3], 18);
+    } else {
+        h32 = state->v[2] /* == seed */ + XXH_PRIME32_5;
+    }
+
+    h32 += state->total_len_32;
+
+    return XXH32_finalize(h32, (const xxh_u8*)state->mem32, state->memsize, XXH_aligned);
+}
+#endif /* !XXH_NO_STREAM */
+
+/*******   Canonical representation   *******/
+
+/*!
+ * @ingroup XXH32_family
+ * The default return values from XXH functions are unsigned 32 and 64 bit
+ * integers.
+ *
+ * The canonical representation uses big endian convention, the same convention
+ * as human-readable numbers (large digits first).
+ *
+ * This way, hash values can be written into a file or buffer, remaining
+ * comparable across different systems.
+ *
+ * The following functions allow transformation of hash values to and from their
+ * canonical format.
+ */
+XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH32_canonical_t) == sizeof(XXH32_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    XXH_memcpy(dst, &hash, sizeof(*dst));
+}
+/*! @ingroup XXH32_family */
+XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src)
+{
+    return XXH_readBE32(src);
+}
+
+
+#ifndef XXH_NO_LONG_LONG
+
+/* *******************************************************************
+*  64-bit hash functions
+*********************************************************************/
+/*!
+ * @}
+ * @ingroup impl
+ * @{
+ */
+/*******   Memory access   *******/
+
+typedef XXH64_hash_t xxh_u64;
+
+#ifdef XXH_OLD_NAMES
+#  define U64 xxh_u64
+#endif
+
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==3))
+/*
+ * Manual byteshift. Best for old compilers which don't inline memcpy.
+ * We actually directly use XXH_readLE64 and XXH_readBE64.
+ */
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==2))
+
+/* Force direct memory access. Only works on CPU which support unaligned memory access in hardware */
+static xxh_u64 XXH_read64(const void* memPtr)
+{
+    return *(const xxh_u64*) memPtr;
+}
+
+#elif (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==1))
+
+/*
+ * __attribute__((aligned(1))) is supported by gcc and clang. Originally the
+ * documentation claimed that it only increased the alignment, but actually it
+ * can decrease it on gcc, clang, and icc:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69502,
+ * https://gcc.godbolt.org/z/xYez1j67Y.
+ */
+#ifdef XXH_OLD_NAMES
+typedef union { xxh_u32 u32; xxh_u64 u64; } __attribute__((packed)) unalign64;
+#endif
+static xxh_u64 XXH_read64(const void* ptr)
+{
+    typedef __attribute__((aligned(1))) xxh_u64 xxh_unalign64;
+    return *((const xxh_unalign64*)ptr);
+}
+
+#else
+
+/*
+ * Portable and safe solution. Generally efficient.
+ * see: https://fastcompression.blogspot.com/2015/08/accessing-unaligned-memory.html
+ */
+static xxh_u64 XXH_read64(const void* memPtr)
+{
+    xxh_u64 val;
+    XXH_memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
+
+#endif   /* XXH_FORCE_DIRECT_MEMORY_ACCESS */
+
+#if defined(_MSC_VER)     /* Visual Studio */
+#  define XXH_swap64 _byteswap_uint64
+#elif XXH_GCC_VERSION >= 403
+#  define XXH_swap64 __builtin_bswap64
+#else
+static xxh_u64 XXH_swap64(xxh_u64 x)
+{
+    return  ((x << 56) & 0xff00000000000000ULL) |
+            ((x << 40) & 0x00ff000000000000ULL) |
+            ((x << 24) & 0x0000ff0000000000ULL) |
+            ((x << 8)  & 0x000000ff00000000ULL) |
+            ((x >> 8)  & 0x00000000ff000000ULL) |
+            ((x >> 24) & 0x0000000000ff0000ULL) |
+            ((x >> 40) & 0x000000000000ff00ULL) |
+            ((x >> 56) & 0x00000000000000ffULL);
+}
+#endif
+
+
+/* XXH_FORCE_MEMORY_ACCESS==3 is an endian-independent byteshift load. */
+#if (defined(XXH_FORCE_MEMORY_ACCESS) && (XXH_FORCE_MEMORY_ACCESS==3))
+
+XXH_FORCE_INLINE xxh_u64 XXH_readLE64(const void* memPtr)
+{
+    const xxh_u8* bytePtr = (const xxh_u8 *)memPtr;
+    return bytePtr[0]
+         | ((xxh_u64)bytePtr[1] << 8)
+         | ((xxh_u64)bytePtr[2] << 16)
+         | ((xxh_u64)bytePtr[3] << 24)
+         | ((xxh_u64)bytePtr[4] << 32)
+         | ((xxh_u64)bytePtr[5] << 40)
+         | ((xxh_u64)bytePtr[6] << 48)
+         | ((xxh_u64)bytePtr[7] << 56);
+}
+
+XXH_FORCE_INLINE xxh_u64 XXH_readBE64(const void* memPtr)
+{
+    const xxh_u8* bytePtr = (const xxh_u8 *)memPtr;
+    return bytePtr[7]
+         | ((xxh_u64)bytePtr[6] << 8)
+         | ((xxh_u64)bytePtr[5] << 16)
+         | ((xxh_u64)bytePtr[4] << 24)
+         | ((xxh_u64)bytePtr[3] << 32)
+         | ((xxh_u64)bytePtr[2] << 40)
+         | ((xxh_u64)bytePtr[1] << 48)
+         | ((xxh_u64)bytePtr[0] << 56);
+}
+
+#else
+XXH_FORCE_INLINE xxh_u64 XXH_readLE64(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+}
+
+static xxh_u64 XXH_readBE64(const void* ptr)
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+}
+#endif
+
+XXH_FORCE_INLINE xxh_u64
+XXH_readLE64_align(const void* ptr, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return XXH_readLE64(ptr);
+    else
+        return XXH_CPU_LITTLE_ENDIAN ? *(const xxh_u64*)ptr : XXH_swap64(*(const xxh_u64*)ptr);
+}
+
+
+/*******   xxh64   *******/
+/*!
+ * @}
+ * @defgroup XXH64_impl XXH64 implementation
+ * @ingroup impl
+ *
+ * Details on the XXH64 implementation.
+ * @{
+ */
+/* #define rather that static const, to be used as initializers */
+#define XXH_PRIME64_1  0x9E3779B185EBCA87ULL  /*!< 0b1001111000110111011110011011000110000101111010111100101010000111 */
+#define XXH_PRIME64_2  0xC2B2AE3D27D4EB4FULL  /*!< 0b1100001010110010101011100011110100100111110101001110101101001111 */
+#define XXH_PRIME64_3  0x165667B19E3779F9ULL  /*!< 0b0001011001010110011001111011000110011110001101110111100111111001 */
+#define XXH_PRIME64_4  0x85EBCA77C2B2AE63ULL  /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
+#define XXH_PRIME64_5  0x27D4EB2F165667C5ULL  /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
+
+#ifdef XXH_OLD_NAMES
+#  define PRIME64_1 XXH_PRIME64_1
+#  define PRIME64_2 XXH_PRIME64_2
+#  define PRIME64_3 XXH_PRIME64_3
+#  define PRIME64_4 XXH_PRIME64_4
+#  define PRIME64_5 XXH_PRIME64_5
+#endif
+
+/*! @copydoc XXH32_round */
+static xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input)
+{
+    acc += input * XXH_PRIME64_2;
+    acc  = XXH_rotl64(acc, 31);
+    acc *= XXH_PRIME64_1;
+    return acc;
+}
+
+static xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val)
+{
+    val  = XXH64_round(0, val);
+    acc ^= val;
+    acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
+    return acc;
+}
+
+/*! @copydoc XXH32_avalanche */
+static xxh_u64 XXH64_avalanche(xxh_u64 hash)
+{
+    hash ^= hash >> 33;
+    hash *= XXH_PRIME64_2;
+    hash ^= hash >> 29;
+    hash *= XXH_PRIME64_3;
+    hash ^= hash >> 32;
+    return hash;
+}
+
+
+#define XXH_get64bits(p) XXH_readLE64_align(p, align)
+
+/*!
+ * @internal
+ * @brief Processes the last 0-31 bytes of @p ptr.
+ *
+ * There may be up to 31 bytes remaining to consume from the input.
+ * This final stage will digest them to ensure that all input bytes are present
+ * in the final mix.
+ *
+ * @param hash The hash to finalize.
+ * @param ptr The pointer to the remaining input.
+ * @param len The remaining length, modulo 32.
+ * @param align Whether @p ptr is aligned.
+ * @return The finalized hash
+ * @see XXH32_finalize().
+ */
+static XXH_PUREF xxh_u64
+XXH64_finalize(xxh_u64 hash, const xxh_u8* ptr, size_t len, XXH_alignment align)
+{
+    if (ptr==NULL) XXH_ASSERT(len == 0);
+    len &= 31;
+    while (len >= 8) {
+        xxh_u64 const k1 = XXH64_round(0, XXH_get64bits(ptr));
+        ptr += 8;
+        hash ^= k1;
+        hash  = XXH_rotl64(hash,27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+        len -= 8;
+    }
+    if (len >= 4) {
+        hash ^= (xxh_u64)(XXH_get32bits(ptr)) * XXH_PRIME64_1;
+        ptr += 4;
+        hash = XXH_rotl64(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
+        len -= 4;
+    }
+    while (len > 0) {
+        hash ^= (*ptr++) * XXH_PRIME64_5;
+        hash = XXH_rotl64(hash, 11) * XXH_PRIME64_1;
+        --len;
+    }
+    return  XXH64_avalanche(hash);
+}
+
+#ifdef XXH_OLD_NAMES
+#  define PROCESS1_64 XXH_PROCESS1_64
+#  define PROCESS4_64 XXH_PROCESS4_64
+#  define PROCESS8_64 XXH_PROCESS8_64
+#else
+#  undef XXH_PROCESS1_64
+#  undef XXH_PROCESS4_64
+#  undef XXH_PROCESS8_64
+#endif
+
+/*!
+ * @internal
+ * @brief The implementation for @ref XXH64().
+ *
+ * @param input , len , seed Directly passed from @ref XXH64().
+ * @param align Whether @p input is aligned.
+ * @return The calculated hash.
+ */
+XXH_FORCE_INLINE XXH_PUREF xxh_u64
+XXH64_endian_align(const xxh_u8* input, size_t len, xxh_u64 seed, XXH_alignment align)
+{
+    xxh_u64 h64;
+    if (input==NULL) XXH_ASSERT(len == 0);
+
+    if (len>=32) {
+        const xxh_u8* const bEnd = input + len;
+        const xxh_u8* const limit = bEnd - 31;
+        xxh_u64 v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+        xxh_u64 v2 = seed + XXH_PRIME64_2;
+        xxh_u64 v3 = seed + 0;
+        xxh_u64 v4 = seed - XXH_PRIME64_1;
+
+        do {
+            v1 = XXH64_round(v1, XXH_get64bits(input)); input+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(input)); input+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(input)); input+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(input)); input+=8;
+        } while (input<limit);
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+
+    } else {
+        h64  = seed + XXH_PRIME64_5;
+    }
+
+    h64 += (xxh_u64) len;
+
+    return XXH64_finalize(h64, input, len, align);
+}
+
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH64_hash_t XXH64 (XXH_NOESCAPE const void* input, size_t len, XXH64_hash_t seed)
+{
+#if !defined(XXH_NO_STREAM) && XXH_SIZE_OPT >= 2
+    /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+    XXH64_state_t state;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, (const xxh_u8*)input, len);
+    return XXH64_digest(&state);
+#else
+    if (XXH_FORCE_ALIGN_CHECK) {
+        if ((((size_t)input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
+            return XXH64_endian_align((const xxh_u8*)input, len, seed, XXH_aligned);
+    }   }
+
+    return XXH64_endian_align((const xxh_u8*)input, len, seed, XXH_unaligned);
+
+#endif
+}
+
+/*******   Hash Streaming   *******/
+#ifndef XXH_NO_STREAM
+/*! @ingroup XXH64_family*/
+XXH_PUBLIC_API XXH64_state_t* XXH64_createState(void)
+{
+    return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
+}
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API void XXH64_copyState(XXH_NOESCAPE XXH64_state_t* dstState, const XXH64_state_t* srcState)
+{
+    XXH_memcpy(dstState, srcState, sizeof(*dstState));
+}
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH_NOESCAPE XXH64_state_t* statePtr, XXH64_hash_t seed)
+{
+    XXH_ASSERT(statePtr != NULL);
+    memset(statePtr, 0, sizeof(*statePtr));
+    statePtr->v[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+    statePtr->v[1] = seed + XXH_PRIME64_2;
+    statePtr->v[2] = seed + 0;
+    statePtr->v[3] = seed - XXH_PRIME64_1;
+    return XXH_OK;
+}
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH64_update (XXH_NOESCAPE XXH64_state_t* state, XXH_NOESCAPE const void* input, size_t len)
+{
+    if (input==NULL) {
+        XXH_ASSERT(len == 0);
+        return XXH_OK;
+    }
+
+    {   const xxh_u8* p = (const xxh_u8*)input;
+        const xxh_u8* const bEnd = p + len;
+
+        state->total_len += len;
+
+        if (state->memsize + len < 32) {  /* fill in tmp buffer */
+            XXH_memcpy(((xxh_u8*)state->mem64) + state->memsize, input, len);
+            state->memsize += (xxh_u32)len;
+            return XXH_OK;
+        }
+
+        if (state->memsize) {   /* tmp buffer is full */
+            XXH_memcpy(((xxh_u8*)state->mem64) + state->memsize, input, 32-state->memsize);
+            state->v[0] = XXH64_round(state->v[0], XXH_readLE64(state->mem64+0));
+            state->v[1] = XXH64_round(state->v[1], XXH_readLE64(state->mem64+1));
+            state->v[2] = XXH64_round(state->v[2], XXH_readLE64(state->mem64+2));
+            state->v[3] = XXH64_round(state->v[3], XXH_readLE64(state->mem64+3));
+            p += 32 - state->memsize;
+            state->memsize = 0;
+        }
+
+        if (p+32 <= bEnd) {
+            const xxh_u8* const limit = bEnd - 32;
+
+            do {
+                state->v[0] = XXH64_round(state->v[0], XXH_readLE64(p)); p+=8;
+                state->v[1] = XXH64_round(state->v[1], XXH_readLE64(p)); p+=8;
+                state->v[2] = XXH64_round(state->v[2], XXH_readLE64(p)); p+=8;
+                state->v[3] = XXH64_round(state->v[3], XXH_readLE64(p)); p+=8;
+            } while (p<=limit);
+
+        }
+
+        if (p < bEnd) {
+            XXH_memcpy(state->mem64, p, (size_t)(bEnd-p));
+            state->memsize = (unsigned)(bEnd-p);
+        }
+    }
+
+    return XXH_OK;
+}
+
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH64_hash_t XXH64_digest(XXH_NOESCAPE const XXH64_state_t* state)
+{
+    xxh_u64 h64;
+
+    if (state->total_len >= 32) {
+        h64 = XXH_rotl64(state->v[0], 1) + XXH_rotl64(state->v[1], 7) + XXH_rotl64(state->v[2], 12) + XXH_rotl64(state->v[3], 18);
+        h64 = XXH64_mergeRound(h64, state->v[0]);
+        h64 = XXH64_mergeRound(h64, state->v[1]);
+        h64 = XXH64_mergeRound(h64, state->v[2]);
+        h64 = XXH64_mergeRound(h64, state->v[3]);
+    } else {
+        h64  = state->v[2] /*seed*/ + XXH_PRIME64_5;
+    }
+
+    h64 += (xxh_u64) state->total_len;
+
+    return XXH64_finalize(h64, (const xxh_u8*)state->mem64, (size_t)state->total_len, XXH_aligned);
+}
+#endif /* !XXH_NO_STREAM */
+
+/******* Canonical representation   *******/
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API void XXH64_canonicalFromHash(XXH_NOESCAPE XXH64_canonical_t* dst, XXH64_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH64_canonical_t) == sizeof(XXH64_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    XXH_memcpy(dst, &hash, sizeof(*dst));
+}
+
+/*! @ingroup XXH64_family */
+XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_canonical_t* src)
+{
+    return XXH_readBE64(src);
+}
+
+#ifndef XXH_NO_XXH3
+
+/* *********************************************************************
+*  XXH3
+*  New generation hash designed for speed on small keys and vectorization
+************************************************************************ */
+/*!
+ * @}
+ * @defgroup XXH3_impl XXH3 implementation
+ * @ingroup impl
+ * @{
+ */
+
+/* ===   Compiler specifics   === */
+
+#if ((defined(sun) || defined(__sun)) && __cplusplus) /* Solaris includes __STDC_VERSION__ with C++. Tested with GCC 5.5 */
+#  define XXH_RESTRICT   /* disable */
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
+#  define XXH_RESTRICT   restrict
+#elif (defined (__GNUC__) && ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))) \
+   || (defined (__clang__)) \
+   || (defined (_MSC_VER) && (_MSC_VER >= 1400)) \
+   || (defined (__INTEL_COMPILER) && (__INTEL_COMPILER >= 1300))
+/*
+ * There are a LOT more compilers that recognize __restrict but this
+ * covers the major ones.
+ */
+#  define XXH_RESTRICT   __restrict
+#else
+#  define XXH_RESTRICT   /* disable */
+#endif
+
+#if (defined(__GNUC__) && (__GNUC__ >= 3))  \
+  || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) \
+  || defined(__clang__)
+#    define XXH_likely(x) __builtin_expect(x, 1)
+#    define XXH_unlikely(x) __builtin_expect(x, 0)
+#else
+#    define XXH_likely(x) (x)
+#    define XXH_unlikely(x) (x)
+#endif
+
+#ifndef XXH_HAS_INCLUDE
+#  ifdef __has_include
+#    define XXH_HAS_INCLUDE(x) __has_include(x)
+#  else
+#    define XXH_HAS_INCLUDE(x) 0
+#  endif
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#  if defined(__ARM_FEATURE_SVE)
+#    include <arm_sve.h>
+#  endif
+#  if defined(__ARM_NEON__) || defined(__ARM_NEON) \
+   || (defined(_M_ARM) && _M_ARM >= 7) \
+   || defined(_M_ARM64) || defined(_M_ARM64EC) \
+   || (defined(__wasm_simd128__) && XXH_HAS_INCLUDE(<arm_neon.h>)) /* WASM SIMD128 via SIMDe */
+#    define inline __inline__  /* circumvent a clang bug */
+#    include <arm_neon.h>
+#    undef inline
+#  elif defined(__AVX2__)
+#    include <immintrin.h>
+#  elif defined(__SSE2__)
+#    include <emmintrin.h>
+#  endif
+#endif
+
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
+/*
+ * One goal of XXH3 is to make it fast on both 32-bit and 64-bit, while
+ * remaining a true 64-bit/128-bit hash function.
+ *
+ * This is done by prioritizing a subset of 64-bit operations that can be
+ * emulated without too many steps on the average 32-bit machine.
+ *
+ * For example, these two lines seem similar, and run equally fast on 64-bit:
+ *
+ *   xxh_u64 x;
+ *   x ^= (x >> 47); // good
+ *   x ^= (x >> 13); // bad
+ *
+ * However, to a 32-bit machine, there is a major difference.
+ *
+ * x ^= (x >> 47) looks like this:
+ *
+ *   x.lo ^= (x.hi >> (47 - 32));
+ *
+ * while x ^= (x >> 13) looks like this:
+ *
+ *   // note: funnel shifts are not usually cheap.
+ *   x.lo ^= (x.lo >> 13) | (x.hi << (32 - 13));
+ *   x.hi ^= (x.hi >> 13);
+ *
+ * The first one is significantly faster than the second, simply because the
+ * shift is larger than 32. This means:
+ *  - All the bits we need are in the upper 32 bits, so we can ignore the lower
+ *    32 bits in the shift.
+ *  - The shift result will always fit in the lower 32 bits, and therefore,
+ *    we can ignore the upper 32 bits in the xor.
+ *
+ * Thanks to this optimization, XXH3 only requires these features to be efficient:
+ *
+ *  - Usable unaligned access
+ *  - A 32-bit or 64-bit ALU
+ *      - If 32-bit, a decent ADC instruction
+ *  - A 32 or 64-bit multiply with a 64-bit result
+ *  - For the 128-bit variant, a decent byteswap helps short inputs.
+ *
+ * The first two are already required by XXH32, and almost all 32-bit and 64-bit
+ * platforms which can run XXH32 can run XXH3 efficiently.
+ *
+ * Thumb-1, the classic 16-bit only subset of ARM's instruction set, is one
+ * notable exception.
+ *
+ * First of all, Thumb-1 lacks support for the UMULL instruction which
+ * performs the important long multiply. This means numerous __aeabi_lmul
+ * calls.
+ *
+ * Second of all, the 8 functional registers are just not enough.
+ * Setup for __aeabi_lmul, byteshift loads, pointers, and all arithmetic need
+ * Lo registers, and this shuffling results in thousands more MOVs than A32.
+ *
+ * A32 and T32 don't have this limitation. They can access all 14 registers,
+ * do a 32->64 multiply with UMULL, and the flexible operand allowing free
+ * shifts is helpful, too.
+ *
+ * Therefore, we do a quick sanity check.
+ *
+ * If compiling Thumb-1 for a target which supports ARM instructions, we will
+ * emit a warning, as it is not a "sane" platform to compile for.
+ *
+ * Usually, if this happens, it is because of an accident and you probably need
+ * to specify -march, as you likely meant to compile for a newer architecture.
+ *
+ * Credit: large sections of the vectorial and asm source code paths
+ *         have been contributed by @easyaspi314
+ */
+#if defined(__thumb__) && !defined(__thumb2__) && defined(__ARM_ARCH_ISA_ARM)
+#   warning "XXH3 is highly inefficient without ARM or Thumb-2."
+#endif
+
+/* ==========================================
+ * Vectorization detection
+ * ========================================== */
+
+#ifdef XXH_DOXYGEN
+/*!
+ * @ingroup tuning
+ * @brief Overrides the vectorization implementation chosen for XXH3.
+ *
+ * Can be defined to 0 to disable SIMD or any of the values mentioned in
+ * @ref XXH_VECTOR_TYPE.
+ *
+ * If this is not defined, it uses predefined macros to determine the best
+ * implementation.
+ */
+#  define XXH_VECTOR XXH_SCALAR
+/*!
+ * @ingroup tuning
+ * @brief Possible values for @ref XXH_VECTOR.
+ *
+ * Note that these are actually implemented as macros.
+ *
+ * If this is not defined, it is detected automatically.
+ * internal macro XXH_X86DISPATCH overrides this.
+ */
+enum XXH_VECTOR_TYPE /* fake enum */ {
+    XXH_SCALAR = 0,  /*!< Portable scalar version */
+    XXH_SSE2   = 1,  /*!<
+                      * SSE2 for Pentium 4, Opteron, all x86_64.
+                      *
+                      * @note SSE2 is also guaranteed on Windows 10, macOS, and
+                      * Android x86.
+                      */
+    XXH_AVX2   = 2,  /*!< AVX2 for Haswell and Bulldozer */
+    XXH_AVX512 = 3,  /*!< AVX512 for Skylake and Icelake */
+    XXH_NEON   = 4,  /*!<
+                       * NEON for most ARMv7-A, all AArch64, and WASM SIMD128
+                       * via the SIMDeverywhere polyfill provided with the
+                       * Emscripten SDK.
+                       */
+    XXH_VSX    = 5,  /*!< VSX and ZVector for POWER8/z13 (64-bit) */
+    XXH_SVE    = 6,  /*!< SVE for some ARMv8-A and ARMv9-A */
+};
+/*!
+ * @ingroup tuning
+ * @brief Selects the minimum alignment for XXH3's accumulators.
+ *
+ * When using SIMD, this should match the alignment required for said vector
+ * type, so, for example, 32 for AVX2.
+ *
+ * Default: Auto detected.
+ */
+#  define XXH_ACC_ALIGN 8
+#endif
+
+/* Actual definition */
+#ifndef XXH_DOXYGEN
+#  define XXH_SCALAR 0
+#  define XXH_SSE2   1
+#  define XXH_AVX2   2
+#  define XXH_AVX512 3
+#  define XXH_NEON   4
+#  define XXH_VSX    5
+#  define XXH_SVE    6
+#endif
+
+#ifndef XXH_VECTOR    /* can be defined on command line */
+#  if defined(__ARM_FEATURE_SVE)
+#    define XXH_VECTOR XXH_SVE
+#  elif ( \
+        defined(__ARM_NEON__) || defined(__ARM_NEON) /* gcc */ \
+     || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) /* msvc */ \
+     || (defined(__wasm_simd128__) && XXH_HAS_INCLUDE(<arm_neon.h>)) /* wasm simd128 via SIMDe */ \
+   ) && ( \
+        defined(_WIN32) || defined(__LITTLE_ENDIAN__) /* little endian only */ \
+    || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
+   )
+#    define XXH_VECTOR XXH_NEON
+#  elif defined(__AVX512F__)
+#    define XXH_VECTOR XXH_AVX512
+#  elif defined(__AVX2__)
+#    define XXH_VECTOR XXH_AVX2
+#  elif defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP == 2))
+#    define XXH_VECTOR XXH_SSE2
+#  elif (defined(__PPC64__) && defined(__POWER8_VECTOR__)) \
+     || (defined(__s390x__) && defined(__VEC__)) \
+     && defined(__GNUC__) /* TODO: IBM XL */
+#    define XXH_VECTOR XXH_VSX
+#  else
+#    define XXH_VECTOR XXH_SCALAR
+#  endif
+#endif
+
+/* __ARM_FEATURE_SVE is only supported by GCC & Clang. */
+#if (XXH_VECTOR == XXH_SVE) && !defined(__ARM_FEATURE_SVE)
+#  ifdef _MSC_VER
+#    pragma warning(once : 4606)
+#  else
+#    warning "__ARM_FEATURE_SVE isn't supported. Use SCALAR instead."
+#  endif
+#  undef XXH_VECTOR
+#  define XXH_VECTOR XXH_SCALAR
+#endif
+
+/*
+ * Controls the alignment of the accumulator,
+ * for compatibility with aligned vector loads, which are usually faster.
+ */
+#ifndef XXH_ACC_ALIGN
+#  if defined(XXH_X86DISPATCH)
+#     define XXH_ACC_ALIGN 64  /* for compatibility with avx512 */
+#  elif XXH_VECTOR == XXH_SCALAR  /* scalar */
+#     define XXH_ACC_ALIGN 8
+#  elif XXH_VECTOR == XXH_SSE2  /* sse2 */
+#     define XXH_ACC_ALIGN 16
+#  elif XXH_VECTOR == XXH_AVX2  /* avx2 */
+#     define XXH_ACC_ALIGN 32
+#  elif XXH_VECTOR == XXH_NEON  /* neon */
+#     define XXH_ACC_ALIGN 16
+#  elif XXH_VECTOR == XXH_VSX   /* vsx */
+#     define XXH_ACC_ALIGN 16
+#  elif XXH_VECTOR == XXH_AVX512  /* avx512 */
+#     define XXH_ACC_ALIGN 64
+#  elif XXH_VECTOR == XXH_SVE   /* sve */
+#     define XXH_ACC_ALIGN 64
+#  endif
+#endif
+
+#if defined(XXH_X86DISPATCH) || XXH_VECTOR == XXH_SSE2 \
+    || XXH_VECTOR == XXH_AVX2 || XXH_VECTOR == XXH_AVX512
+#  define XXH_SEC_ALIGN XXH_ACC_ALIGN
+#elif XXH_VECTOR == XXH_SVE
+#  define XXH_SEC_ALIGN XXH_ACC_ALIGN
+#else
+#  define XXH_SEC_ALIGN 8
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#  define XXH_ALIASING __attribute__((may_alias))
+#else
+#  define XXH_ALIASING /* nothing */
+#endif
+
+/*
+ * UGLY HACK:
+ * GCC usually generates the best code with -O3 for xxHash.
+ *
+ * However, when targeting AVX2, it is overzealous in its unrolling resulting
+ * in code roughly 3/4 the speed of Clang.
+ *
+ * There are other issues, such as GCC splitting _mm256_loadu_si256 into
+ * _mm_loadu_si128 + _mm256_inserti128_si256. This is an optimization which
+ * only applies to Sandy and Ivy Bridge... which don't even support AVX2.
+ *
+ * That is why when compiling the AVX2 version, it is recommended to use either
+ *   -O2 -mavx2 -march=haswell
+ * or
+ *   -O2 -mavx2 -mno-avx256-split-unaligned-load
+ * for decent performance, or to use Clang instead.
+ *
+ * Fortunately, we can control the first one with a pragma that forces GCC into
+ * -O2, but the other one we can't control without "failed to inline always
+ * inline function due to target mismatch" warnings.
+ */
+#if XXH_VECTOR == XXH_AVX2 /* AVX2 */ \
+  && defined(__GNUC__) && !defined(__clang__) /* GCC, not Clang */ \
+  && defined(__OPTIMIZE__) && XXH_SIZE_OPT <= 0 /* respect -O0 and -Os */
+#  pragma GCC push_options
+#  pragma GCC optimize("-O2")
+#endif
+
+#if XXH_VECTOR == XXH_NEON
+
+/*
+ * UGLY HACK: While AArch64 GCC on Linux does not seem to care, on macOS, GCC -O3
+ * optimizes out the entire hashLong loop because of the aliasing violation.
+ *
+ * However, GCC is also inefficient at load-store optimization with vld1q/vst1q,
+ * so the only option is to mark it as aliasing.
+ */
+typedef uint64x2_t xxh_aliasing_uint64x2_t XXH_ALIASING;
+
+/*!
+ * @internal
+ * @brief `vld1q_u64` but faster and alignment-safe.
+ *
+ * On AArch64, unaligned access is always safe, but on ARMv7-a, it is only
+ * *conditionally* safe (`vld1` has an alignment bit like `movdq[ua]` in x86).
+ *
+ * GCC for AArch64 sees `vld1q_u8` as an intrinsic instead of a load, so it
+ * prohibits load-store optimizations. Therefore, a direct dereference is used.
+ *
+ * Otherwise, `vld1q_u8` is used with `vreinterpretq_u8_u64` to do a safe
+ * unaligned load.
+ */
+#if defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__)
+XXH_FORCE_INLINE uint64x2_t XXH_vld1q_u64(void const* ptr) /* silence -Wcast-align */
+{
+    return *(xxh_aliasing_uint64x2_t const *)ptr;
+}
+#else
+XXH_FORCE_INLINE uint64x2_t XXH_vld1q_u64(void const* ptr)
+{
+    return vreinterpretq_u64_u8(vld1q_u8((uint8_t const*)ptr));
+}
+#endif
+
+/*!
+ * @internal
+ * @brief `vmlal_u32` on low and high halves of a vector.
+ *
+ * This is a workaround for AArch64 GCC < 11 which implemented arm_neon.h with
+ * inline assembly and were therefore incapable of merging the `vget_{low, high}_u32`
+ * with `vmlal_u32`.
+ */
+#if defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
+XXH_FORCE_INLINE uint64x2_t
+XXH_vmlal_low_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
+{
+    /* Inline assembly is the only way */
+    __asm__("umlal   %0.2d, %1.2s, %2.2s" : "+w" (acc) : "w" (lhs), "w" (rhs));
+    return acc;
+}
+XXH_FORCE_INLINE uint64x2_t
+XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
+{
+    /* This intrinsic works as expected */
+    return vmlal_high_u32(acc, lhs, rhs);
+}
+#else
+/* Portable intrinsic versions */
+XXH_FORCE_INLINE uint64x2_t
+XXH_vmlal_low_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
+{
+    return vmlal_u32(acc, vget_low_u32(lhs), vget_low_u32(rhs));
+}
+/*! @copydoc XXH_vmlal_low_u32
+ * Assume the compiler converts this to vmlal_high_u32 on aarch64 */
+XXH_FORCE_INLINE uint64x2_t
+XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
+{
+    return vmlal_u32(acc, vget_high_u32(lhs), vget_high_u32(rhs));
+}
+#endif
+
+/*!
+ * @ingroup tuning
+ * @brief Controls the NEON to scalar ratio for XXH3
+ *
+ * This can be set to 2, 4, 6, or 8.
+ *
+ * ARM Cortex CPUs are _very_ sensitive to how their pipelines are used.
+ *
+ * For example, the Cortex-A73 can dispatch 3 micro-ops per cycle, but only 2 of those
+ * can be NEON. If you are only using NEON instructions, you are only using 2/3 of the CPU
+ * bandwidth.
+ *
+ * This is even more noticeable on the more advanced cores like the Cortex-A76 which
+ * can dispatch 8 micro-ops per cycle, but still only 2 NEON micro-ops at once.
+ *
+ * Therefore, to make the most out of the pipeline, it is beneficial to run 6 NEON lanes
+ * and 2 scalar lanes, which is chosen by default.
+ *
+ * This does not apply to Apple processors or 32-bit processors, which run better with
+ * full NEON. These will default to 8. Additionally, size-optimized builds run 8 lanes.
+ *
+ * This change benefits CPUs with large micro-op buffers without negatively affecting
+ * most other CPUs:
+ *
+ *  | Chipset               | Dispatch type       | NEON only | 6:2 hybrid | Diff. |
+ *  |:----------------------|:--------------------|----------:|-----------:|------:|
+ *  | Snapdragon 730 (A76)  | 2 NEON/8 micro-ops  |  8.8 GB/s |  10.1 GB/s |  ~16% |
+ *  | Snapdragon 835 (A73)  | 2 NEON/3 micro-ops  |  5.1 GB/s |   5.3 GB/s |   ~5% |
+ *  | Marvell PXA1928 (A53) | In-order dual-issue |  1.9 GB/s |   1.9 GB/s |    0% |
+ *  | Apple M1              | 4 NEON/8 micro-ops  | 37.3 GB/s |  36.1 GB/s |  ~-3% |
+ *
+ * It also seems to fix some bad codegen on GCC, making it almost as fast as clang.
+ *
+ * When using WASM SIMD128, if this is 2 or 6, SIMDe will scalarize 2 of the lanes meaning
+ * it effectively becomes worse 4.
+ *
+ * @see XXH3_accumulate_512_neon()
+ */
+# ifndef XXH3_NEON_LANES
+#  if (defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64) || defined(_M_ARM64EC)) \
+   && !defined(__APPLE__) && XXH_SIZE_OPT <= 0
+#   define XXH3_NEON_LANES 6
+#  else
+#   define XXH3_NEON_LANES XXH_ACC_NB
+#  endif
+# endif
+#endif  /* XXH_VECTOR == XXH_NEON */
+
+/*
+ * VSX and Z Vector helpers.
+ *
+ * This is very messy, and any pull requests to clean this up are welcome.
+ *
+ * There are a lot of problems with supporting VSX and s390x, due to
+ * inconsistent intrinsics, spotty coverage, and multiple endiannesses.
+ */
+#if XXH_VECTOR == XXH_VSX
+/* Annoyingly, these headers _may_ define three macros: `bool`, `vector`,
+ * and `pixel`. This is a problem for obvious reasons.
+ *
+ * These keywords are unnecessary; the spec literally says they are
+ * equivalent to `__bool`, `__vector`, and `__pixel` and may be undef'd
+ * after including the header.
+ *
+ * We use pragma push_macro/pop_macro to keep the namespace clean. */
+#  pragma push_macro("bool")
+#  pragma push_macro("vector")
+#  pragma push_macro("pixel")
+/* silence potential macro redefined warnings */
+#  undef bool
+#  undef vector
+#  undef pixel
+
+#  if defined(__s390x__)
+#    include <s390intrin.h>
+#  else
+#    include <altivec.h>
+#  endif
+
+/* Restore the original macro values, if applicable. */
+#  pragma pop_macro("pixel")
+#  pragma pop_macro("vector")
+#  pragma pop_macro("bool")
+
+typedef __vector unsigned long long xxh_u64x2;
+typedef __vector unsigned char xxh_u8x16;
+typedef __vector unsigned xxh_u32x4;
+
+/*
+ * UGLY HACK: Similar to aarch64 macOS GCC, s390x GCC has the same aliasing issue.
+ */
+typedef xxh_u64x2 xxh_aliasing_u64x2 XXH_ALIASING;
+
+# ifndef XXH_VSX_BE
+#  if defined(__BIG_ENDIAN__) \
+  || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#    define XXH_VSX_BE 1
+#  elif defined(__VEC_ELEMENT_REG_ORDER__) && __VEC_ELEMENT_REG_ORDER__ == __ORDER_BIG_ENDIAN__
+#    warning "-maltivec=be is not recommended. Please use native endianness."
+#    define XXH_VSX_BE 1
+#  else
+#    define XXH_VSX_BE 0
+#  endif
+# endif /* !defined(XXH_VSX_BE) */
+
+# if XXH_VSX_BE
+#  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
+#    define XXH_vec_revb vec_revb
+#  else
+/*!
+ * A polyfill for POWER9's vec_revb().
+ */
+XXH_FORCE_INLINE xxh_u64x2 XXH_vec_revb(xxh_u64x2 val)
+{
+    xxh_u8x16 const vByteSwap = { 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00,
+                                  0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08 };
+    return vec_perm(val, val, vByteSwap);
+}
+#  endif
+# endif /* XXH_VSX_BE */
+
+/*!
+ * Performs an unaligned vector load and byte swaps it on big endian.
+ */
+XXH_FORCE_INLINE xxh_u64x2 XXH_vec_loadu(const void *ptr)
+{
+    xxh_u64x2 ret;
+    XXH_memcpy(&ret, ptr, sizeof(xxh_u64x2));
+# if XXH_VSX_BE
+    ret = XXH_vec_revb(ret);
+# endif
+    return ret;
+}
+
+/*
+ * vec_mulo and vec_mule are very problematic intrinsics on PowerPC
+ *
+ * These intrinsics weren't added until GCC 8, despite existing for a while,
+ * and they are endian dependent. Also, their meaning swap depending on version.
+ * */
+# if defined(__s390x__)
+ /* s390x is always big endian, no issue on this platform */
+#  define XXH_vec_mulo vec_mulo
+#  define XXH_vec_mule vec_mule
+# elif defined(__clang__) && XXH_HAS_BUILTIN(__builtin_altivec_vmuleuw) && !defined(__ibmxl__)
+/* Clang has a better way to control this, we can just use the builtin which doesn't swap. */
+ /* The IBM XL Compiler (which defined __clang__) only implements the vec_* operations */
+#  define XXH_vec_mulo __builtin_altivec_vmulouw
+#  define XXH_vec_mule __builtin_altivec_vmuleuw
+# else
+/* gcc needs inline assembly */
+/* Adapted from https://github.com/google/highwayhash/blob/master/highwayhash/hh_vsx.h. */
+XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mulo(xxh_u32x4 a, xxh_u32x4 b)
+{
+    xxh_u64x2 result;
+    __asm__("vmulouw %0, %1, %2" : "=v" (result) : "v" (a), "v" (b));
+    return result;
+}
+XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
+{
+    xxh_u64x2 result;
+    __asm__("vmuleuw %0, %1, %2" : "=v" (result) : "v" (a), "v" (b));
+    return result;
+}
+# endif /* XXH_vec_mulo, XXH_vec_mule */
+#endif /* XXH_VECTOR == XXH_VSX */
+
+#if XXH_VECTOR == XXH_SVE
+#define ACCRND(acc, offset) \
+do { \
+    svuint64_t input_vec = svld1_u64(mask, xinput + offset);         \
+    svuint64_t secret_vec = svld1_u64(mask, xsecret + offset);       \
+    svuint64_t mixed = sveor_u64_x(mask, secret_vec, input_vec);     \
+    svuint64_t swapped = svtbl_u64(input_vec, kSwap);                \
+    svuint64_t mixed_lo = svextw_u64_x(mask, mixed);                 \
+    svuint64_t mixed_hi = svlsr_n_u64_x(mask, mixed, 32);            \
+    svuint64_t mul = svmad_u64_x(mask, mixed_lo, mixed_hi, swapped); \
+    acc = svadd_u64_x(mask, acc, mul);                               \
+} while (0)
+#endif /* XXH_VECTOR == XXH_SVE */
+
+/* prefetch
+ * can be disabled, by declaring XXH_NO_PREFETCH build macro */
+#if defined(XXH_NO_PREFETCH)
+#  define XXH_PREFETCH(ptr)  (void)(ptr)  /* disabled */
+#else
+#  if XXH_SIZE_OPT >= 1
+#    define XXH_PREFETCH(ptr) (void)(ptr)
+#  elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))  /* _mm_prefetch() not defined outside of x86/x64 */
+#    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
+#    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
+#  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
+#    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
+#  else
+#    define XXH_PREFETCH(ptr) (void)(ptr)  /* disabled */
+#  endif
+#endif  /* XXH_NO_PREFETCH */
+
+
+/* ==========================================
+ * XXH3 default settings
+ * ========================================== */
+
+#define XXH_SECRET_DEFAULT_SIZE 192   /* minimum XXH3_SECRET_SIZE_MIN */
+
+#if (XXH_SECRET_DEFAULT_SIZE < XXH3_SECRET_SIZE_MIN)
+#  error "default keyset is not large enough"
+#endif
+
+/*! Pseudorandom secret taken directly from FARSH. */
+XXH_ALIGN(64) static const xxh_u8 XXH3_kSecret[XXH_SECRET_DEFAULT_SIZE] = {
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
+    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
+    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
+    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
+    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
+    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
+    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
+    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
+    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+};
+
+static const xxh_u64 PRIME_MX1 = 0x165667919E3779F9ULL;  /*!< 0b0001011001010110011001111001000110011110001101110111100111111001 */
+static const xxh_u64 PRIME_MX2 = 0x9FB21C651E98DF25ULL;  /*!< 0b1001111110110010000111000110010100011110100110001101111100100101 */
+
+#ifdef XXH_OLD_NAMES
+#  define kSecret XXH3_kSecret
+#endif
+
+#ifdef XXH_DOXYGEN
+/*!
+ * @brief Calculates a 32-bit to 64-bit long multiply.
+ *
+ * Implemented as a macro.
+ *
+ * Wraps `__emulu` on MSVC x86 because it tends to call `__allmul` when it doesn't
+ * need to (but it shouldn't need to anyways, it is about 7 instructions to do
+ * a 64x64 multiply...). Since we know that this will _always_ emit `MULL`, we
+ * use that instead of the normal method.
+ *
+ * If you are compiling for platforms like Thumb-1 and don't have a better option,
+ * you may also want to write your own long multiply routine here.
+ *
+ * @param x, y Numbers to be multiplied
+ * @return 64-bit product of the low 32 bits of @p x and @p y.
+ */
+XXH_FORCE_INLINE xxh_u64
+XXH_mult32to64(xxh_u64 x, xxh_u64 y)
+{
+   return (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF);
+}
+#elif defined(_MSC_VER) && defined(_M_IX86)
+#    define XXH_mult32to64(x, y) __emulu((unsigned)(x), (unsigned)(y))
+#else
+/*
+ * Downcast + upcast is usually better than masking on older compilers like
+ * GCC 4.2 (especially 32-bit ones), all without affecting newer compilers.
+ *
+ * The other method, (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF), will AND both operands
+ * and perform a full 64x64 multiply -- entirely redundant on 32-bit.
+ */
+#    define XXH_mult32to64(x, y) ((xxh_u64)(xxh_u32)(x) * (xxh_u64)(xxh_u32)(y))
+#endif
+
+/*!
+ * @brief Calculates a 64->128-bit long multiply.
+ *
+ * Uses `__uint128_t` and `_umul128` if available, otherwise uses a scalar
+ * version.
+ *
+ * @param lhs , rhs The 64-bit integers to be multiplied
+ * @return The 128-bit result represented in an @ref XXH128_hash_t.
+ */
+static XXH128_hash_t
+XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs)
+{
+    /*
+     * GCC/Clang __uint128_t method.
+     *
+     * On most 64-bit targets, GCC and Clang define a __uint128_t type.
+     * This is usually the best way as it usually uses a native long 64-bit
+     * multiply, such as MULQ on x86_64 or MUL + UMULH on aarch64.
+     *
+     * Usually.
+     *
+     * Despite being a 32-bit platform, Clang (and emscripten) define this type
+     * despite not having the arithmetic for it. This results in a laggy
+     * compiler builtin call which calculates a full 128-bit multiply.
+     * In that case it is best to use the portable one.
+     * https://github.com/Cyan4973/xxHash/issues/211#issuecomment-515575677
+     */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__wasm__) \
+    && defined(__SIZEOF_INT128__) \
+    || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+
+    __uint128_t const product = (__uint128_t)lhs * (__uint128_t)rhs;
+    XXH128_hash_t r128;
+    r128.low64  = (xxh_u64)(product);
+    r128.high64 = (xxh_u64)(product >> 64);
+    return r128;
+
+    /*
+     * MSVC for x64's _umul128 method.
+     *
+     * xxh_u64 _umul128(xxh_u64 Multiplier, xxh_u64 Multiplicand, xxh_u64 *HighProduct);
+     *
+     * This compiles to single operand MUL on x64.
+     */
+#elif (defined(_M_X64) || defined(_M_IA64)) && !defined(_M_ARM64EC)
+
+#ifndef _MSC_VER
+#   pragma intrinsic(_umul128)
+#endif
+    xxh_u64 product_high;
+    xxh_u64 const product_low = _umul128(lhs, rhs, &product_high);
+    XXH128_hash_t r128;
+    r128.low64  = product_low;
+    r128.high64 = product_high;
+    return r128;
+
+    /*
+     * MSVC for ARM64's __umulh method.
+     *
+     * This compiles to the same MUL + UMULH as GCC/Clang's __uint128_t method.
+     */
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
+
+#ifndef _MSC_VER
+#   pragma intrinsic(__umulh)
+#endif
+    XXH128_hash_t r128;
+    r128.low64  = lhs * rhs;
+    r128.high64 = __umulh(lhs, rhs);
+    return r128;
+
+#else
+    /*
+     * Portable scalar method. Optimized for 32-bit and 64-bit ALUs.
+     *
+     * This is a fast and simple grade school multiply, which is shown below
+     * with base 10 arithmetic instead of base 0x100000000.
+     *
+     *           9 3 // D2 lhs = 93
+     *         x 7 5 // D2 rhs = 75
+     *     ----------
+     *           1 5 // D2 lo_lo = (93 % 10) * (75 % 10) = 15
+     *         4 5 | // D2 hi_lo = (93 / 10) * (75 % 10) = 45
+     *         2 1 | // D2 lo_hi = (93 % 10) * (75 / 10) = 21
+     *     + 6 3 | | // D2 hi_hi = (93 / 10) * (75 / 10) = 63
+     *     ---------
+     *         2 7 | // D2 cross = (15 / 10) + (45 % 10) + 21 = 27
+     *     + 6 7 | | // D2 upper = (27 / 10) + (45 / 10) + 63 = 67
+     *     ---------
+     *       6 9 7 5 // D4 res = (27 * 10) + (15 % 10) + (67 * 100) = 6975
+     *
+     * The reasons for adding the products like this are:
+     *  1. It avoids manual carry tracking. Just like how
+     *     (9 * 9) + 9 + 9 = 99, the same applies with this for UINT64_MAX.
+     *     This avoids a lot of complexity.
+     *
+     *  2. It hints for, and on Clang, compiles to, the powerful UMAAL
+     *     instruction available in ARM's Digital Signal Processing extension
+     *     in 32-bit ARMv6 and later, which is shown below:
+     *
+     *         void UMAAL(xxh_u32 *RdLo, xxh_u32 *RdHi, xxh_u32 Rn, xxh_u32 Rm)
+     *         {
+     *             xxh_u64 product = (xxh_u64)*RdLo * (xxh_u64)*RdHi + Rn + Rm;
+     *             *RdLo = (xxh_u32)(product & 0xFFFFFFFF);
+     *             *RdHi = (xxh_u32)(product >> 32);
+     *         }
+     *
+     *     This instruction was designed for efficient long multiplication, and
+     *     allows this to be calculated in only 4 instructions at speeds
+     *     comparable to some 64-bit ALUs.
+     *
+     *  3. It isn't terrible on other platforms. Usually this will be a couple
+     *     of 32-bit ADD/ADCs.
+     */
+
+    /* First calculate all of the cross products. */
+    xxh_u64 const lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
+    xxh_u64 const hi_lo = XXH_mult32to64(lhs >> 32,        rhs & 0xFFFFFFFF);
+    xxh_u64 const lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
+    xxh_u64 const hi_hi = XXH_mult32to64(lhs >> 32,        rhs >> 32);
+
+    /* Now add the products together. These will never overflow. */
+    xxh_u64 const cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
+    xxh_u64 const upper = (hi_lo >> 32) + (cross >> 32)        + hi_hi;
+    xxh_u64 const lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
+
+    XXH128_hash_t r128;
+    r128.low64  = lower;
+    r128.high64 = upper;
+    return r128;
+#endif
+}
+
+/*!
+ * @brief Calculates a 64-bit to 128-bit multiply, then XOR folds it.
+ *
+ * The reason for the separate function is to prevent passing too many structs
+ * around by value. This will hopefully inline the multiply, but we don't force it.
+ *
+ * @param lhs , rhs The 64-bit integers to multiply
+ * @return The low 64 bits of the product XOR'd by the high 64 bits.
+ * @see XXH_mult64to128()
+ */
+static xxh_u64
+XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs)
+{
+    XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
+    return product.low64 ^ product.high64;
+}
+
+/*! Seems to produce slightly better code on GCC for some reason. */
+XXH_FORCE_INLINE XXH_CONSTF xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift)
+{
+    XXH_ASSERT(0 <= shift && shift < 64);
+    return v64 ^ (v64 >> shift);
+}
+
+/*
+ * This is a fast avalanche stage,
+ * suitable when input bits are already partially mixed
+ */
+static XXH64_hash_t XXH3_avalanche(xxh_u64 h64)
+{
+    h64 = XXH_xorshift64(h64, 37);
+    h64 *= PRIME_MX1;
+    h64 = XXH_xorshift64(h64, 32);
+    return h64;
+}
+
+/*
+ * This is a stronger avalanche,
+ * inspired by Pelle Evensen's rrmxmx
+ * preferable when input has not been previously mixed
+ */
+static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len)
+{
+    /* this mix is inspired by Pelle Evensen's rrmxmx */
+    h64 ^= XXH_rotl64(h64, 49) ^ XXH_rotl64(h64, 24);
+    h64 *= PRIME_MX2;
+    h64 ^= (h64 >> 35) + len ;
+    h64 *= PRIME_MX2;
+    return XXH_xorshift64(h64, 28);
+}
+
+
+/* ==========================================
+ * Short keys
+ * ==========================================
+ * One of the shortcomings of XXH32 and XXH64 was that their performance was
+ * sub-optimal on short lengths. It used an iterative algorithm which strongly
+ * favored lengths that were a multiple of 4 or 8.
+ *
+ * Instead of iterating over individual inputs, we use a set of single shot
+ * functions which piece together a range of lengths and operate in constant time.
+ *
+ * Additionally, the number of multiplies has been significantly reduced. This
+ * reduces latency, especially when emulating 64-bit multiplies on 32-bit.
+ *
+ * Depending on the platform, this may or may not be faster than XXH32, but it
+ * is almost guaranteed to be faster than XXH64.
+ */
+
+/*
+ * At very short lengths, there isn't enough input to fully hide secrets, or use
+ * the entire secret.
+ *
+ * There is also only a limited amount of mixing we can do before significantly
+ * impacting performance.
+ *
+ * Therefore, we use different sections of the secret and always mix two secret
+ * samples with an XOR. This should have no effect on performance on the
+ * seedless or withSeed variants because everything _should_ be constant folded
+ * by modern compilers.
+ *
+ * The XOR mixing hides individual parts of the secret and increases entropy.
+ *
+ * This adds an extra layer of strength for custom secrets.
+ */
+XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(1 <= len && len <= 3);
+    XXH_ASSERT(secret != NULL);
+    /*
+     * len = 1: combined = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combined = { input[1], 0x02, input[0], input[1] }
+     * len = 3: combined = { input[2], 0x03, input[0], input[1] }
+     */
+    {   xxh_u8  const c1 = input[0];
+        xxh_u8  const c2 = input[len >> 1];
+        xxh_u8  const c3 = input[len - 1];
+        xxh_u32 const combined = ((xxh_u32)c1 << 16) | ((xxh_u32)c2  << 24)
+                               | ((xxh_u32)c3 <<  0) | ((xxh_u32)len << 8);
+        xxh_u64 const bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
+        xxh_u64 const keyed = (xxh_u64)combined ^ bitflip;
+        return XXH64_avalanche(keyed);
+    }
+}
+
+XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(secret != NULL);
+    XXH_ASSERT(4 <= len && len <= 8);
+    seed ^= (xxh_u64)XXH_swap32((xxh_u32)seed) << 32;
+    {   xxh_u32 const input1 = XXH_readLE32(input);
+        xxh_u32 const input2 = XXH_readLE32(input + len - 4);
+        xxh_u64 const bitflip = (XXH_readLE64(secret+8) ^ XXH_readLE64(secret+16)) - seed;
+        xxh_u64 const input64 = input2 + (((xxh_u64)input1) << 32);
+        xxh_u64 const keyed = input64 ^ bitflip;
+        return XXH3_rrmxmx(keyed, len);
+    }
+}
+
+XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_9to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(secret != NULL);
+    XXH_ASSERT(9 <= len && len <= 16);
+    {   xxh_u64 const bitflip1 = (XXH_readLE64(secret+24) ^ XXH_readLE64(secret+32)) + seed;
+        xxh_u64 const bitflip2 = (XXH_readLE64(secret+40) ^ XXH_readLE64(secret+48)) - seed;
+        xxh_u64 const input_lo = XXH_readLE64(input)           ^ bitflip1;
+        xxh_u64 const input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
+        xxh_u64 const acc = len
+                          + XXH_swap64(input_lo) + input_hi
+                          + XXH3_mul128_fold64(input_lo, input_hi);
+        return XXH3_avalanche(acc);
+    }
+}
+
+XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(len <= 16);
+    {   if (XXH_likely(len >  8)) return XXH3_len_9to16_64b(input, len, secret, seed);
+        if (XXH_likely(len >= 4)) return XXH3_len_4to8_64b(input, len, secret, seed);
+        if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
+        return XXH64_avalanche(seed ^ (XXH_readLE64(secret+56) ^ XXH_readLE64(secret+64)));
+    }
+}
+
+/*
+ * DISCLAIMER: There are known *seed-dependent* multicollisions here due to
+ * multiplication by zero, affecting hashes of lengths 17 to 240.
+ *
+ * However, they are very unlikely.
+ *
+ * Keep this in mind when using the unseeded XXH3_64bits() variant: As with all
+ * unseeded non-cryptographic hashes, it does not attempt to defend itself
+ * against specially crafted inputs, only random inputs.
+ *
+ * Compared to classic UMAC where a 1 in 2^31 chance of 4 consecutive bytes
+ * cancelling out the secret is taken an arbitrary number of times (addressed
+ * in XXH3_accumulate_512), this collision is very unlikely with random inputs
+ * and/or proper seeding:
+ *
+ * This only has a 1 in 2^63 chance of 8 consecutive bytes cancelling out, in a
+ * function that is only called up to 16 times per hash with up to 240 bytes of
+ * input.
+ *
+ * This is not too bad for a non-cryptographic hash function, especially with
+ * only 64 bit outputs.
+ *
+ * The 128-bit variant (which trades some speed for strength) is NOT affected
+ * by this, although it is always a good idea to use a proper seed if you care
+ * about strength.
+ */
+XXH_FORCE_INLINE xxh_u64 XXH3_mix16B(const xxh_u8* XXH_RESTRICT input,
+                                     const xxh_u8* XXH_RESTRICT secret, xxh_u64 seed64)
+{
+#if defined(__GNUC__) && !defined(__clang__) /* GCC, not Clang */ \
+  && defined(__i386__) && defined(__SSE2__)  /* x86 + SSE2 */ \
+  && !defined(XXH_ENABLE_AUTOVECTORIZE)      /* Define to disable like XXH32 hack */
+    /*
+     * UGLY HACK:
+     * GCC for x86 tends to autovectorize the 128-bit multiply, resulting in
+     * slower code.
+     *
+     * By forcing seed64 into a register, we disrupt the cost model and
+     * cause it to scalarize. See `XXH32_round()`
+     *
+     * FIXME: Clang's output is still _much_ faster -- On an AMD Ryzen 3600,
+     * XXH3_64bits @ len=240 runs at 4.6 GB/s with Clang 9, but 3.3 GB/s on
+     * GCC 9.2, despite both emitting scalar code.
+     *
+     * GCC generates much better scalar code than Clang for the rest of XXH3,
+     * which is why finding a more optimal codepath is an interest.
+     */
+    XXH_COMPILER_GUARD(seed64);
+#endif
+    {   xxh_u64 const input_lo = XXH_readLE64(input);
+        xxh_u64 const input_hi = XXH_readLE64(input+8);
+        return XXH3_mul128_fold64(
+            input_lo ^ (XXH_readLE64(secret)   + seed64),
+            input_hi ^ (XXH_readLE64(secret+8) - seed64)
+        );
+    }
+}
+
+/* For mid range keys, XXH3 uses a Mum-hash variant. */
+XXH_FORCE_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_17to128_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
+                     const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                     XXH64_hash_t seed)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(16 < len && len <= 128);
+
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
+#if XXH_SIZE_OPT >= 1
+        /* Smaller and cleaner, but slightly slower. */
+        unsigned int i = (unsigned int)(len - 1) / 32;
+        do {
+            acc += XXH3_mix16B(input+16 * i, secret+32*i, seed);
+            acc += XXH3_mix16B(input+len-16*(i+1), secret+32*i+16, seed);
+        } while (i-- != 0);
+#else
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    acc += XXH3_mix16B(input+48, secret+96, seed);
+                    acc += XXH3_mix16B(input+len-64, secret+112, seed);
+                }
+                acc += XXH3_mix16B(input+32, secret+64, seed);
+                acc += XXH3_mix16B(input+len-48, secret+80, seed);
+            }
+            acc += XXH3_mix16B(input+16, secret+32, seed);
+            acc += XXH3_mix16B(input+len-32, secret+48, seed);
+        }
+        acc += XXH3_mix16B(input+0, secret+0, seed);
+        acc += XXH3_mix16B(input+len-16, secret+16, seed);
+#endif
+        return XXH3_avalanche(acc);
+    }
+}
+
+#define XXH3_MIDSIZE_MAX 240
+
+XXH_NO_INLINE XXH_PUREF XXH64_hash_t
+XXH3_len_129to240_64b(const xxh_u8* XXH_RESTRICT input, size_t len,
+                      const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                      XXH64_hash_t seed)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+    #define XXH3_MIDSIZE_STARTOFFSET 3
+    #define XXH3_MIDSIZE_LASTOFFSET  17
+
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
+        xxh_u64 acc_end;
+        unsigned int const nbRounds = (unsigned int)len / 16;
+        unsigned int i;
+        XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
+        for (i=0; i<8; i++) {
+            acc += XXH3_mix16B(input+(16*i), secret+(16*i), seed);
+        }
+        /* last bytes */
+        acc_end = XXH3_mix16B(input + len - 16, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+        XXH_ASSERT(nbRounds >= 8);
+        acc = XXH3_avalanche(acc);
+#if defined(__clang__)                                /* Clang */ \
+    && (defined(__ARM_NEON) || defined(__ARM_NEON__)) /* NEON */ \
+    && !defined(XXH_ENABLE_AUTOVECTORIZE)             /* Define to disable */
+        /*
+         * UGLY HACK:
+         * Clang for ARMv7-A tries to vectorize this loop, similar to GCC x86.
+         * In everywhere else, it uses scalar code.
+         *
+         * For 64->128-bit multiplies, even if the NEON was 100% optimal, it
+         * would still be slower than UMAAL (see XXH_mult64to128).
+         *
+         * Unfortunately, Clang doesn't handle the long multiplies properly and
+         * converts them to the nonexistent "vmulq_u64" intrinsic, which is then
+         * scalarized into an ugly mess of VMOV.32 instructions.
+         *
+         * This mess is difficult to avoid without turning autovectorization
+         * off completely, but they are usually relatively minor and/or not
+         * worth it to fix.
+         *
+         * This loop is the easiest to fix, as unlike XXH32, this pragma
+         * _actually works_ because it is a loop vectorization instead of an
+         * SLP vectorization.
+         */
+        #pragma clang loop vectorize(disable)
+#endif
+        for (i=8 ; i < nbRounds; i++) {
+            /*
+             * Prevents clang for unrolling the acc loop and interleaving with this one.
+             */
+            XXH_COMPILER_GUARD(acc);
+            acc_end += XXH3_mix16B(input+(16*i), secret+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
+        }
+        return XXH3_avalanche(acc + acc_end);
+    }
+}
+
+
+/* =======     Long Keys     ======= */
+
+#define XXH_STRIPE_LEN 64
+#define XXH_SECRET_CONSUME_RATE 8   /* nb of secret bytes consumed at each accumulation */
+#define XXH_ACC_NB (XXH_STRIPE_LEN / sizeof(xxh_u64))
+
+#ifdef XXH_OLD_NAMES
+#  define STRIPE_LEN XXH_STRIPE_LEN
+#  define ACC_NB XXH_ACC_NB
+#endif
+
+#ifndef XXH_PREFETCH_DIST
+#  ifdef __clang__
+#    define XXH_PREFETCH_DIST 320
+#  else
+#    if (XXH_VECTOR == XXH_AVX512)
+#      define XXH_PREFETCH_DIST 512
+#    else
+#      define XXH_PREFETCH_DIST 384
+#    endif
+#  endif  /* __clang__ */
+#endif  /* XXH_PREFETCH_DIST */
+
+/*
+ * These macros are to generate an XXH3_accumulate() function.
+ * The two arguments select the name suffix and target attribute.
+ *
+ * The name of this symbol is XXH3_accumulate_<name>() and it calls
+ * XXH3_accumulate_512_<name>().
+ *
+ * It may be useful to hand implement this function if the compiler fails to
+ * optimize the inline function.
+ */
+#define XXH3_ACCUMULATE_TEMPLATE(name)                      \
+void                                                        \
+XXH3_accumulate_##name(xxh_u64* XXH_RESTRICT acc,           \
+                       const xxh_u8* XXH_RESTRICT input,    \
+                       const xxh_u8* XXH_RESTRICT secret,   \
+                       size_t nbStripes)                    \
+{                                                           \
+    size_t n;                                               \
+    for (n = 0; n < nbStripes; n++ ) {                      \
+        const xxh_u8* const in = input + n*XXH_STRIPE_LEN;  \
+        XXH_PREFETCH(in + XXH_PREFETCH_DIST);               \
+        XXH3_accumulate_512_##name(                         \
+                 acc,                                       \
+                 in,                                        \
+                 secret + n*XXH_SECRET_CONSUME_RATE);       \
+    }                                                       \
+}
+
+
+XXH_FORCE_INLINE void XXH_writeLE64(void* dst, xxh_u64 v64)
+{
+    if (!XXH_CPU_LITTLE_ENDIAN) v64 = XXH_swap64(v64);
+    XXH_memcpy(dst, &v64, sizeof(v64));
+}
+
+/* Several intrinsic functions below are supposed to accept __int64 as argument,
+ * as documented in https://software.intel.com/sites/landingpage/IntrinsicsGuide/ .
+ * However, several environments do not define __int64 type,
+ * requiring a workaround.
+ */
+#if !defined (__VMS) \
+  && (defined (__cplusplus) \
+  || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+    typedef int64_t xxh_i64;
+#else
+    /* the following type must have a width of 64-bit */
+    typedef long long xxh_i64;
+#endif
+
+
+/*
+ * XXH3_accumulate_512 is the tightest loop for long inputs, and it is the most optimized.
+ *
+ * It is a hardened version of UMAC, based off of FARSH's implementation.
+ *
+ * This was chosen because it adapts quite well to 32-bit, 64-bit, and SIMD
+ * implementations, and it is ridiculously fast.
+ *
+ * We harden it by mixing the original input to the accumulators as well as the product.
+ *
+ * This means that in the (relatively likely) case of a multiply by zero, the
+ * original input is preserved.
+ *
+ * On 128-bit inputs, we swap 64-bit pairs when we add the input to improve
+ * cross-pollination, as otherwise the upper and lower halves would be
+ * essentially independent.
+ *
+ * This doesn't matter on 64-bit hashes since they all get merged together in
+ * the end, so we skip the extra step.
+ *
+ * Both XXH3_64bits and XXH3_128bits use this subroutine.
+ */
+
+#if (XXH_VECTOR == XXH_AVX512) \
+     || (defined(XXH_DISPATCH_AVX512) && XXH_DISPATCH_AVX512 != 0)
+
+#ifndef XXH_TARGET_AVX512
+# define XXH_TARGET_AVX512  /* disable attribute target */
+#endif
+
+XXH_FORCE_INLINE XXH_TARGET_AVX512 void
+XXH3_accumulate_512_avx512(void* XXH_RESTRICT acc,
+                     const void* XXH_RESTRICT input,
+                     const void* XXH_RESTRICT secret)
+{
+    __m512i* const xacc = (__m512i *) acc;
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+    XXH_STATIC_ASSERT(XXH_STRIPE_LEN == sizeof(__m512i));
+
+    {
+        /* data_vec    = input[0]; */
+        __m512i const data_vec    = _mm512_loadu_si512   (input);
+        /* key_vec     = secret[0]; */
+        __m512i const key_vec     = _mm512_loadu_si512   (secret);
+        /* data_key    = data_vec ^ key_vec; */
+        __m512i const data_key    = _mm512_xor_si512     (data_vec, key_vec);
+        /* data_key_lo = data_key >> 32; */
+        __m512i const data_key_lo = _mm512_srli_epi64 (data_key, 32);
+        /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+        __m512i const product     = _mm512_mul_epu32     (data_key, data_key_lo);
+        /* xacc[0] += swap(data_vec); */
+        __m512i const data_swap = _mm512_shuffle_epi32(data_vec, (_MM_PERM_ENUM)_MM_SHUFFLE(1, 0, 3, 2));
+        __m512i const sum       = _mm512_add_epi64(*xacc, data_swap);
+        /* xacc[0] += product; */
+        *xacc = _mm512_add_epi64(product, sum);
+    }
+}
+XXH_FORCE_INLINE XXH_TARGET_AVX512 XXH3_ACCUMULATE_TEMPLATE(avx512)
+
+/*
+ * XXH3_scrambleAcc: Scrambles the accumulators to improve mixing.
+ *
+ * Multiplication isn't perfect, as explained by Google in HighwayHash:
+ *
+ *  // Multiplication mixes/scrambles bytes 0-7 of the 64-bit result to
+ *  // varying degrees. In descending order of goodness, bytes
+ *  // 3 4 2 5 1 6 0 7 have quality 228 224 164 160 100 96 36 32.
+ *  // As expected, the upper and lower bytes are much worse.
+ *
+ * Source: https://github.com/google/highwayhash/blob/0aaf66b/highwayhash/hh_avx2.h#L291
+ *
+ * Since our algorithm uses a pseudorandom secret to add some variance into the
+ * mix, we don't need to (or want to) mix as often or as much as HighwayHash does.
+ *
+ * This isn't as tight as XXH3_accumulate, but still written in SIMD to avoid
+ * extraction.
+ *
+ * Both XXH3_64bits and XXH3_128bits use this subroutine.
+ */
+
+XXH_FORCE_INLINE XXH_TARGET_AVX512 void
+XXH3_scrambleAcc_avx512(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 63) == 0);
+    XXH_STATIC_ASSERT(XXH_STRIPE_LEN == sizeof(__m512i));
+    {   __m512i* const xacc = (__m512i*) acc;
+        const __m512i prime32 = _mm512_set1_epi32((int)XXH_PRIME32_1);
+
+        /* xacc[0] ^= (xacc[0] >> 47) */
+        __m512i const acc_vec     = *xacc;
+        __m512i const shifted     = _mm512_srli_epi64    (acc_vec, 47);
+        /* xacc[0] ^= secret; */
+        __m512i const key_vec     = _mm512_loadu_si512   (secret);
+        __m512i const data_key    = _mm512_ternarylogic_epi32(key_vec, acc_vec, shifted, 0x96 /* key_vec ^ acc_vec ^ shifted */);
+
+        /* xacc[0] *= XXH_PRIME32_1; */
+        __m512i const data_key_hi = _mm512_srli_epi64 (data_key, 32);
+        __m512i const prod_lo     = _mm512_mul_epu32     (data_key, prime32);
+        __m512i const prod_hi     = _mm512_mul_epu32     (data_key_hi, prime32);
+        *xacc = _mm512_add_epi64(prod_lo, _mm512_slli_epi64(prod_hi, 32));
+    }
+}
+
+XXH_FORCE_INLINE XXH_TARGET_AVX512 void
+XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
+{
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 63) == 0);
+    XXH_STATIC_ASSERT(XXH_SEC_ALIGN == 64);
+    XXH_ASSERT(((size_t)customSecret & 63) == 0);
+    (void)(&XXH_writeLE64);
+    {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m512i);
+        __m512i const seed_pos = _mm512_set1_epi64((xxh_i64)seed64);
+        __m512i const seed     = _mm512_mask_sub_epi64(seed_pos, 0xAA, _mm512_set1_epi8(0), seed_pos);
+
+        const __m512i* const src  = (const __m512i*) ((const void*) XXH3_kSecret);
+              __m512i* const dest = (      __m512i*) customSecret;
+        int i;
+        XXH_ASSERT(((size_t)src & 63) == 0); /* control alignment */
+        XXH_ASSERT(((size_t)dest & 63) == 0);
+        for (i=0; i < nbRounds; ++i) {
+            dest[i] = _mm512_add_epi64(_mm512_load_si512(src + i), seed);
+    }   }
+}
+
+#endif
+
+#if (XXH_VECTOR == XXH_AVX2) \
+    || (defined(XXH_DISPATCH_AVX2) && XXH_DISPATCH_AVX2 != 0)
+
+#ifndef XXH_TARGET_AVX2
+# define XXH_TARGET_AVX2  /* disable attribute target */
+#endif
+
+XXH_FORCE_INLINE XXH_TARGET_AVX2 void
+XXH3_accumulate_512_avx2( void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 31) == 0);
+    {   __m256i* const xacc    =       (__m256i *) acc;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm256_loadu_si256 requires  a const __m256i * pointer for some reason. */
+        const         __m256i* const xinput  = (const __m256i *) input;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm256_loadu_si256 requires a const __m256i * pointer for some reason. */
+        const         __m256i* const xsecret = (const __m256i *) secret;
+
+        size_t i;
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m256i); i++) {
+            /* data_vec    = xinput[i]; */
+            __m256i const data_vec    = _mm256_loadu_si256    (xinput+i);
+            /* key_vec     = xsecret[i]; */
+            __m256i const key_vec     = _mm256_loadu_si256   (xsecret+i);
+            /* data_key    = data_vec ^ key_vec; */
+            __m256i const data_key    = _mm256_xor_si256     (data_vec, key_vec);
+            /* data_key_lo = data_key >> 32; */
+            __m256i const data_key_lo = _mm256_srli_epi64 (data_key, 32);
+            /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+            __m256i const product     = _mm256_mul_epu32     (data_key, data_key_lo);
+            /* xacc[i] += swap(data_vec); */
+            __m256i const data_swap = _mm256_shuffle_epi32(data_vec, _MM_SHUFFLE(1, 0, 3, 2));
+            __m256i const sum       = _mm256_add_epi64(xacc[i], data_swap);
+            /* xacc[i] += product; */
+            xacc[i] = _mm256_add_epi64(product, sum);
+    }   }
+}
+XXH_FORCE_INLINE XXH_TARGET_AVX2 XXH3_ACCUMULATE_TEMPLATE(avx2)
+
+XXH_FORCE_INLINE XXH_TARGET_AVX2 void
+XXH3_scrambleAcc_avx2(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 31) == 0);
+    {   __m256i* const xacc = (__m256i*) acc;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm256_loadu_si256 requires a const __m256i * pointer for some reason. */
+        const         __m256i* const xsecret = (const __m256i *) secret;
+        const __m256i prime32 = _mm256_set1_epi32((int)XXH_PRIME32_1);
+
+        size_t i;
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m256i); i++) {
+            /* xacc[i] ^= (xacc[i] >> 47) */
+            __m256i const acc_vec     = xacc[i];
+            __m256i const shifted     = _mm256_srli_epi64    (acc_vec, 47);
+            __m256i const data_vec    = _mm256_xor_si256     (acc_vec, shifted);
+            /* xacc[i] ^= xsecret; */
+            __m256i const key_vec     = _mm256_loadu_si256   (xsecret+i);
+            __m256i const data_key    = _mm256_xor_si256     (data_vec, key_vec);
+
+            /* xacc[i] *= XXH_PRIME32_1; */
+            __m256i const data_key_hi = _mm256_srli_epi64 (data_key, 32);
+            __m256i const prod_lo     = _mm256_mul_epu32     (data_key, prime32);
+            __m256i const prod_hi     = _mm256_mul_epu32     (data_key_hi, prime32);
+            xacc[i] = _mm256_add_epi64(prod_lo, _mm256_slli_epi64(prod_hi, 32));
+        }
+    }
+}
+
+XXH_FORCE_INLINE XXH_TARGET_AVX2 void XXH3_initCustomSecret_avx2(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
+{
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 31) == 0);
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE / sizeof(__m256i)) == 6);
+    XXH_STATIC_ASSERT(XXH_SEC_ALIGN <= 64);
+    (void)(&XXH_writeLE64);
+    XXH_PREFETCH(customSecret);
+    {   __m256i const seed = _mm256_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64, (xxh_i64)(0U - seed64), (xxh_i64)seed64);
+
+        const __m256i* const src  = (const __m256i*) ((const void*) XXH3_kSecret);
+              __m256i*       dest = (      __m256i*) customSecret;
+
+#       if defined(__GNUC__) || defined(__clang__)
+        /*
+         * On GCC & Clang, marking 'dest' as modified will cause the compiler:
+         *   - do not extract the secret from sse registers in the internal loop
+         *   - use less common registers, and avoid pushing these reg into stack
+         */
+        XXH_COMPILER_GUARD(dest);
+#       endif
+        XXH_ASSERT(((size_t)src & 31) == 0); /* control alignment */
+        XXH_ASSERT(((size_t)dest & 31) == 0);
+
+        /* GCC -O2 need unroll loop manually */
+        dest[0] = _mm256_add_epi64(_mm256_load_si256(src+0), seed);
+        dest[1] = _mm256_add_epi64(_mm256_load_si256(src+1), seed);
+        dest[2] = _mm256_add_epi64(_mm256_load_si256(src+2), seed);
+        dest[3] = _mm256_add_epi64(_mm256_load_si256(src+3), seed);
+        dest[4] = _mm256_add_epi64(_mm256_load_si256(src+4), seed);
+        dest[5] = _mm256_add_epi64(_mm256_load_si256(src+5), seed);
+    }
+}
+
+#endif
+
+/* x86dispatch always generates SSE2 */
+#if (XXH_VECTOR == XXH_SSE2) || defined(XXH_X86DISPATCH)
+
+#ifndef XXH_TARGET_SSE2
+# define XXH_TARGET_SSE2  /* disable attribute target */
+#endif
+
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void
+XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    /* SSE2 is just a half-scale version of the AVX2 version. */
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {   __m128i* const xacc    =       (__m128i *) acc;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm_loadu_si128 requires a const __m128i * pointer for some reason. */
+        const         __m128i* const xinput  = (const __m128i *) input;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm_loadu_si128 requires a const __m128i * pointer for some reason. */
+        const         __m128i* const xsecret = (const __m128i *) secret;
+
+        size_t i;
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m128i); i++) {
+            /* data_vec    = xinput[i]; */
+            __m128i const data_vec    = _mm_loadu_si128   (xinput+i);
+            /* key_vec     = xsecret[i]; */
+            __m128i const key_vec     = _mm_loadu_si128   (xsecret+i);
+            /* data_key    = data_vec ^ key_vec; */
+            __m128i const data_key    = _mm_xor_si128     (data_vec, key_vec);
+            /* data_key_lo = data_key >> 32; */
+            __m128i const data_key_lo = _mm_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
+            /* product     = (data_key & 0xffffffff) * (data_key_lo & 0xffffffff); */
+            __m128i const product     = _mm_mul_epu32     (data_key, data_key_lo);
+            /* xacc[i] += swap(data_vec); */
+            __m128i const data_swap = _mm_shuffle_epi32(data_vec, _MM_SHUFFLE(1,0,3,2));
+            __m128i const sum       = _mm_add_epi64(xacc[i], data_swap);
+            /* xacc[i] += product; */
+            xacc[i] = _mm_add_epi64(product, sum);
+    }   }
+}
+XXH_FORCE_INLINE XXH_TARGET_SSE2 XXH3_ACCUMULATE_TEMPLATE(sse2)
+
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void
+XXH3_scrambleAcc_sse2(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    {   __m128i* const xacc = (__m128i*) acc;
+        /* Unaligned. This is mainly for pointer arithmetic, and because
+         * _mm_loadu_si128 requires a const __m128i * pointer for some reason. */
+        const         __m128i* const xsecret = (const __m128i *) secret;
+        const __m128i prime32 = _mm_set1_epi32((int)XXH_PRIME32_1);
+
+        size_t i;
+        for (i=0; i < XXH_STRIPE_LEN/sizeof(__m128i); i++) {
+            /* xacc[i] ^= (xacc[i] >> 47) */
+            __m128i const acc_vec     = xacc[i];
+            __m128i const shifted     = _mm_srli_epi64    (acc_vec, 47);
+            __m128i const data_vec    = _mm_xor_si128     (acc_vec, shifted);
+            /* xacc[i] ^= xsecret[i]; */
+            __m128i const key_vec     = _mm_loadu_si128   (xsecret+i);
+            __m128i const data_key    = _mm_xor_si128     (data_vec, key_vec);
+
+            /* xacc[i] *= XXH_PRIME32_1; */
+            __m128i const data_key_hi = _mm_shuffle_epi32 (data_key, _MM_SHUFFLE(0, 3, 0, 1));
+            __m128i const prod_lo     = _mm_mul_epu32     (data_key, prime32);
+            __m128i const prod_hi     = _mm_mul_epu32     (data_key_hi, prime32);
+            xacc[i] = _mm_add_epi64(prod_lo, _mm_slli_epi64(prod_hi, 32));
+        }
+    }
+}
+
+XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
+{
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
+    (void)(&XXH_writeLE64);
+    {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m128i);
+
+#       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
+        /* MSVC 32bit mode does not support _mm_set_epi64x before 2015 */
+        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
+        __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
+#       else
+        __m128i const seed = _mm_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64);
+#       endif
+        int i;
+
+        const void* const src16 = XXH3_kSecret;
+        __m128i* dst16 = (__m128i*) customSecret;
+#       if defined(__GNUC__) || defined(__clang__)
+        /*
+         * On GCC & Clang, marking 'dest' as modified will cause the compiler:
+         *   - do not extract the secret from sse registers in the internal loop
+         *   - use less common registers, and avoid pushing these reg into stack
+         */
+        XXH_COMPILER_GUARD(dst16);
+#       endif
+        XXH_ASSERT(((size_t)src16 & 15) == 0); /* control alignment */
+        XXH_ASSERT(((size_t)dst16 & 15) == 0);
+
+        for (i=0; i < nbRounds; ++i) {
+            dst16[i] = _mm_add_epi64(_mm_load_si128((const __m128i *)src16+i), seed);
+    }   }
+}
+
+#endif
+
+#if (XXH_VECTOR == XXH_NEON)
+
+/* forward declarations for the scalar routines */
+XXH_FORCE_INLINE void
+XXH3_scalarRound(void* XXH_RESTRICT acc, void const* XXH_RESTRICT input,
+                 void const* XXH_RESTRICT secret, size_t lane);
+
+XXH_FORCE_INLINE void
+XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
+                         void const* XXH_RESTRICT secret, size_t lane);
+
+/*!
+ * @internal
+ * @brief The bulk processing loop for NEON and WASM SIMD128.
+ *
+ * The NEON code path is actually partially scalar when running on AArch64. This
+ * is to optimize the pipelining and can have up to 15% speedup depending on the
+ * CPU, and it also mitigates some GCC codegen issues.
+ *
+ * @see XXH3_NEON_LANES for configuring this and details about this optimization.
+ *
+ * NEON's 32-bit to 64-bit long multiply takes a half vector of 32-bit
+ * integers instead of the other platforms which mask full 64-bit vectors,
+ * so the setup is more complicated than just shifting right.
+ *
+ * Additionally, there is an optimization for 4 lanes at once noted below.
+ *
+ * Since, as stated, the most optimal amount of lanes for Cortexes is 6,
+ * there needs to be *three* versions of the accumulate operation used
+ * for the remaining 2 lanes.
+ *
+ * WASM's SIMD128 uses SIMDe's arm_neon.h polyfill because the intrinsics overlap
+ * nearly perfectly.
+ */
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+    XXH_STATIC_ASSERT(XXH3_NEON_LANES > 0 && XXH3_NEON_LANES <= XXH_ACC_NB && XXH3_NEON_LANES % 2 == 0);
+    {   /* GCC for darwin arm64 does not like aliasing here */
+        xxh_aliasing_uint64x2_t* const xacc = (xxh_aliasing_uint64x2_t*) acc;
+        /* We don't use a uint32x4_t pointer because it causes bus errors on ARMv7. */
+        uint8_t const* xinput = (const uint8_t *) input;
+        uint8_t const* xsecret  = (const uint8_t *) secret;
+
+        size_t i;
+#ifdef __wasm_simd128__
+        /*
+         * On WASM SIMD128, Clang emits direct address loads when XXH3_kSecret
+         * is constant propagated, which results in it converting it to this
+         * inside the loop:
+         *
+         *    a = v128.load(XXH3_kSecret +  0 + $secret_offset, offset = 0)
+         *    b = v128.load(XXH3_kSecret + 16 + $secret_offset, offset = 0)
+         *    ...
+         *
+         * This requires a full 32-bit address immediate (and therefore a 6 byte
+         * instruction) as well as an add for each offset.
+         *
+         * Putting an asm guard prevents it from folding (at the cost of losing
+         * the alignment hint), and uses the free offset in `v128.load` instead
+         * of adding secret_offset each time which overall reduces code size by
+         * about a kilobyte and improves performance.
+         */
+        XXH_COMPILER_GUARD(xsecret);
+#endif
+        /* Scalar lanes use the normal scalarRound routine */
+        for (i = XXH3_NEON_LANES; i < XXH_ACC_NB; i++) {
+            XXH3_scalarRound(acc, input, secret, i);
+        }
+        i = 0;
+        /* 4 NEON lanes at a time. */
+        for (; i+1 < XXH3_NEON_LANES / 2; i+=2) {
+            /* data_vec = xinput[i]; */
+            uint64x2_t data_vec_1 = XXH_vld1q_u64(xinput  + (i * 16));
+            uint64x2_t data_vec_2 = XXH_vld1q_u64(xinput  + ((i+1) * 16));
+            /* key_vec  = xsecret[i];  */
+            uint64x2_t key_vec_1  = XXH_vld1q_u64(xsecret + (i * 16));
+            uint64x2_t key_vec_2  = XXH_vld1q_u64(xsecret + ((i+1) * 16));
+            /* data_swap = swap(data_vec) */
+            uint64x2_t data_swap_1 = vextq_u64(data_vec_1, data_vec_1, 1);
+            uint64x2_t data_swap_2 = vextq_u64(data_vec_2, data_vec_2, 1);
+            /* data_key = data_vec ^ key_vec; */
+            uint64x2_t data_key_1 = veorq_u64(data_vec_1, key_vec_1);
+            uint64x2_t data_key_2 = veorq_u64(data_vec_2, key_vec_2);
+
+            /*
+             * If we reinterpret the 64x2 vectors as 32x4 vectors, we can use a
+             * de-interleave operation for 4 lanes in 1 step with `vuzpq_u32` to
+             * get one vector with the low 32 bits of each lane, and one vector
+             * with the high 32 bits of each lane.
+             *
+             * The intrinsic returns a double vector because the original ARMv7-a
+             * instruction modified both arguments in place. AArch64 and SIMD128 emit
+             * two instructions from this intrinsic.
+             *
+             *  [ dk11L | dk11H | dk12L | dk12H ] -> [ dk11L | dk12L | dk21L | dk22L ]
+             *  [ dk21L | dk21H | dk22L | dk22H ] -> [ dk11H | dk12H | dk21H | dk22H ]
+             */
+            uint32x4x2_t unzipped = vuzpq_u32(
+                vreinterpretq_u32_u64(data_key_1),
+                vreinterpretq_u32_u64(data_key_2)
+            );
+            /* data_key_lo = data_key & 0xFFFFFFFF */
+            uint32x4_t data_key_lo = unzipped.val[0];
+            /* data_key_hi = data_key >> 32 */
+            uint32x4_t data_key_hi = unzipped.val[1];
+            /*
+             * Then, we can split the vectors horizontally and multiply which, as for most
+             * widening intrinsics, have a variant that works on both high half vectors
+             * for free on AArch64. A similar instruction is available on SIMD128.
+             *
+             * sum = data_swap + (u64x2) data_key_lo * (u64x2) data_key_hi
+             */
+            uint64x2_t sum_1 = XXH_vmlal_low_u32(data_swap_1, data_key_lo, data_key_hi);
+            uint64x2_t sum_2 = XXH_vmlal_high_u32(data_swap_2, data_key_lo, data_key_hi);
+            /*
+             * Clang reorders
+             *    a += b * c;     // umlal   swap.2d, dkl.2s, dkh.2s
+             *    c += a;         // add     acc.2d, acc.2d, swap.2d
+             * to
+             *    c += a;         // add     acc.2d, acc.2d, swap.2d
+             *    c += b * c;     // umlal   acc.2d, dkl.2s, dkh.2s
+             *
+             * While it would make sense in theory since the addition is faster,
+             * for reasons likely related to umlal being limited to certain NEON
+             * pipelines, this is worse. A compiler guard fixes this.
+             */
+            XXH_COMPILER_GUARD_CLANG_NEON(sum_1);
+            XXH_COMPILER_GUARD_CLANG_NEON(sum_2);
+            /* xacc[i] = acc_vec + sum; */
+            xacc[i]   = vaddq_u64(xacc[i], sum_1);
+            xacc[i+1] = vaddq_u64(xacc[i+1], sum_2);
+        }
+        /* Operate on the remaining NEON lanes 2 at a time. */
+        for (; i < XXH3_NEON_LANES / 2; i++) {
+            /* data_vec = xinput[i]; */
+            uint64x2_t data_vec = XXH_vld1q_u64(xinput  + (i * 16));
+            /* key_vec  = xsecret[i];  */
+            uint64x2_t key_vec  = XXH_vld1q_u64(xsecret + (i * 16));
+            /* acc_vec_2 = swap(data_vec) */
+            uint64x2_t data_swap = vextq_u64(data_vec, data_vec, 1);
+            /* data_key = data_vec ^ key_vec; */
+            uint64x2_t data_key = veorq_u64(data_vec, key_vec);
+            /* For two lanes, just use VMOVN and VSHRN. */
+            /* data_key_lo = data_key & 0xFFFFFFFF; */
+            uint32x2_t data_key_lo = vmovn_u64(data_key);
+            /* data_key_hi = data_key >> 32; */
+            uint32x2_t data_key_hi = vshrn_n_u64(data_key, 32);
+            /* sum = data_swap + (u64x2) data_key_lo * (u64x2) data_key_hi; */
+            uint64x2_t sum = vmlal_u32(data_swap, data_key_lo, data_key_hi);
+            /* Same Clang workaround as before */
+            XXH_COMPILER_GUARD_CLANG_NEON(sum);
+            /* xacc[i] = acc_vec + sum; */
+            xacc[i] = vaddq_u64 (xacc[i], sum);
+        }
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(neon)
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_neon(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+
+    {   xxh_aliasing_uint64x2_t* xacc       = (xxh_aliasing_uint64x2_t*) acc;
+        uint8_t const* xsecret = (uint8_t const*) secret;
+
+        size_t i;
+        /* WASM uses operator overloads and doesn't need these. */
+#ifndef __wasm_simd128__
+        /* { prime32_1, prime32_1 } */
+        uint32x2_t const kPrimeLo = vdup_n_u32(XXH_PRIME32_1);
+        /* { 0, prime32_1, 0, prime32_1 } */
+        uint32x4_t const kPrimeHi = vreinterpretq_u32_u64(vdupq_n_u64((xxh_u64)XXH_PRIME32_1 << 32));
+#endif
+
+        /* AArch64 uses both scalar and neon at the same time */
+        for (i = XXH3_NEON_LANES; i < XXH_ACC_NB; i++) {
+            XXH3_scalarScrambleRound(acc, secret, i);
+        }
+        for (i=0; i < XXH3_NEON_LANES / 2; i++) {
+            /* xacc[i] ^= (xacc[i] >> 47); */
+            uint64x2_t acc_vec  = xacc[i];
+            uint64x2_t shifted  = vshrq_n_u64(acc_vec, 47);
+            uint64x2_t data_vec = veorq_u64(acc_vec, shifted);
+
+            /* xacc[i] ^= xsecret[i]; */
+            uint64x2_t key_vec  = XXH_vld1q_u64(xsecret + (i * 16));
+            uint64x2_t data_key = veorq_u64(data_vec, key_vec);
+            /* xacc[i] *= XXH_PRIME32_1 */
+#ifdef __wasm_simd128__
+            /* SIMD128 has multiply by u64x2, use it instead of expanding and scalarizing */
+            xacc[i] = data_key * XXH_PRIME32_1;
+#else
+            /*
+             * Expanded version with portable NEON intrinsics
+             *
+             *    lo(x) * lo(y) + (hi(x) * lo(y) << 32)
+             *
+             * prod_hi = hi(data_key) * lo(prime) << 32
+             *
+             * Since we only need 32 bits of this multiply a trick can be used, reinterpreting the vector
+             * as a uint32x4_t and multiplying by { 0, prime, 0, prime } to cancel out the unwanted bits
+             * and avoid the shift.
+             */
+            uint32x4_t prod_hi = vmulq_u32 (vreinterpretq_u32_u64(data_key), kPrimeHi);
+            /* Extract low bits for vmlal_u32  */
+            uint32x2_t data_key_lo = vmovn_u64(data_key);
+            /* xacc[i] = prod_hi + lo(data_key) * XXH_PRIME32_1; */
+            xacc[i] = vmlal_u32(vreinterpretq_u64_u32(prod_hi), data_key_lo, kPrimeLo);
+#endif
+        }
+    }
+}
+#endif
+
+#if (XXH_VECTOR == XXH_VSX)
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_vsx(  void* XXH_RESTRICT acc,
+                    const void* XXH_RESTRICT input,
+                    const void* XXH_RESTRICT secret)
+{
+    /* presumed aligned */
+    xxh_aliasing_u64x2* const xacc = (xxh_aliasing_u64x2*) acc;
+    xxh_u8 const* const xinput   = (xxh_u8 const*) input;   /* no alignment restriction */
+    xxh_u8 const* const xsecret  = (xxh_u8 const*) secret;    /* no alignment restriction */
+    xxh_u64x2 const v32 = { 32, 32 };
+    size_t i;
+    for (i = 0; i < XXH_STRIPE_LEN / sizeof(xxh_u64x2); i++) {
+        /* data_vec = xinput[i]; */
+        xxh_u64x2 const data_vec = XXH_vec_loadu(xinput + 16*i);
+        /* key_vec = xsecret[i]; */
+        xxh_u64x2 const key_vec  = XXH_vec_loadu(xsecret + 16*i);
+        xxh_u64x2 const data_key = data_vec ^ key_vec;
+        /* shuffled = (data_key << 32) | (data_key >> 32); */
+        xxh_u32x4 const shuffled = (xxh_u32x4)vec_rl(data_key, v32);
+        /* product = ((xxh_u64x2)data_key & 0xFFFFFFFF) * ((xxh_u64x2)shuffled & 0xFFFFFFFF); */
+        xxh_u64x2 const product  = XXH_vec_mulo((xxh_u32x4)data_key, shuffled);
+        /* acc_vec = xacc[i]; */
+        xxh_u64x2 acc_vec        = xacc[i];
+        acc_vec += product;
+
+        /* swap high and low halves */
+#ifdef __s390x__
+        acc_vec += vec_permi(data_vec, data_vec, 2);
+#else
+        acc_vec += vec_xxpermdi(data_vec, data_vec, 2);
+#endif
+        xacc[i] = acc_vec;
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(vsx)
+
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_vsx(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    XXH_ASSERT((((size_t)acc) & 15) == 0);
+
+    {   xxh_aliasing_u64x2* const xacc = (xxh_aliasing_u64x2*) acc;
+        const xxh_u8* const xsecret = (const xxh_u8*) secret;
+        /* constants */
+        xxh_u64x2 const v32  = { 32, 32 };
+        xxh_u64x2 const v47 = { 47, 47 };
+        xxh_u32x4 const prime = { XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1, XXH_PRIME32_1 };
+        size_t i;
+        for (i = 0; i < XXH_STRIPE_LEN / sizeof(xxh_u64x2); i++) {
+            /* xacc[i] ^= (xacc[i] >> 47); */
+            xxh_u64x2 const acc_vec  = xacc[i];
+            xxh_u64x2 const data_vec = acc_vec ^ (acc_vec >> v47);
+
+            /* xacc[i] ^= xsecret[i]; */
+            xxh_u64x2 const key_vec  = XXH_vec_loadu(xsecret + 16*i);
+            xxh_u64x2 const data_key = data_vec ^ key_vec;
+
+            /* xacc[i] *= XXH_PRIME32_1 */
+            /* prod_lo = ((xxh_u64x2)data_key & 0xFFFFFFFF) * ((xxh_u64x2)prime & 0xFFFFFFFF);  */
+            xxh_u64x2 const prod_even  = XXH_vec_mule((xxh_u32x4)data_key, prime);
+            /* prod_hi = ((xxh_u64x2)data_key >> 32) * ((xxh_u64x2)prime >> 32);  */
+            xxh_u64x2 const prod_odd  = XXH_vec_mulo((xxh_u32x4)data_key, prime);
+            xacc[i] = prod_odd + (prod_even << v32);
+    }   }
+}
+
+#endif
+
+#if (XXH_VECTOR == XXH_SVE)
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_sve( void* XXH_RESTRICT acc,
+                   const void* XXH_RESTRICT input,
+                   const void* XXH_RESTRICT secret)
+{
+    uint64_t *xacc = (uint64_t *)acc;
+    const uint64_t *xinput = (const uint64_t *)(const void *)input;
+    const uint64_t *xsecret = (const uint64_t *)(const void *)secret;
+    svuint64_t kSwap = sveor_n_u64_z(svptrue_b64(), svindex_u64(0, 1), 1);
+    uint64_t element_count = svcntd();
+    if (element_count >= 8) {
+        svbool_t mask = svptrue_pat_b64(SV_VL8);
+        svuint64_t vacc = svld1_u64(mask, xacc);
+        ACCRND(vacc, 0);
+        svst1_u64(mask, xacc, vacc);
+    } else if (element_count == 2) {   /* sve128 */
+        svbool_t mask = svptrue_pat_b64(SV_VL2);
+        svuint64_t acc0 = svld1_u64(mask, xacc + 0);
+        svuint64_t acc1 = svld1_u64(mask, xacc + 2);
+        svuint64_t acc2 = svld1_u64(mask, xacc + 4);
+        svuint64_t acc3 = svld1_u64(mask, xacc + 6);
+        ACCRND(acc0, 0);
+        ACCRND(acc1, 2);
+        ACCRND(acc2, 4);
+        ACCRND(acc3, 6);
+        svst1_u64(mask, xacc + 0, acc0);
+        svst1_u64(mask, xacc + 2, acc1);
+        svst1_u64(mask, xacc + 4, acc2);
+        svst1_u64(mask, xacc + 6, acc3);
+    } else {
+        svbool_t mask = svptrue_pat_b64(SV_VL4);
+        svuint64_t acc0 = svld1_u64(mask, xacc + 0);
+        svuint64_t acc1 = svld1_u64(mask, xacc + 4);
+        ACCRND(acc0, 0);
+        ACCRND(acc1, 4);
+        svst1_u64(mask, xacc + 0, acc0);
+        svst1_u64(mask, xacc + 4, acc1);
+    }
+}
+
+XXH_FORCE_INLINE void
+XXH3_accumulate_sve(xxh_u64* XXH_RESTRICT acc,
+               const xxh_u8* XXH_RESTRICT input,
+               const xxh_u8* XXH_RESTRICT secret,
+               size_t nbStripes)
+{
+    if (nbStripes != 0) {
+        uint64_t *xacc = (uint64_t *)acc;
+        const uint64_t *xinput = (const uint64_t *)(const void *)input;
+        const uint64_t *xsecret = (const uint64_t *)(const void *)secret;
+        svuint64_t kSwap = sveor_n_u64_z(svptrue_b64(), svindex_u64(0, 1), 1);
+        uint64_t element_count = svcntd();
+        if (element_count >= 8) {
+            svbool_t mask = svptrue_pat_b64(SV_VL8);
+            svuint64_t vacc = svld1_u64(mask, xacc + 0);
+            do {
+                /* svprfd(svbool_t, void *, enum svfprop); */
+                svprfd(mask, xinput + 128, SV_PLDL1STRM);
+                ACCRND(vacc, 0);
+                xinput += 8;
+                xsecret += 1;
+                nbStripes--;
+           } while (nbStripes != 0);
+
+           svst1_u64(mask, xacc + 0, vacc);
+        } else if (element_count == 2) { /* sve128 */
+            svbool_t mask = svptrue_pat_b64(SV_VL2);
+            svuint64_t acc0 = svld1_u64(mask, xacc + 0);
+            svuint64_t acc1 = svld1_u64(mask, xacc + 2);
+            svuint64_t acc2 = svld1_u64(mask, xacc + 4);
+            svuint64_t acc3 = svld1_u64(mask, xacc + 6);
+            do {
+                svprfd(mask, xinput + 128, SV_PLDL1STRM);
+                ACCRND(acc0, 0);
+                ACCRND(acc1, 2);
+                ACCRND(acc2, 4);
+                ACCRND(acc3, 6);
+                xinput += 8;
+                xsecret += 1;
+                nbStripes--;
+           } while (nbStripes != 0);
+
+           svst1_u64(mask, xacc + 0, acc0);
+           svst1_u64(mask, xacc + 2, acc1);
+           svst1_u64(mask, xacc + 4, acc2);
+           svst1_u64(mask, xacc + 6, acc3);
+        } else {
+            svbool_t mask = svptrue_pat_b64(SV_VL4);
+            svuint64_t acc0 = svld1_u64(mask, xacc + 0);
+            svuint64_t acc1 = svld1_u64(mask, xacc + 4);
+            do {
+                svprfd(mask, xinput + 128, SV_PLDL1STRM);
+                ACCRND(acc0, 0);
+                ACCRND(acc1, 4);
+                xinput += 8;
+                xsecret += 1;
+                nbStripes--;
+           } while (nbStripes != 0);
+
+           svst1_u64(mask, xacc + 0, acc0);
+           svst1_u64(mask, xacc + 4, acc1);
+       }
+    }
+}
+
+#endif
+
+/* scalar variants - universal */
+
+#if defined(__aarch64__) && (defined(__GNUC__) || defined(__clang__))
+/*
+ * In XXH3_scalarRound(), GCC and Clang have a similar codegen issue, where they
+ * emit an excess mask and a full 64-bit multiply-add (MADD X-form).
+ *
+ * While this might not seem like much, as AArch64 is a 64-bit architecture, only
+ * big Cortex designs have a full 64-bit multiplier.
+ *
+ * On the little cores, the smaller 32-bit multiplier is used, and full 64-bit
+ * multiplies expand to 2-3 multiplies in microcode. This has a major penalty
+ * of up to 4 latency cycles and 2 stall cycles in the multiply pipeline.
+ *
+ * Thankfully, AArch64 still provides the 32-bit long multiply-add (UMADDL) which does
+ * not have this penalty and does the mask automatically.
+ */
+XXH_FORCE_INLINE xxh_u64
+XXH_mult32to64_add64(xxh_u64 lhs, xxh_u64 rhs, xxh_u64 acc)
+{
+    xxh_u64 ret;
+    /* note: %x = 64-bit register, %w = 32-bit register */
+    __asm__("umaddl %x0, %w1, %w2, %x3" : "=r" (ret) : "r" (lhs), "r" (rhs), "r" (acc));
+    return ret;
+}
+#else
+XXH_FORCE_INLINE xxh_u64
+XXH_mult32to64_add64(xxh_u64 lhs, xxh_u64 rhs, xxh_u64 acc)
+{
+    return XXH_mult32to64((xxh_u32)lhs, (xxh_u32)rhs) + acc;
+}
+#endif
+
+/*!
+ * @internal
+ * @brief Scalar round for @ref XXH3_accumulate_512_scalar().
+ *
+ * This is extracted to its own function because the NEON path uses a combination
+ * of NEON and scalar.
+ */
+XXH_FORCE_INLINE void
+XXH3_scalarRound(void* XXH_RESTRICT acc,
+                 void const* XXH_RESTRICT input,
+                 void const* XXH_RESTRICT secret,
+                 size_t lane)
+{
+    xxh_u64* xacc = (xxh_u64*) acc;
+    xxh_u8 const* xinput  = (xxh_u8 const*) input;
+    xxh_u8 const* xsecret = (xxh_u8 const*) secret;
+    XXH_ASSERT(lane < XXH_ACC_NB);
+    XXH_ASSERT(((size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
+    {
+        xxh_u64 const data_val = XXH_readLE64(xinput + lane * 8);
+        xxh_u64 const data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
+        xacc[lane ^ 1] += data_val; /* swap adjacent lanes */
+        xacc[lane] = XXH_mult32to64_add64(data_key /* & 0xFFFFFFFF */, data_key >> 32, xacc[lane]);
+    }
+}
+
+/*!
+ * @internal
+ * @brief Processes a 64 byte block of data using the scalar path.
+ */
+XXH_FORCE_INLINE void
+XXH3_accumulate_512_scalar(void* XXH_RESTRICT acc,
+                     const void* XXH_RESTRICT input,
+                     const void* XXH_RESTRICT secret)
+{
+    size_t i;
+    /* ARM GCC refuses to unroll this loop, resulting in a 24% slowdown on ARMv6. */
+#if defined(__GNUC__) && !defined(__clang__) \
+  && (defined(__arm__) || defined(__thumb2__)) \
+  && defined(__ARM_FEATURE_UNALIGNED) /* no unaligned access just wastes bytes */ \
+  && XXH_SIZE_OPT <= 0
+#  pragma GCC unroll 8
+#endif
+    for (i=0; i < XXH_ACC_NB; i++) {
+        XXH3_scalarRound(acc, input, secret, i);
+    }
+}
+XXH_FORCE_INLINE XXH3_ACCUMULATE_TEMPLATE(scalar)
+
+/*!
+ * @internal
+ * @brief Scalar scramble step for @ref XXH3_scrambleAcc_scalar().
+ *
+ * This is extracted to its own function because the NEON path uses a combination
+ * of NEON and scalar.
+ */
+XXH_FORCE_INLINE void
+XXH3_scalarScrambleRound(void* XXH_RESTRICT acc,
+                         void const* XXH_RESTRICT secret,
+                         size_t lane)
+{
+    xxh_u64* const xacc = (xxh_u64*) acc;   /* presumed aligned */
+    const xxh_u8* const xsecret = (const xxh_u8*) secret;   /* no alignment restriction */
+    XXH_ASSERT((((size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
+    XXH_ASSERT(lane < XXH_ACC_NB);
+    {
+        xxh_u64 const key64 = XXH_readLE64(xsecret + lane * 8);
+        xxh_u64 acc64 = xacc[lane];
+        acc64 = XXH_xorshift64(acc64, 47);
+        acc64 ^= key64;
+        acc64 *= XXH_PRIME32_1;
+        xacc[lane] = acc64;
+    }
+}
+
+/*!
+ * @internal
+ * @brief Scrambles the accumulators after a large chunk has been read
+ */
+XXH_FORCE_INLINE void
+XXH3_scrambleAcc_scalar(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
+{
+    size_t i;
+    for (i=0; i < XXH_ACC_NB; i++) {
+        XXH3_scalarScrambleRound(acc, secret, i);
+    }
+}
+
+XXH_FORCE_INLINE void
+XXH3_initCustomSecret_scalar(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
+{
+    /*
+     * We need a separate pointer for the hack below,
+     * which requires a non-const pointer.
+     * Any decent compiler will optimize this out otherwise.
+     */
+    const xxh_u8* kSecretPtr = XXH3_kSecret;
+    XXH_STATIC_ASSERT((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
+
+#if defined(__GNUC__) && defined(__aarch64__)
+    /*
+     * UGLY HACK:
+     * GCC and Clang generate a bunch of MOV/MOVK pairs for aarch64, and they are
+     * placed sequentially, in order, at the top of the unrolled loop.
+     *
+     * While MOVK is great for generating constants (2 cycles for a 64-bit
+     * constant compared to 4 cycles for LDR), it fights for bandwidth with
+     * the arithmetic instructions.
+     *
+     *   I   L   S
+     * MOVK
+     * MOVK
+     * MOVK
+     * MOVK
+     * ADD
+     * SUB      STR
+     *          STR
+     * By forcing loads from memory (as the asm line causes the compiler to assume
+     * that XXH3_kSecretPtr has been changed), the pipelines are used more
+     * efficiently:
+     *   I   L   S
+     *      LDR
+     *  ADD LDR
+     *  SUB     STR
+     *          STR
+     *
+     * See XXH3_NEON_LANES for details on the pipsline.
+     *
+     * XXH3_64bits_withSeed, len == 256, Snapdragon 835
+     *   without hack: 2654.4 MB/s
+     *   with hack:    3202.9 MB/s
+     */
+    XXH_COMPILER_GUARD(kSecretPtr);
+#endif
+    {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
+        int i;
+        for (i=0; i < nbRounds; i++) {
+            /*
+             * The asm hack causes the compiler to assume that kSecretPtr aliases with
+             * customSecret, and on aarch64, this prevented LDP from merging two
+             * loads together for free. Putting the loads together before the stores
+             * properly generates LDP.
+             */
+            xxh_u64 lo = XXH_readLE64(kSecretPtr + 16*i)     + seed64;
+            xxh_u64 hi = XXH_readLE64(kSecretPtr + 16*i + 8) - seed64;
+            XXH_writeLE64((xxh_u8*)customSecret + 16*i,     lo);
+            XXH_writeLE64((xxh_u8*)customSecret + 16*i + 8, hi);
+    }   }
+}
+
+
+typedef void (*XXH3_f_accumulate)(xxh_u64* XXH_RESTRICT, const xxh_u8* XXH_RESTRICT, const xxh_u8* XXH_RESTRICT, size_t);
+typedef void (*XXH3_f_scrambleAcc)(void* XXH_RESTRICT, const void*);
+typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
+
+
+#if (XXH_VECTOR == XXH_AVX512)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_avx512
+#define XXH3_accumulate     XXH3_accumulate_avx512
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_avx512
+#define XXH3_initCustomSecret XXH3_initCustomSecret_avx512
+
+#elif (XXH_VECTOR == XXH_AVX2)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_avx2
+#define XXH3_accumulate     XXH3_accumulate_avx2
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_avx2
+#define XXH3_initCustomSecret XXH3_initCustomSecret_avx2
+
+#elif (XXH_VECTOR == XXH_SSE2)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_sse2
+#define XXH3_accumulate     XXH3_accumulate_sse2
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_sse2
+#define XXH3_initCustomSecret XXH3_initCustomSecret_sse2
+
+#elif (XXH_VECTOR == XXH_NEON)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_neon
+#define XXH3_accumulate     XXH3_accumulate_neon
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_neon
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#elif (XXH_VECTOR == XXH_VSX)
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_vsx
+#define XXH3_accumulate     XXH3_accumulate_vsx
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_vsx
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#elif (XXH_VECTOR == XXH_SVE)
+#define XXH3_accumulate_512 XXH3_accumulate_512_sve
+#define XXH3_accumulate     XXH3_accumulate_sve
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_scalar
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#else /* scalar */
+
+#define XXH3_accumulate_512 XXH3_accumulate_512_scalar
+#define XXH3_accumulate     XXH3_accumulate_scalar
+#define XXH3_scrambleAcc    XXH3_scrambleAcc_scalar
+#define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+
+#endif
+
+#if XXH_SIZE_OPT >= 1 /* don't do SIMD for initialization */
+#  undef XXH3_initCustomSecret
+#  define XXH3_initCustomSecret XXH3_initCustomSecret_scalar
+#endif
+
+XXH_FORCE_INLINE void
+XXH3_hashLong_internal_loop(xxh_u64* XXH_RESTRICT acc,
+                      const xxh_u8* XXH_RESTRICT input, size_t len,
+                      const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                            XXH3_f_accumulate f_acc,
+                            XXH3_f_scrambleAcc f_scramble)
+{
+    size_t const nbStripesPerBlock = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
+    size_t const block_len = XXH_STRIPE_LEN * nbStripesPerBlock;
+    size_t const nb_blocks = (len - 1) / block_len;
+
+    size_t n;
+
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+
+    for (n = 0; n < nb_blocks; n++) {
+        f_acc(acc, input + n*block_len, secret, nbStripesPerBlock);
+        f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
+    }
+
+    /* last partial block */
+    XXH_ASSERT(len > XXH_STRIPE_LEN);
+    {   size_t const nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
+        XXH_ASSERT(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
+        f_acc(acc, input + nb_blocks*block_len, secret, nbStripes);
+
+        /* last stripe */
+        {   const xxh_u8* const p = input + len - XXH_STRIPE_LEN;
+#define XXH_SECRET_LASTACC_START 7  /* not aligned on 8, last secret is different from acc & scrambler */
+            XXH3_accumulate_512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
+    }   }
+}
+
+XXH_FORCE_INLINE xxh_u64
+XXH3_mix2Accs(const xxh_u64* XXH_RESTRICT acc, const xxh_u8* XXH_RESTRICT secret)
+{
+    return XXH3_mul128_fold64(
+               acc[0] ^ XXH_readLE64(secret),
+               acc[1] ^ XXH_readLE64(secret+8) );
+}
+
+static XXH64_hash_t
+XXH3_mergeAccs(const xxh_u64* XXH_RESTRICT acc, const xxh_u8* XXH_RESTRICT secret, xxh_u64 start)
+{
+    xxh_u64 result64 = start;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++) {
+        result64 += XXH3_mix2Accs(acc+2*i, secret + 16*i);
+#if defined(__clang__)                                /* Clang */ \
+    && (defined(__arm__) || defined(__thumb__))       /* ARMv7 */ \
+    && (defined(__ARM_NEON) || defined(__ARM_NEON__)) /* NEON */  \
+    && !defined(XXH_ENABLE_AUTOVECTORIZE)             /* Define to disable */
+        /*
+         * UGLY HACK:
+         * Prevent autovectorization on Clang ARMv7-a. Exact same problem as
+         * the one in XXH3_len_129to240_64b. Speeds up shorter keys > 240b.
+         * XXH3_64bits, len == 256, Snapdragon 835:
+         *   without hack: 2063.7 MB/s
+         *   with hack:    2560.7 MB/s
+         */
+        XXH_COMPILER_GUARD(result64);
+#endif
+    }
+
+    return XXH3_avalanche(result64);
+}
+
+#define XXH3_INIT_ACC { XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, \
+                        XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 }
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_hashLong_64b_internal(const void* XXH_RESTRICT input, size_t len,
+                           const void* XXH_RESTRICT secret, size_t secretSize,
+                           XXH3_f_accumulate f_acc,
+                           XXH3_f_scrambleAcc f_scramble)
+{
+    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(acc, (const xxh_u8*)input, len, (const xxh_u8*)secret, secretSize, f_acc, f_scramble);
+
+    /* converge into final hash */
+    XXH_STATIC_ASSERT(sizeof(acc) == 64);
+    /* do not align on 8, so that the secret is different from the accumulator */
+#define XXH_SECRET_MERGEACCS_START 11
+    XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+    return XXH3_mergeAccs(acc, (const xxh_u8*)secret + XXH_SECRET_MERGEACCS_START, (xxh_u64)len * XXH_PRIME64_1);
+}
+
+/*
+ * It's important for performance to transmit secret's size (when it's static)
+ * so that the compiler can properly optimize the vectorized loop.
+ * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
+ * When the secret size is unknown, or on GCC 12 where the mix of NO_INLINE and FORCE_INLINE
+ * breaks -Og, this is XXH_NO_INLINE.
+ */
+XXH3_WITH_SECRET_INLINE XXH64_hash_t
+XXH3_hashLong_64b_withSecret(const void* XXH_RESTRICT input, size_t len,
+                             XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)seed64;
+    return XXH3_hashLong_64b_internal(input, len, secret, secretLen, XXH3_accumulate, XXH3_scrambleAcc);
+}
+
+/*
+ * It's preferable for performance that XXH3_hashLong is not inlined,
+ * as it results in a smaller function for small data, easier to the instruction cache.
+ * Note that inside this no_inline function, we do inline the internal loop,
+ * and provide a statically defined secret size to allow optimization of vector loop.
+ */
+XXH_NO_INLINE XXH_PUREF XXH64_hash_t
+XXH3_hashLong_64b_default(const void* XXH_RESTRICT input, size_t len,
+                          XXH64_hash_t seed64, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)seed64; (void)secret; (void)secretLen;
+    return XXH3_hashLong_64b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_accumulate, XXH3_scrambleAcc);
+}
+
+/*
+ * XXH3_hashLong_64b_withSeed():
+ * Generate a custom key based on alteration of default XXH3_kSecret with the seed,
+ * and then use this key for long mode hashing.
+ *
+ * This operation is decently fast but nonetheless costs a little bit of time.
+ * Try to avoid it whenever possible (typically when seed==0).
+ *
+ * It's important for performance that XXH3_hashLong is not inlined. Not sure
+ * why (uop cache maybe?), but the difference is large and easily measurable.
+ */
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_hashLong_64b_withSeed_internal(const void* input, size_t len,
+                                    XXH64_hash_t seed,
+                                    XXH3_f_accumulate f_acc,
+                                    XXH3_f_scrambleAcc f_scramble,
+                                    XXH3_f_initCustomSecret f_initSec)
+{
+#if XXH_SIZE_OPT <= 0
+    if (seed == 0)
+        return XXH3_hashLong_64b_internal(input, len,
+                                          XXH3_kSecret, sizeof(XXH3_kSecret),
+                                          f_acc, f_scramble);
+#endif
+    {   XXH_ALIGN(XXH_SEC_ALIGN) xxh_u8 secret[XXH_SECRET_DEFAULT_SIZE];
+        f_initSec(secret, seed);
+        return XXH3_hashLong_64b_internal(input, len, secret, sizeof(secret),
+                                          f_acc, f_scramble);
+    }
+}
+
+/*
+ * It's important for performance that XXH3_hashLong is not inlined.
+ */
+XXH_NO_INLINE XXH64_hash_t
+XXH3_hashLong_64b_withSeed(const void* XXH_RESTRICT input, size_t len,
+                           XXH64_hash_t seed, const xxh_u8* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)secret; (void)secretLen;
+    return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
+                XXH3_accumulate, XXH3_scrambleAcc, XXH3_initCustomSecret);
+}
+
+
+typedef XXH64_hash_t (*XXH3_hashLong64_f)(const void* XXH_RESTRICT, size_t,
+                                          XXH64_hash_t, const xxh_u8* XXH_RESTRICT, size_t);
+
+XXH_FORCE_INLINE XXH64_hash_t
+XXH3_64bits_internal(const void* XXH_RESTRICT input, size_t len,
+                     XXH64_hash_t seed64, const void* XXH_RESTRICT secret, size_t secretLen,
+                     XXH3_hashLong64_f f_hashLong)
+{
+    XXH_ASSERT(secretLen >= XXH3_SECRET_SIZE_MIN);
+    /*
+     * If an action is to be taken if `secretLen` condition is not respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash.
+     * Also, note that function signature doesn't offer room to return an error.
+     */
+    if (len <= 16)
+        return XXH3_len_0to16_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, seed64);
+    if (len <= 128)
+        return XXH3_len_17to128_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_64b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    return f_hashLong(input, len, seed64, (const xxh_u8*)secret, secretLen);
+}
+
+
+/* ===   Public entry point   === */
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(XXH_NOESCAPE const void* input, size_t length)
+{
+    return XXH3_64bits_internal(input, length, 0, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_default);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSecret(XXH_NOESCAPE const void* input, size_t length, XXH_NOESCAPE const void* secret, size_t secretSize)
+{
+    return XXH3_64bits_internal(input, length, 0, secret, secretSize, XXH3_hashLong_64b_withSecret);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSeed(XXH_NOESCAPE const void* input, size_t length, XXH64_hash_t seed)
+{
+    return XXH3_64bits_internal(input, length, seed, XXH3_kSecret, sizeof(XXH3_kSecret), XXH3_hashLong_64b_withSeed);
+}
+
+XXH_PUBLIC_API XXH64_hash_t
+XXH3_64bits_withSecretandSeed(XXH_NOESCAPE const void* input, size_t length, XXH_NOESCAPE const void* secret, size_t secretSize, XXH64_hash_t seed)
+{
+    if (length <= XXH3_MIDSIZE_MAX)
+        return XXH3_64bits_internal(input, length, seed, XXH3_kSecret, sizeof(XXH3_kSecret), NULL);
+    return XXH3_hashLong_64b_withSecret(input, length, seed, (const xxh_u8*)secret, secretSize);
+}
+
+
+/* ===   XXH3 streaming   === */
+#ifndef XXH_NO_STREAM
+/*
+ * Malloc's a pointer that is always aligned to align.
+ *
+ * This must be freed with `XXH_alignedFree()`.
+ *
+ * malloc typically guarantees 16 byte alignment on 64-bit systems and 8 byte
+ * alignment on 32-bit. This isn't enough for the 32 byte aligned loads in AVX2
+ * or on 32-bit, the 16 byte aligned loads in SSE2 and NEON.
+ *
+ * This underalignment previously caused a rather obvious crash which went
+ * completely unnoticed due to XXH3_createState() not actually being tested.
+ * Credit to RedSpah for noticing this bug.
+ *
+ * The alignment is done manually: Functions like posix_memalign or _mm_malloc
+ * are avoided: To maintain portability, we would have to write a fallback
+ * like this anyways, and besides, testing for the existence of library
+ * functions without relying on external build tools is impossible.
+ *
+ * The method is simple: Overallocate, manually align, and store the offset
+ * to the original behind the returned pointer.
+ *
+ * Align must be a power of 2 and 8 <= align <= 128.
+ */
+static XXH_MALLOCF void* XXH_alignedMalloc(size_t s, size_t align)
+{
+    XXH_ASSERT(align <= 128 && align >= 8); /* range check */
+    XXH_ASSERT((align & (align-1)) == 0);   /* power of 2 */
+    XXH_ASSERT(s != 0 && s < (s + align));  /* empty/overflow */
+    {   /* Overallocate to make room for manual realignment and an offset byte */
+        xxh_u8* base = (xxh_u8*)XXH_malloc(s + align);
+        if (base != NULL) {
+            /*
+             * Get the offset needed to align this pointer.
+             *
+             * Even if the returned pointer is aligned, there will always be
+             * at least one byte to store the offset to the original pointer.
+             */
+            size_t offset = align - ((size_t)base & (align - 1)); /* base % align */
+            /* Add the offset for the now-aligned pointer */
+            xxh_u8* ptr = base + offset;
+
+            XXH_ASSERT((size_t)ptr % align == 0);
+
+            /* Store the offset immediately before the returned pointer. */
+            ptr[-1] = (xxh_u8)offset;
+            return ptr;
+        }
+        return NULL;
+    }
+}
+/*
+ * Frees an aligned pointer allocated by XXH_alignedMalloc(). Don't pass
+ * normal malloc'd pointers, XXH_alignedMalloc has a specific data layout.
+ */
+static void XXH_alignedFree(void* p)
+{
+    if (p != NULL) {
+        xxh_u8* ptr = (xxh_u8*)p;
+        /* Get the offset byte we added in XXH_malloc. */
+        xxh_u8 offset = ptr[-1];
+        /* Free the original malloc'd pointer */
+        xxh_u8* base = ptr - offset;
+        XXH_free(base);
+    }
+}
+/*! @ingroup XXH3_family */
+/*!
+ * @brief Allocate an @ref XXH3_state_t.
+ *
+ * Must be freed with XXH3_freeState().
+ * @return An allocated XXH3_state_t on success, `NULL` on failure.
+ */
+XXH_PUBLIC_API XXH3_state_t* XXH3_createState(void)
+{
+    XXH3_state_t* const state = (XXH3_state_t*)XXH_alignedMalloc(sizeof(XXH3_state_t), 64);
+    if (state==NULL) return NULL;
+    XXH3_INITSTATE(state);
+    return state;
+}
+
+/*! @ingroup XXH3_family */
+/*!
+ * @brief Frees an @ref XXH3_state_t.
+ *
+ * Must be allocated with XXH3_createState().
+ * @param statePtr A pointer to an @ref XXH3_state_t allocated with @ref XXH3_createState().
+ * @return XXH_OK.
+ */
+XXH_PUBLIC_API XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr)
+{
+    XXH_alignedFree(statePtr);
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API void
+XXH3_copyState(XXH_NOESCAPE XXH3_state_t* dst_state, XXH_NOESCAPE const XXH3_state_t* src_state)
+{
+    XXH_memcpy(dst_state, src_state, sizeof(*dst_state));
+}
+
+static void
+XXH3_reset_internal(XXH3_state_t* statePtr,
+                    XXH64_hash_t seed,
+                    const void* secret, size_t secretSize)
+{
+    size_t const initStart = offsetof(XXH3_state_t, bufferedSize);
+    size_t const initLength = offsetof(XXH3_state_t, nbStripesPerBlock) - initStart;
+    XXH_ASSERT(offsetof(XXH3_state_t, nbStripesPerBlock) > initStart);
+    XXH_ASSERT(statePtr != NULL);
+    /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
+    memset((char*)statePtr + initStart, 0, initLength);
+    statePtr->acc[0] = XXH_PRIME32_3;
+    statePtr->acc[1] = XXH_PRIME64_1;
+    statePtr->acc[2] = XXH_PRIME64_2;
+    statePtr->acc[3] = XXH_PRIME64_3;
+    statePtr->acc[4] = XXH_PRIME64_4;
+    statePtr->acc[5] = XXH_PRIME32_2;
+    statePtr->acc[6] = XXH_PRIME64_5;
+    statePtr->acc[7] = XXH_PRIME32_1;
+    statePtr->seed = seed;
+    statePtr->useSeed = (seed != 0);
+    statePtr->extSecret = (const unsigned char*)secret;
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+    statePtr->secretLimit = secretSize - XXH_STRIPE_LEN;
+    statePtr->nbStripesPerBlock = statePtr->secretLimit / XXH_SECRET_CONSUME_RATE;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset(XXH_NOESCAPE XXH3_state_t* statePtr)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_reset_internal(statePtr, 0, XXH3_kSecret, XXH_SECRET_DEFAULT_SIZE);
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSecret(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    XXH3_reset_internal(statePtr, 0, secret, secretSize);
+    if (secret == NULL) return XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH64_hash_t seed)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    if (seed==0) return XXH3_64bits_reset(statePtr);
+    if ((seed != statePtr->seed) || (statePtr->extSecret != NULL))
+        XXH3_initCustomSecret(statePtr->customSecret, seed);
+    XXH3_reset_internal(statePtr, seed, NULL, XXH_SECRET_DEFAULT_SIZE);
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize, XXH64_hash_t seed64)
+{
+    if (statePtr == NULL) return XXH_ERROR;
+    if (secret == NULL) return XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+    XXH3_reset_internal(statePtr, seed64, secret, secretSize);
+    statePtr->useSeed = 1; /* always, even if seed64==0 */
+    return XXH_OK;
+}
+
+/*!
+ * @internal
+ * @brief Processes a large input for XXH3_update() and XXH3_digest_long().
+ *
+ * Unlike XXH3_hashLong_internal_loop(), this can process data that overlaps a block.
+ *
+ * @param acc                Pointer to the 8 accumulator lanes
+ * @param nbStripesSoFarPtr  In/out pointer to the number of leftover stripes in the block*
+ * @param nbStripesPerBlock  Number of stripes in a block
+ * @param input              Input pointer
+ * @param nbStripes          Number of stripes to process
+ * @param secret             Secret pointer
+ * @param secretLimit        Offset of the last block in @p secret
+ * @param f_acc              Pointer to an XXH3_accumulate implementation
+ * @param f_scramble         Pointer to an XXH3_scrambleAcc implementation
+ * @return                   Pointer past the end of @p input after processing
+ */
+XXH_FORCE_INLINE const xxh_u8 *
+XXH3_consumeStripes(xxh_u64* XXH_RESTRICT acc,
+                    size_t* XXH_RESTRICT nbStripesSoFarPtr, size_t nbStripesPerBlock,
+                    const xxh_u8* XXH_RESTRICT input, size_t nbStripes,
+                    const xxh_u8* XXH_RESTRICT secret, size_t secretLimit,
+                    XXH3_f_accumulate f_acc,
+                    XXH3_f_scrambleAcc f_scramble)
+{
+    const xxh_u8* initialSecret = secret + *nbStripesSoFarPtr * XXH_SECRET_CONSUME_RATE;
+    /* Process full blocks */
+    if (nbStripes >= (nbStripesPerBlock - *nbStripesSoFarPtr)) {
+        /* Process the initial partial block... */
+        size_t nbStripesThisIter = nbStripesPerBlock - *nbStripesSoFarPtr;
+
+        do {
+            /* Accumulate and scramble */
+            f_acc(acc, input, initialSecret, nbStripesThisIter);
+            f_scramble(acc, secret + secretLimit);
+            input += nbStripesThisIter * XXH_STRIPE_LEN;
+            nbStripes -= nbStripesThisIter;
+            /* Then continue the loop with the full block size */
+            nbStripesThisIter = nbStripesPerBlock;
+            initialSecret = secret;
+        } while (nbStripes >= nbStripesPerBlock);
+        *nbStripesSoFarPtr = 0;
+    }
+    /* Process a partial block */
+    if (nbStripes > 0) {
+        f_acc(acc, input, initialSecret, nbStripes);
+        input += nbStripes * XXH_STRIPE_LEN;
+        *nbStripesSoFarPtr += nbStripes;
+    }
+    /* Return end pointer */
+    return input;
+}
+
+#ifndef XXH3_STREAM_USE_STACK
+# if XXH_SIZE_OPT <= 0 && !defined(__clang__) /* clang doesn't need additional stack space */
+#   define XXH3_STREAM_USE_STACK 1
+# endif
+#endif
+/*
+ * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
+ */
+XXH_FORCE_INLINE XXH_errorcode
+XXH3_update(XXH3_state_t* XXH_RESTRICT const state,
+            const xxh_u8* XXH_RESTRICT input, size_t len,
+            XXH3_f_accumulate f_acc,
+            XXH3_f_scrambleAcc f_scramble)
+{
+    if (input==NULL) {
+        XXH_ASSERT(len == 0);
+        return XXH_OK;
+    }
+
+    XXH_ASSERT(state != NULL);
+    {   const xxh_u8* const bEnd = input + len;
+        const unsigned char* const secret = (state->extSecret == NULL) ? state->customSecret : state->extSecret;
+#if defined(XXH3_STREAM_USE_STACK) && XXH3_STREAM_USE_STACK >= 1
+        /* For some reason, gcc and MSVC seem to suffer greatly
+         * when operating accumulators directly into state.
+         * Operating into stack space seems to enable proper optimization.
+         * clang, on the other hand, doesn't seem to need this trick */
+        XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[8];
+        XXH_memcpy(acc, state->acc, sizeof(acc));
+#else
+        xxh_u64* XXH_RESTRICT const acc = state->acc;
+#endif
+        state->totalLen += len;
+        XXH_ASSERT(state->bufferedSize <= XXH3_INTERNALBUFFER_SIZE);
+
+        /* small input : just fill in tmp buffer */
+        if (len <= XXH3_INTERNALBUFFER_SIZE - state->bufferedSize) {
+            XXH_memcpy(state->buffer + state->bufferedSize, input, len);
+            state->bufferedSize += (XXH32_hash_t)len;
+            return XXH_OK;
+        }
+
+        /* total input is now > XXH3_INTERNALBUFFER_SIZE */
+        #define XXH3_INTERNALBUFFER_STRIPES (XXH3_INTERNALBUFFER_SIZE / XXH_STRIPE_LEN)
+        XXH_STATIC_ASSERT(XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN == 0);   /* clean multiple */
+
+        /*
+         * Internal buffer is partially filled (always, except at beginning)
+         * Complete it, then consume it.
+         */
+        if (state->bufferedSize) {
+            size_t const loadSize = XXH3_INTERNALBUFFER_SIZE - state->bufferedSize;
+            XXH_memcpy(state->buffer + state->bufferedSize, input, loadSize);
+            input += loadSize;
+            XXH3_consumeStripes(acc,
+                               &state->nbStripesSoFar, state->nbStripesPerBlock,
+                                state->buffer, XXH3_INTERNALBUFFER_STRIPES,
+                                secret, state->secretLimit,
+                                f_acc, f_scramble);
+            state->bufferedSize = 0;
+        }
+        XXH_ASSERT(input < bEnd);
+        if (bEnd - input > XXH3_INTERNALBUFFER_SIZE) {
+            size_t nbStripes = (size_t)(bEnd - 1 - input) / XXH_STRIPE_LEN;
+            input = XXH3_consumeStripes(acc,
+                                       &state->nbStripesSoFar, state->nbStripesPerBlock,
+                                       input, nbStripes,
+                                       secret, state->secretLimit,
+                                       f_acc, f_scramble);
+            XXH_memcpy(state->buffer + sizeof(state->buffer) - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+
+        }
+        /* Some remaining input (always) : buffer it */
+        XXH_ASSERT(input < bEnd);
+        XXH_ASSERT(bEnd - input <= XXH3_INTERNALBUFFER_SIZE);
+        XXH_ASSERT(state->bufferedSize == 0);
+        XXH_memcpy(state->buffer, input, (size_t)(bEnd-input));
+        state->bufferedSize = (XXH32_hash_t)(bEnd-input);
+#if defined(XXH3_STREAM_USE_STACK) && XXH3_STREAM_USE_STACK >= 1
+        /* save stack accumulators into state */
+        XXH_memcpy(state->acc, acc, sizeof(acc));
+#endif
+    }
+
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_64bits_update(XXH_NOESCAPE XXH3_state_t* state, XXH_NOESCAPE const void* input, size_t len)
+{
+    return XXH3_update(state, (const xxh_u8*)input, len,
+                       XXH3_accumulate, XXH3_scrambleAcc);
+}
+
+
+XXH_FORCE_INLINE void
+XXH3_digest_long (XXH64_hash_t* acc,
+                  const XXH3_state_t* state,
+                  const unsigned char* secret)
+{
+    xxh_u8 lastStripe[XXH_STRIPE_LEN];
+    const xxh_u8* lastStripePtr;
+
+    /*
+     * Digest on a local copy. This way, the state remains unaltered, and it can
+     * continue ingesting more input afterwards.
+     */
+    XXH_memcpy(acc, state->acc, sizeof(state->acc));
+    if (state->bufferedSize >= XXH_STRIPE_LEN) {
+        /* Consume remaining stripes then point to remaining data in buffer */
+        size_t const nbStripes = (state->bufferedSize - 1) / XXH_STRIPE_LEN;
+        size_t nbStripesSoFar = state->nbStripesSoFar;
+        XXH3_consumeStripes(acc,
+                           &nbStripesSoFar, state->nbStripesPerBlock,
+                            state->buffer, nbStripes,
+                            secret, state->secretLimit,
+                            XXH3_accumulate, XXH3_scrambleAcc);
+        lastStripePtr = state->buffer + state->bufferedSize - XXH_STRIPE_LEN;
+    } else {  /* bufferedSize < XXH_STRIPE_LEN */
+        /* Copy to temp buffer */
+        size_t const catchupSize = XXH_STRIPE_LEN - state->bufferedSize;
+        XXH_ASSERT(state->bufferedSize > 0);  /* there is always some input buffered */
+        XXH_memcpy(lastStripe, state->buffer + sizeof(state->buffer) - catchupSize, catchupSize);
+        XXH_memcpy(lastStripe + catchupSize, state->buffer, state->bufferedSize);
+        lastStripePtr = lastStripe;
+    }
+    /* Last stripe */
+    XXH3_accumulate_512(acc,
+                        lastStripePtr,
+                        secret + state->secretLimit - XXH_SECRET_LASTACC_START);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH64_hash_t XXH3_64bits_digest (XXH_NOESCAPE const XXH3_state_t* state)
+{
+    const unsigned char* const secret = (state->extSecret == NULL) ? state->customSecret : state->extSecret;
+    if (state->totalLen > XXH3_MIDSIZE_MAX) {
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
+        XXH3_digest_long(acc, state, secret);
+        return XXH3_mergeAccs(acc,
+                              secret + XXH_SECRET_MERGEACCS_START,
+                              (xxh_u64)state->totalLen * XXH_PRIME64_1);
+    }
+    /* totalLen <= XXH3_MIDSIZE_MAX: digesting a short input */
+    if (state->useSeed)
+        return XXH3_64bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
+    return XXH3_64bits_withSecret(state->buffer, (size_t)(state->totalLen),
+                                  secret, state->secretLimit + XXH_STRIPE_LEN);
+}
+#endif /* !XXH_NO_STREAM */
+
+
+/* ==========================================
+ * XXH3 128 bits (a.k.a XXH128)
+ * ==========================================
+ * XXH3's 128-bit variant has better mixing and strength than the 64-bit variant,
+ * even without counting the significantly larger output size.
+ *
+ * For example, extra steps are taken to avoid the seed-dependent collisions
+ * in 17-240 byte inputs (See XXH3_mix16B and XXH128_mix32B).
+ *
+ * This strength naturally comes at the cost of some speed, especially on short
+ * lengths. Note that longer hashes are about as fast as the 64-bit version
+ * due to it using only a slight modification of the 64-bit loop.
+ *
+ * XXH128 is also more oriented towards 64-bit machines. It is still extremely
+ * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
+ */
+
+XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    /* A doubled version of 1to3_64b with different constants. */
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(1 <= len && len <= 3);
+    XXH_ASSERT(secret != NULL);
+    /*
+     * len = 1: combinedl = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combinedl = { input[1], 0x02, input[0], input[1] }
+     * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
+     */
+    {   xxh_u8 const c1 = input[0];
+        xxh_u8 const c2 = input[len >> 1];
+        xxh_u8 const c3 = input[len - 1];
+        xxh_u32 const combinedl = ((xxh_u32)c1 <<16) | ((xxh_u32)c2 << 24)
+                                | ((xxh_u32)c3 << 0) | ((xxh_u32)len << 8);
+        xxh_u32 const combinedh = XXH_rotl32(XXH_swap32(combinedl), 13);
+        xxh_u64 const bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
+        xxh_u64 const bitfliph = (XXH_readLE32(secret+8) ^ XXH_readLE32(secret+12)) - seed;
+        xxh_u64 const keyed_lo = (xxh_u64)combinedl ^ bitflipl;
+        xxh_u64 const keyed_hi = (xxh_u64)combinedh ^ bitfliph;
+        XXH128_hash_t h128;
+        h128.low64  = XXH64_avalanche(keyed_lo);
+        h128.high64 = XXH64_avalanche(keyed_hi);
+        return h128;
+    }
+}
+
+XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(secret != NULL);
+    XXH_ASSERT(4 <= len && len <= 8);
+    seed ^= (xxh_u64)XXH_swap32((xxh_u32)seed) << 32;
+    {   xxh_u32 const input_lo = XXH_readLE32(input);
+        xxh_u32 const input_hi = XXH_readLE32(input + len - 4);
+        xxh_u64 const input_64 = input_lo + ((xxh_u64)input_hi << 32);
+        xxh_u64 const bitflip = (XXH_readLE64(secret+16) ^ XXH_readLE64(secret+24)) + seed;
+        xxh_u64 const keyed = input_64 ^ bitflip;
+
+        /* Shift len to the left to ensure it is even, this avoids even multiplies. */
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
+
+        m128.high64 += (m128.low64 << 1);
+        m128.low64  ^= (m128.high64 >> 3);
+
+        m128.low64   = XXH_xorshift64(m128.low64, 35);
+        m128.low64  *= PRIME_MX2;
+        m128.low64   = XXH_xorshift64(m128.low64, 28);
+        m128.high64  = XXH3_avalanche(m128.high64);
+        return m128;
+    }
+}
+
+XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(input != NULL);
+    XXH_ASSERT(secret != NULL);
+    XXH_ASSERT(9 <= len && len <= 16);
+    {   xxh_u64 const bitflipl = (XXH_readLE64(secret+32) ^ XXH_readLE64(secret+40)) - seed;
+        xxh_u64 const bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) + seed;
+        xxh_u64 const input_lo = XXH_readLE64(input);
+        xxh_u64       input_hi = XXH_readLE64(input + len - 8);
+        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
+        /*
+         * Put len in the middle of m128 to ensure that the length gets mixed to
+         * both the low and high bits in the 128x64 multiply below.
+         */
+        m128.low64 += (xxh_u64)(len - 1) << 54;
+        input_hi   ^= bitfliph;
+        /*
+         * Add the high 32 bits of input_hi to the high 32 bits of m128, then
+         * add the long product of the low 32 bits of input_hi and XXH_PRIME32_2 to
+         * the high 64 bits of m128.
+         *
+         * The best approach to this operation is different on 32-bit and 64-bit.
+         */
+        if (sizeof(void *) < sizeof(xxh_u64)) { /* 32-bit */
+            /*
+             * 32-bit optimized version, which is more readable.
+             *
+             * On 32-bit, it removes an ADC and delays a dependency between the two
+             * halves of m128.high64, but it generates an extra mask on 64-bit.
+             */
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000ULL) + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2);
+        } else {
+            /*
+             * 64-bit optimized (albeit more confusing) version.
+             *
+             * Uses some properties of addition and multiplication to remove the mask:
+             *
+             * Let:
+             *    a = input_hi.lo = (input_hi & 0x00000000FFFFFFFF)
+             *    b = input_hi.hi = (input_hi & 0xFFFFFFFF00000000)
+             *    c = XXH_PRIME32_2
+             *
+             *    a + (b * c)
+             * Inverse Property: x + y - x == y
+             *    a + (b * (1 + c - 1))
+             * Distributive Property: x * (y + z) == (x * y) + (x * z)
+             *    a + (b * 1) + (b * (c - 1))
+             * Identity Property: x * 1 == x
+             *    a + b + (b * (c - 1))
+             *
+             * Substitute a, b, and c:
+             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             *
+             * Since input_hi.hi + input_hi.lo == input_hi, we get this:
+             *    input_hi + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             */
+            m128.high64 += input_hi + XXH_mult32to64((xxh_u32)input_hi, XXH_PRIME32_2 - 1);
+        }
+        /* m128 ^= XXH_swap64(m128 >> 64); */
+        m128.low64  ^= XXH_swap64(m128.high64);
+
+        {   /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
+            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, XXH_PRIME64_2);
+            h128.high64 += m128.high64 * XXH_PRIME64_2;
+
+            h128.low64   = XXH3_avalanche(h128.low64);
+            h128.high64  = XXH3_avalanche(h128.high64);
+            return h128;
+    }   }
+}
+
+/*
+ * Assumption: `secret` size is >= XXH3_SECRET_SIZE_MIN
+ */
+XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+{
+    XXH_ASSERT(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_128b(input, len, secret, seed);
+        if (len >= 4) return XXH3_len_4to8_128b(input, len, secret, seed);
+        if (len) return XXH3_len_1to3_128b(input, len, secret, seed);
+        {   XXH128_hash_t h128;
+            xxh_u64 const bitflipl = XXH_readLE64(secret+64) ^ XXH_readLE64(secret+72);
+            xxh_u64 const bitfliph = XXH_readLE64(secret+80) ^ XXH_readLE64(secret+88);
+            h128.low64 = XXH64_avalanche(seed ^ bitflipl);
+            h128.high64 = XXH64_avalanche( seed ^ bitfliph);
+            return h128;
+    }   }
+}
+
+/*
+ * A bit slower than XXH3_mix16B, but handles multiply by zero better.
+ */
+XXH_FORCE_INLINE XXH128_hash_t
+XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1, const xxh_u8* input_2,
+              const xxh_u8* secret, XXH64_hash_t seed)
+{
+    acc.low64  += XXH3_mix16B (input_1, secret+0, seed);
+    acc.low64  ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
+    acc.high64 += XXH3_mix16B (input_2, secret+16, seed);
+    acc.high64 ^= XXH_readLE64(input_1) + XXH_readLE64(input_1 + 8);
+    return acc;
+}
+
+
+XXH_FORCE_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_17to128_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
+                      const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                      XXH64_hash_t seed)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(16 < len && len <= 128);
+
+    {   XXH128_hash_t acc;
+        acc.low64 = len * XXH_PRIME64_1;
+        acc.high64 = 0;
+
+#if XXH_SIZE_OPT >= 1
+        {
+            /* Smaller, but slightly slower. */
+            unsigned int i = (unsigned int)(len - 1) / 32;
+            do {
+                acc = XXH128_mix32B(acc, input+16*i, input+len-16*(i+1), secret+32*i, seed);
+            } while (i-- != 0);
+        }
+#else
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    acc = XXH128_mix32B(acc, input+48, input+len-64, secret+96, seed);
+                }
+                acc = XXH128_mix32B(acc, input+32, input+len-48, secret+64, seed);
+            }
+            acc = XXH128_mix32B(acc, input+16, input+len-32, secret+32, seed);
+        }
+        acc = XXH128_mix32B(acc, input, input+len-16, secret, seed);
+#endif
+        {   XXH128_hash_t h128;
+            h128.low64  = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
+            h128.low64  = XXH3_avalanche(h128.low64);
+            h128.high64 = (XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+            return h128;
+        }
+    }
+}
+
+XXH_NO_INLINE XXH_PUREF XXH128_hash_t
+XXH3_len_129to240_128b(const xxh_u8* XXH_RESTRICT input, size_t len,
+                       const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                       XXH64_hash_t seed)
+{
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN); (void)secretSize;
+    XXH_ASSERT(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+    {   XXH128_hash_t acc;
+        unsigned i;
+        acc.low64 = len * XXH_PRIME64_1;
+        acc.high64 = 0;
+        /*
+         *  We set as `i` as offset + 32. We do this so that unchanged
+         * `len` can be used as upper bound. This reaches a sweet spot
+         * where both x86 and aarch64 get simple agen and good codegen
+         * for the loop.
+         */
+        for (i = 32; i < 160; i += 32) {
+            acc = XXH128_mix32B(acc,
+                                input  + i - 32,
+                                input  + i - 16,
+                                secret + i - 32,
+                                seed);
+        }
+        acc.low64 = XXH3_avalanche(acc.low64);
+        acc.high64 = XXH3_avalanche(acc.high64);
+        /*
+         * NB: `i <= len` will duplicate the last 32-bytes if
+         * len % 32 was zero. This is an unfortunate necessity to keep
+         * the hash result stable.
+         */
+        for (i=160; i <= len; i += 32) {
+            acc = XXH128_mix32B(acc,
+                                input + i - 32,
+                                input + i - 16,
+                                secret + XXH3_MIDSIZE_STARTOFFSET + i - 160,
+                                seed);
+        }
+        /* last bytes */
+        acc = XXH128_mix32B(acc,
+                            input + len - 16,
+                            input + len - 32,
+                            secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16,
+                            (XXH64_hash_t)0 - seed);
+
+        {   XXH128_hash_t h128;
+            h128.low64  = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
+            h128.low64  = XXH3_avalanche(h128.low64);
+            h128.high64 = (XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+            return h128;
+        }
+    }
+}
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_hashLong_128b_internal(const void* XXH_RESTRICT input, size_t len,
+                            const xxh_u8* XXH_RESTRICT secret, size_t secretSize,
+                            XXH3_f_accumulate f_acc,
+                            XXH3_f_scrambleAcc f_scramble)
+{
+    XXH_ALIGN(XXH_ACC_ALIGN) xxh_u64 acc[XXH_ACC_NB] = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(acc, (const xxh_u8*)input, len, secret, secretSize, f_acc, f_scramble);
+
+    /* converge into final hash */
+    XXH_STATIC_ASSERT(sizeof(acc) == 64);
+    XXH_ASSERT(secretSize >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+    {   XXH128_hash_t h128;
+        h128.low64  = XXH3_mergeAccs(acc,
+                                     secret + XXH_SECRET_MERGEACCS_START,
+                                     (xxh_u64)len * XXH_PRIME64_1);
+        h128.high64 = XXH3_mergeAccs(acc,
+                                     secret + secretSize
+                                            - sizeof(acc) - XXH_SECRET_MERGEACCS_START,
+                                     ~((xxh_u64)len * XXH_PRIME64_2));
+        return h128;
+    }
+}
+
+/*
+ * It's important for performance that XXH3_hashLong() is not inlined.
+ */
+XXH_NO_INLINE XXH_PUREF XXH128_hash_t
+XXH3_hashLong_128b_default(const void* XXH_RESTRICT input, size_t len,
+                           XXH64_hash_t seed64,
+                           const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)seed64; (void)secret; (void)secretLen;
+    return XXH3_hashLong_128b_internal(input, len, XXH3_kSecret, sizeof(XXH3_kSecret),
+                                       XXH3_accumulate, XXH3_scrambleAcc);
+}
+
+/*
+ * It's important for performance to pass @p secretLen (when it's static)
+ * to the compiler, so that it can properly optimize the vectorized loop.
+ *
+ * When the secret size is unknown, or on GCC 12 where the mix of NO_INLINE and FORCE_INLINE
+ * breaks -Og, this is XXH_NO_INLINE.
+ */
+XXH3_WITH_SECRET_INLINE XXH128_hash_t
+XXH3_hashLong_128b_withSecret(const void* XXH_RESTRICT input, size_t len,
+                              XXH64_hash_t seed64,
+                              const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)seed64;
+    return XXH3_hashLong_128b_internal(input, len, (const xxh_u8*)secret, secretLen,
+                                       XXH3_accumulate, XXH3_scrambleAcc);
+}
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_hashLong_128b_withSeed_internal(const void* XXH_RESTRICT input, size_t len,
+                                XXH64_hash_t seed64,
+                                XXH3_f_accumulate f_acc,
+                                XXH3_f_scrambleAcc f_scramble,
+                                XXH3_f_initCustomSecret f_initSec)
+{
+    if (seed64 == 0)
+        return XXH3_hashLong_128b_internal(input, len,
+                                           XXH3_kSecret, sizeof(XXH3_kSecret),
+                                           f_acc, f_scramble);
+    {   XXH_ALIGN(XXH_SEC_ALIGN) xxh_u8 secret[XXH_SECRET_DEFAULT_SIZE];
+        f_initSec(secret, seed64);
+        return XXH3_hashLong_128b_internal(input, len, (const xxh_u8*)secret, sizeof(secret),
+                                           f_acc, f_scramble);
+    }
+}
+
+/*
+ * It's important for performance that XXH3_hashLong is not inlined.
+ */
+XXH_NO_INLINE XXH128_hash_t
+XXH3_hashLong_128b_withSeed(const void* input, size_t len,
+                            XXH64_hash_t seed64, const void* XXH_RESTRICT secret, size_t secretLen)
+{
+    (void)secret; (void)secretLen;
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed64,
+                XXH3_accumulate, XXH3_scrambleAcc, XXH3_initCustomSecret);
+}
+
+typedef XXH128_hash_t (*XXH3_hashLong128_f)(const void* XXH_RESTRICT, size_t,
+                                            XXH64_hash_t, const void* XXH_RESTRICT, size_t);
+
+XXH_FORCE_INLINE XXH128_hash_t
+XXH3_128bits_internal(const void* input, size_t len,
+                      XXH64_hash_t seed64, const void* XXH_RESTRICT secret, size_t secretLen,
+                      XXH3_hashLong128_f f_hl128)
+{
+    XXH_ASSERT(secretLen >= XXH3_SECRET_SIZE_MIN);
+    /*
+     * If an action is to be taken if `secret` conditions are not respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash.
+     */
+    if (len <= 16)
+        return XXH3_len_0to16_128b((const xxh_u8*)input, len, (const xxh_u8*)secret, seed64);
+    if (len <= 128)
+        return XXH3_len_17to128_128b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_128b((const xxh_u8*)input, len, (const xxh_u8*)secret, secretLen, seed64);
+    return f_hl128(input, len, seed64, secret, secretLen);
+}
+
+
+/* ===   Public XXH128 API   === */
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits(XXH_NOESCAPE const void* input, size_t len)
+{
+    return XXH3_128bits_internal(input, len, 0,
+                                 XXH3_kSecret, sizeof(XXH3_kSecret),
+                                 XXH3_hashLong_128b_default);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSecret(XXH_NOESCAPE const void* input, size_t len, XXH_NOESCAPE const void* secret, size_t secretSize)
+{
+    return XXH3_128bits_internal(input, len, 0,
+                                 (const xxh_u8*)secret, secretSize,
+                                 XXH3_hashLong_128b_withSecret);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSeed(XXH_NOESCAPE const void* input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_128bits_internal(input, len, seed,
+                                 XXH3_kSecret, sizeof(XXH3_kSecret),
+                                 XXH3_hashLong_128b_withSeed);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t
+XXH3_128bits_withSecretandSeed(XXH_NOESCAPE const void* input, size_t len, XXH_NOESCAPE const void* secret, size_t secretSize, XXH64_hash_t seed)
+{
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_128bits_internal(input, len, seed, XXH3_kSecret, sizeof(XXH3_kSecret), NULL);
+    return XXH3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t
+XXH128(XXH_NOESCAPE const void* input, size_t len, XXH64_hash_t seed)
+{
+    return XXH3_128bits_withSeed(input, len, seed);
+}
+
+
+/* ===   XXH3 128-bit streaming   === */
+#ifndef XXH_NO_STREAM
+/*
+ * All initialization and update functions are identical to 64-bit streaming variant.
+ * The only difference is the finalization routine.
+ */
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset(XXH_NOESCAPE XXH3_state_t* statePtr)
+{
+    return XXH3_64bits_reset(statePtr);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSecret(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize)
+{
+    return XXH3_64bits_reset_withSecret(statePtr, secret, secretSize);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH64_hash_t seed)
+{
+    return XXH3_64bits_reset_withSeed(statePtr, seed);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize, XXH64_hash_t seed)
+{
+    return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_128bits_update(XXH_NOESCAPE XXH3_state_t* state, XXH_NOESCAPE const void* input, size_t len)
+{
+    return XXH3_64bits_update(state, input, len);
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (XXH_NOESCAPE const XXH3_state_t* state)
+{
+    const unsigned char* const secret = (state->extSecret == NULL) ? state->customSecret : state->extSecret;
+    if (state->totalLen > XXH3_MIDSIZE_MAX) {
+        XXH_ALIGN(XXH_ACC_ALIGN) XXH64_hash_t acc[XXH_ACC_NB];
+        XXH3_digest_long(acc, state, secret);
+        XXH_ASSERT(state->secretLimit + XXH_STRIPE_LEN >= sizeof(acc) + XXH_SECRET_MERGEACCS_START);
+        {   XXH128_hash_t h128;
+            h128.low64  = XXH3_mergeAccs(acc,
+                                         secret + XXH_SECRET_MERGEACCS_START,
+                                         (xxh_u64)state->totalLen * XXH_PRIME64_1);
+            h128.high64 = XXH3_mergeAccs(acc,
+                                         secret + state->secretLimit + XXH_STRIPE_LEN
+                                                - sizeof(acc) - XXH_SECRET_MERGEACCS_START,
+                                         ~((xxh_u64)state->totalLen * XXH_PRIME64_2));
+            return h128;
+        }
+    }
+    /* len <= XXH3_MIDSIZE_MAX : short code */
+    if (state->seed)
+        return XXH3_128bits_withSeed(state->buffer, (size_t)state->totalLen, state->seed);
+    return XXH3_128bits_withSecret(state->buffer, (size_t)(state->totalLen),
+                                   secret, state->secretLimit + XXH_STRIPE_LEN);
+}
+#endif /* !XXH_NO_STREAM */
+/* 128-bit utility functions */
+
+#include <string.h>   /* memcmp, memcpy */
+
+/* return : 1 is equal, 0 if different */
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
+{
+    /* note : XXH128_hash_t is compact, it has no padding byte */
+    return !(memcmp(&h1, &h2, sizeof(h1)));
+}
+
+/* This prototype is compatible with stdlib's qsort().
+ * @return : >0 if *h128_1  > *h128_2
+ *           <0 if *h128_1  < *h128_2
+ *           =0 if *h128_1 == *h128_2  */
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API int XXH128_cmp(XXH_NOESCAPE const void* h128_1, XXH_NOESCAPE const void* h128_2)
+{
+    XXH128_hash_t const h1 = *(const XXH128_hash_t*)h128_1;
+    XXH128_hash_t const h2 = *(const XXH128_hash_t*)h128_2;
+    int const hcmp = (h1.high64 > h2.high64) - (h2.high64 > h1.high64);
+    /* note : bets that, in most cases, hash values are different */
+    if (hcmp) return hcmp;
+    return (h1.low64 > h2.low64) - (h2.low64 > h1.low64);
+}
+
+
+/*======   Canonical representation   ======*/
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API void
+XXH128_canonicalFromHash(XXH_NOESCAPE XXH128_canonical_t* dst, XXH128_hash_t hash)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH128_canonical_t) == sizeof(XXH128_hash_t));
+    if (XXH_CPU_LITTLE_ENDIAN) {
+        hash.high64 = XXH_swap64(hash.high64);
+        hash.low64  = XXH_swap64(hash.low64);
+    }
+    XXH_memcpy(dst, &hash.high64, sizeof(hash.high64));
+    XXH_memcpy((char*)dst + sizeof(hash.high64), &hash.low64, sizeof(hash.low64));
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH128_hash_t
+XXH128_hashFromCanonical(XXH_NOESCAPE const XXH128_canonical_t* src)
+{
+    XXH128_hash_t h;
+    h.high64 = XXH_readBE64(src);
+    h.low64  = XXH_readBE64(src->digest + 8);
+    return h;
+}
+
+
+
+/* ==========================================
+ * Secret generators
+ * ==========================================
+ */
+#define XXH_MIN(x, y) (((x) > (y)) ? (y) : (x))
+
+XXH_FORCE_INLINE void XXH3_combine16(void* dst, XXH128_hash_t h128)
+{
+    XXH_writeLE64( dst, XXH_readLE64(dst) ^ h128.low64 );
+    XXH_writeLE64( (char*)dst+8, XXH_readLE64((char*)dst+8) ^ h128.high64 );
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API XXH_errorcode
+XXH3_generateSecret(XXH_NOESCAPE void* secretBuffer, size_t secretSize, XXH_NOESCAPE const void* customSeed, size_t customSeedSize)
+{
+#if (XXH_DEBUGLEVEL >= 1)
+    XXH_ASSERT(secretBuffer != NULL);
+    XXH_ASSERT(secretSize >= XXH3_SECRET_SIZE_MIN);
+#else
+    /* production mode, assert() are disabled */
+    if (secretBuffer == NULL) return XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+#endif
+
+    if (customSeedSize == 0) {
+        customSeed = XXH3_kSecret;
+        customSeedSize = XXH_SECRET_DEFAULT_SIZE;
+    }
+#if (XXH_DEBUGLEVEL >= 1)
+    XXH_ASSERT(customSeed != NULL);
+#else
+    if (customSeed == NULL) return XXH_ERROR;
+#endif
+
+    /* Fill secretBuffer with a copy of customSeed - repeat as needed */
+    {   size_t pos = 0;
+        while (pos < secretSize) {
+            size_t const toCopy = XXH_MIN((secretSize - pos), customSeedSize);
+            memcpy((char*)secretBuffer + pos, customSeed, toCopy);
+            pos += toCopy;
+    }   }
+
+    {   size_t const nbSeg16 = secretSize / 16;
+        size_t n;
+        XXH128_canonical_t scrambler;
+        XXH128_canonicalFromHash(&scrambler, XXH128(customSeed, customSeedSize, 0));
+        for (n=0; n<nbSeg16; n++) {
+            XXH128_hash_t const h128 = XXH128(&scrambler, sizeof(scrambler), n);
+            XXH3_combine16((char*)secretBuffer + n*16, h128);
+        }
+        /* last segment */
+        XXH3_combine16((char*)secretBuffer + secretSize - 16, XXH128_hashFromCanonical(&scrambler));
+    }
+    return XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_PUBLIC_API void
+XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
+{
+    XXH_ALIGN(XXH_SEC_ALIGN) xxh_u8 secret[XXH_SECRET_DEFAULT_SIZE];
+    XXH3_initCustomSecret(secret, seed);
+    XXH_ASSERT(secretBuffer != NULL);
+    memcpy(secretBuffer, secret, XXH_SECRET_DEFAULT_SIZE);
+}
+
+
+
+/* Pop our optimization override from above */
+#if XXH_VECTOR == XXH_AVX2 /* AVX2 */ \
+  && defined(__GNUC__) && !defined(__clang__) /* GCC, not Clang */ \
+  && defined(__OPTIMIZE__) && XXH_SIZE_OPT <= 0 /* respect -O0 and -Os */
+#  pragma GCC pop_options
+#endif
+
+#endif  /* XXH_NO_LONG_LONG */
+
+#endif  /* XXH_NO_XXH3 */
+
+/*!
+ * @}
+ */
+#endif  /* XXH_IMPLEMENTATION */
+
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif

--- a/plans/bytecode-precompilation/plan.md
+++ b/plans/bytecode-precompilation/plan.md
@@ -1,0 +1,144 @@
+# Bytecode Precompilation (Sidecar Code Caches)
+
+## Goal
+
+Cut process startup time by skipping JS parse/compile for CommonJS modules.
+Both engines serialize compiled code — V8 via `ScriptCompiler` code caches,
+QuickJS (quickjs-ng) via `JS_WriteObject`/`JS_ReadObject` bytecode — and the
+serialized form is stored as a **sidecar file next to the source**:
+
+```
+app.js          the source (unchanged, still authoritative)
+app.js.v8b      V8 code cache        (written by the bundled-v8 build)
+app.js.qjsb     QuickJS bytecode     (written by the quickjs build)
+```
+
+Both sidecars can coexist; each binary only reads its own suffix.
+
+## Behavior
+
+- **Consume (default-on):** when the CJS loader compiles a file and a valid
+  sidecar exists, the engine consumes it instead of parsing the source.
+  Invalid, stale, or corrupted sidecars are silently ignored (normal compile).
+- **Write-on-first-run (default-on):** when no valid sidecar exists, the
+  runtime produces the engine cache during the normal compile and writes the
+  sidecar atomically (temp file + rename). Failures (read-only filesystem,
+  permissions) are silent.
+- **Explicit precompile:** `edge --precompile <file|dir>...` walks the paths,
+  compiles every eligible CJS file (`.cjs` always; `.js` unless its nearest
+  `package.json` declares `"type": "module"`, `node_modules` included) and
+  writes sidecars **without executing any module body**. ESM-syntax files are
+  skipped, not failed.
+- **Opt-outs:** `--no-bytecode-cache` (CLI) or `EDGE_BYTECODE_CACHE=0` (env)
+  disable both reads and writes. `--check` disables the cache implicitly.
+  `--precompile` conflicts with `--check/--eval/--test/--watch/--interactive/
+  --run/--no-bytecode-cache` (exit 9).
+- **Tracing:** `EDGE_BYTECODE_CACHE_TRACE=1` prints `hit/miss/write/remove`
+  lines to stderr (used by tests).
+
+## Sidecar format
+
+Fixed 64-byte little-endian header + engine tag + opaque engine payload
+(`src/edge_bytecode_cache.h`):
+
+| field | notes |
+|---|---|
+| magic `EDGEJSBC` | |
+| format_version u32 | bump when the compile shape changes (wrapper text, params, shebang handling) |
+| flags u32 | bit0 = CJS function-compile shape v1 |
+| engine_tag_len u32 | |
+| source_len + source_hash u64 | FNV-1a-64 over the exact source string handed to the compiler (BOM/TS-stripping/shebang concerns vanish) |
+| filename_hash u64 | QuickJS writes + enforces it (its bytecode embeds the compile-time path); V8 writes 0 and stays relocatable |
+| payload_len + payload_hash u64 | corruption guard |
+| engine tag | `v8-<EDGE_EMBEDDED_V8_VERSION>` / `qjs-ng-<EDGE_EMBEDDED_QUICKJS_VERSION>` |
+
+Validation order: magic → version → flags → tag → source hash → filename hash
+→ payload hash. Any miss = "no cache". V8 additionally self-validates
+(`CachedData::rejected`); a rejected sidecar is deleted so the next run
+rewrites it instead of re-rejecting forever.
+
+## Implementation map
+
+No JS under `lib/` was touched — the feature is invisible to the Node-ported
+loader. All logic is C++:
+
+- `src/edge_bytecode_cache.{h,cc}` — container format, validation, hashing,
+  atomic writes, enable state. Engine identity comes from compile defines
+  (`EDGE_EMBEDDED_V8_VERSION` / `EDGE_EMBEDDED_QUICKJS_VERSION`, the latter
+  parsed from `quickjs.h` in the root `CMakeLists.txt`).
+- `src/edge_module_loader.cc` `ContextifyCompileFunctionForCJSLoaderCallback`
+  — the single runtime hook. The JS loader's `wrapSafe` already calls this
+  binding for every user CJS module; it now reads the sidecar before the
+  compile, passes the payload as cached data into the (pre-existing)
+  `unofficial_napi_contextify_compile_function` cache parameters, and
+  writes/removes the sidecar afterwards. The JS-visible result shape is
+  unchanged.
+- `napi/v8/src/unofficial_napi_contextify.cc` — already supported cached-data
+  consume/produce. Only change: compile with `kEagerCompile` when producing a
+  cache so inner functions are serialized too (matches Node's compile cache).
+- `napi/quickjs/src/internal/napi_contextify.cc` — `compile_cjs_function` now
+  consumes (`JS_ReadObject` + `JS_EvalFunction`; exception ⇒ rejected ⇒ text
+  compile) and produces (`JS_WriteObject` on the `COMPILE_ONLY` result), and
+  `compile_function` reports `cachedData`/`cachedDataProduced`/
+  `cachedDataRejected` exactly like the V8 provider.
+- `src/edge_precompile.{h,cc}` — the `--precompile` driver (file walk, package
+  `type` scope resolution with a per-directory cache, compile-only, summary,
+  exit 1 if any file failed).
+- `src/edge_cli.cc` — `CliMode::kPrecompile`, flag registration, conflicts,
+  `SetEnabledFromCli(false)` for `--no-bytecode-cache`/`--check`.
+
+## Tests
+
+- `tests/runners/test_7_bytecode_cache_phase05.cc` (gtest, V8 lane): header
+  encode/decode round-trip + every corruption mode, plus spawned-binary e2e
+  (write-on-first-run, precompile-without-executing, corrupted/stale fallback,
+  `--check` cleanliness, conflict exits, ESM skip).
+- `scripts/test-bytecode-cache.sh` (both engines): `make test-bytecode-cache`
+  / `make test-bytecode-cache-quickjs`. Covers the same scenarios plus
+  read-only trees, shebang/BOM sources, `type: module` scoping and env-var
+  opt-out, asserting via `EDGE_BYTECODE_CACHE_TRACE`.
+
+## Benchmark
+
+`benchmarks/bench-bytecode-cache.sh` (hyperfine; `EDGE_BIN` selects engine).
+`benchmarks/generate-bytecode-workload.mjs` generates a deterministic ~3.4 MB
+CJS app (150 modules + 1.5 MB vendor bundle). Lanes: cold
+(`--no-bytecode-cache`), first run (compile + write), warm (precompiled
+sidecars). Results land in `benchmarks/results/bytecode-cache-<engine>.*` with
+a printed speedup summary.
+
+Measured 2026-06-11 (Apple Silicon, warmup 3, 20 runs; empty-startup baseline
+37 ms V8 / 55 ms QuickJS):
+
+| engine | cold | first run (writes) | warm | full-startup speedup | module-load portion |
+|---|---|---|---|---|---|
+| V8 | 92.4 ms ± 2.5 | 137.6 ms ± 6.9 | 74.4 ms ± 2.7 | **1.24×** | 55 ms → 37 ms |
+| QuickJS | 184.9 ms ± 4.7 | 248.4 ms ± 7.7 | 143.4 ms ± 3.4 | **1.29×** | 130 ms → 89 ms |
+
+All 152 modules report `hit` under `EDGE_BYTECODE_CACHE_TRACE=1` on both
+engines (no rejects). The fixed cost that remains is builtin bootstrap —
+the phase-3 item below; gains grow with app size since the cached portion
+scales with user code.
+
+## Known limitations / phase 2+
+
+- **ESM (`.mjs`, `type: module`) is not cached yet.** V8 plumbing exists
+  (`unofficial_napi_module_wrap_create_source_text` accepts cached data and
+  `unofficial_napi_module_wrap_create_cached_data` is implemented); QuickJS
+  needs the stub in `napi/quickjs/src/internal/napi_module_wrap.cc`
+  (`create_cached_data`) implemented with `JS_WRITE_OBJ_BYTECODE`, plus a
+  consume path. The runtime hook belongs in the module_wrap binding layer,
+  same no-`lib/` approach.
+- **Builtins are not cached.** Embedded builtins compile on every boot via
+  `EvaluateJsModule`; a build-time bytecode catalog would speed up *empty*
+  startup and is likely the biggest absolute win. Separate initiative.
+- QuickJS sidecars are keyed to the absolute file path (stack-trace fidelity);
+  relocated trees recompile once and rewrite. V8 sidecars are relocatable.
+- Node's `module.enableCompileCache()` stubs remain disabled; sidecars
+  supersede them.
+- `vm.compileFunction` with `produceCachedData` now compiles eagerly under V8
+  (better cache coverage, marginally slower compile) — intentional deviation.
+- The Node test harness lanes (`make test-only` / `test-quickjs-only`) run with
+  `EDGE_BYTECODE_CACHE=0` so write-on-first-run does not spray sidecars into
+  `test/fixtures/`. Both lanes were verified green with the cache enabled too;
+  dedicated cache coverage lives in the suites above.

--- a/plans/bytecode-precompilation/plan.md
+++ b/plans/bytecode-precompilation/plan.md
@@ -5,39 +5,65 @@
 Cut process startup time by skipping JS parse/compile for both CommonJS and
 ES modules. Both engines serialize compiled code — V8 via `ScriptCompiler`
 code caches, QuickJS (quickjs-ng) via `JS_WriteObject`/`JS_ReadObject`
-bytecode — and the serialized form is stored as a **sidecar file next to the
-source**:
+bytecode — and the serialized form is stored in a **per-directory
+`__edgecache__/` subdirectory** next to the source, PEP 3147 (`__pycache__`)
+style:
 
 ```
-app.js / app.mjs        the source (unchanged, still authoritative)
-app.js.v8b              V8 code cache        (written by the bundled-v8 build)
-app.js.qjsb             QuickJS bytecode     (written by the quickjs build)
+src/app.js                                  the source (unchanged, authoritative)
+src/__edgecache__/app.js.v8-13-6.jsc        the cache (full filename + short engine tag)
 ```
 
-Both sidecars can coexist; each binary only reads its own suffix.
+A short engine tag — `v8-<major>-<minor>` / `qjs-<major>-<minor>` (e.g.
+`v8-13-6`, `qjs-0-14`) — is baked into the cache filename, so different engines
+and major.minor versions coexist in the same `__edgecache__/`. The header still
+carries the *full* engine version for the staleness check, so two patch builds
+sharing a major.minor reuse one filename and the header rejects + rewrites the
+stale one (correct, just a recompile — not wrong bytecode). The full
+source filename (extension kept) keys the entry (`app.js` → `app.js.<tag>.jsc`),
+so it is unique within the directory and `.js`/`.mjs`/`.cjs` siblings never
+collide. The cache lives in the
+tree (so it travels with the bundle and works read-only in prod when
+precompiled); a read-only source tree silently skips the write, like PEP 3147.
+
+The consolidated builtins cache is separate: one file next to the binary
+(`<exec-path>.builtins.v8b` / `.qjsb`), not a per-directory `__edgecache__`.
 
 ## Behavior
 
-- **Consume (default-on):** when the CJS loader or the ESM `ModuleWrap`
-  binding compiles a file and a valid sidecar exists, the engine consumes it
-  instead of parsing the source. Invalid, stale, or corrupted sidecars are
-  silently ignored (normal compile).
-- **Write-on-first-run (default-on):** when no valid sidecar exists, the
+Two independently-gated caches:
+
+- **Builtins (lib/) cache — ON by default.** Our own bytecode (a fixed set,
+  validated by engine tag + per-builtin source hash, read-only-safe) is the
+  biggest startup win at minimal risk, so it is consumed and written-on-first-
+  run for everyone, into one file next to the binary. Ship the prebuilt file
+  (`make precompile-builtins`) so the first run / read-only installs benefit
+  too.
+- **Per-file user sidecars — OFF by default (opt-in).** Arbitrary user code is
+  less battle-tested, so the per-file `__edgecache__/` sidecars are only read
+  or written when explicitly enabled. Opt in with `--bytecode-cache`,
+  `EDGE_BYTECODE_CACHE=1` (any truthy value), or `--precompile`.
+
+- **Consume:** when caching is active and a valid sidecar/builtin entry exists,
+  the engine consumes it instead of parsing the source. Invalid, stale, or
+  corrupted entries are silently ignored (normal compile).
+- **Write-on-first-run:** when caching is active and no valid entry exists, the
   runtime compiles eagerly to a bytecode handle, persists it atomically (temp
   file + rename), and executes from the same handle — the source is parsed
   exactly once. Failures (read-only filesystem, permissions) are silent.
-- **Explicit precompile:** `edge --precompile <file|dir>...` walks the paths
-  and compiles every eligible file **without executing any module body**:
-  `.cjs` always (CJS shape), `.mjs` always (module shape), `.js` per its
-  nearest `package.json` `type` (an ESM-syntax `.js` in a commonjs scope is
-  retried with the module shape — mirroring runtime detect-module).
-  `node_modules` is included.
-- **Opt-outs:** `--no-bytecode-cache` (CLI) or `EDGE_BYTECODE_CACHE=0` (env)
-  disable both reads and writes. `--check` disables the cache implicitly.
-  `--precompile` conflicts with `--check/--eval/--test/--watch/--interactive/
-  --run/--no-bytecode-cache` (exit 9).
+- **Explicit precompile:** `edge --precompile <file|dir>...` (implies user
+  sidecars on) walks the paths and compiles every eligible file **without
+  executing any module body**: `.cjs` always (CJS shape), `.mjs` always
+  (module shape), `.js` per its nearest `package.json` `type` (an ESM-syntax
+  `.js` in a commonjs scope is retried with the module shape — mirroring
+  runtime detect-module). `node_modules` is included.
+- **Kill switch:** `--no-bytecode-cache` (CLI) or `EDGE_BYTECODE_CACHE=0`
+  (env) disable **everything** including the builtins cache. `--check`
+  disables implicitly (a syntax check must not write to the tree). CLI flags
+  win over the env var. `--precompile` conflicts with `--check/--eval/--test/
+  --watch/--interactive/--run/--no-bytecode-cache` (exit 9).
 - **Tracing:** `EDGE_BYTECODE_CACHE_TRACE=1` prints `hit/miss/write/remove`
-  lines to stderr (used by tests).
+  and `builtin-*`/`builtins-*` lines to stderr (used by tests).
 
 ## Architecture: JSSource + bytecode handles
 

--- a/plans/bytecode-precompilation/plan.md
+++ b/plans/bytecode-precompilation/plan.md
@@ -2,33 +2,36 @@
 
 ## Goal
 
-Cut process startup time by skipping JS parse/compile for CommonJS modules.
-Both engines serialize compiled code — V8 via `ScriptCompiler` code caches,
-QuickJS (quickjs-ng) via `JS_WriteObject`/`JS_ReadObject` bytecode — and the
-serialized form is stored as a **sidecar file next to the source**:
+Cut process startup time by skipping JS parse/compile for both CommonJS and
+ES modules. Both engines serialize compiled code — V8 via `ScriptCompiler`
+code caches, QuickJS (quickjs-ng) via `JS_WriteObject`/`JS_ReadObject`
+bytecode — and the serialized form is stored as a **sidecar file next to the
+source**:
 
 ```
-app.js          the source (unchanged, still authoritative)
-app.js.v8b      V8 code cache        (written by the bundled-v8 build)
-app.js.qjsb     QuickJS bytecode     (written by the quickjs build)
+app.js / app.mjs        the source (unchanged, still authoritative)
+app.js.v8b              V8 code cache        (written by the bundled-v8 build)
+app.js.qjsb             QuickJS bytecode     (written by the quickjs build)
 ```
 
 Both sidecars can coexist; each binary only reads its own suffix.
 
 ## Behavior
 
-- **Consume (default-on):** when the CJS loader compiles a file and a valid
-  sidecar exists, the engine consumes it instead of parsing the source.
-  Invalid, stale, or corrupted sidecars are silently ignored (normal compile).
+- **Consume (default-on):** when the CJS loader or the ESM `ModuleWrap`
+  binding compiles a file and a valid sidecar exists, the engine consumes it
+  instead of parsing the source. Invalid, stale, or corrupted sidecars are
+  silently ignored (normal compile).
 - **Write-on-first-run (default-on):** when no valid sidecar exists, the
-  runtime produces the engine cache during the normal compile and writes the
-  sidecar atomically (temp file + rename). Failures (read-only filesystem,
-  permissions) are silent.
-- **Explicit precompile:** `edge --precompile <file|dir>...` walks the paths,
-  compiles every eligible CJS file (`.cjs` always; `.js` unless its nearest
-  `package.json` declares `"type": "module"`, `node_modules` included) and
-  writes sidecars **without executing any module body**. ESM-syntax files are
-  skipped, not failed.
+  runtime compiles eagerly to a bytecode handle, persists it atomically (temp
+  file + rename), and executes from the same handle — the source is parsed
+  exactly once. Failures (read-only filesystem, permissions) are silent.
+- **Explicit precompile:** `edge --precompile <file|dir>...` walks the paths
+  and compiles every eligible file **without executing any module body**:
+  `.cjs` always (CJS shape), `.mjs` always (module shape), `.js` per its
+  nearest `package.json` `type` (an ESM-syntax `.js` in a commonjs scope is
+  retried with the module shape — mirroring runtime detect-module).
+  `node_modules` is included.
 - **Opt-outs:** `--no-bytecode-cache` (CLI) or `EDGE_BYTECODE_CACHE=0` (env)
   disable both reads and writes. `--check` disables the cache implicitly.
   `--precompile` conflicts with `--check/--eval/--test/--watch/--interactive/
@@ -36,109 +39,253 @@ Both sidecars can coexist; each binary only reads its own suffix.
 - **Tracing:** `EDGE_BYTECODE_CACHE_TRACE=1` prints `hit/miss/write/remove`
   lines to stderr (used by tests).
 
+## Architecture: JSSource + bytecode handles
+
+The unofficial-NAPI layer models sources as a first-class type instead of
+threading cache parameters through each function:
+
+```c
+typedef struct unofficial_napi_js_source {  // exactly one of:
+  napi_value text;   //   JS string source
+  void* bytecode;    //   opaque bytecode handle
+} unofficial_napi_js_source;
+```
+
+Handles are created by two verbs and consumed by every script-accepting API
+(`contextify_run_script`, `contextify_compile_function`,
+`contextify_compile_function_for_cjs_loader`,
+`module_wrap_create_source_text`):
+
+- `unofficial_napi_bytecode_compile(text, filename, shape, params, ...)` —
+  **eager** compile (V8 `kEagerCompile`, so inner functions are serialized
+  too) producing a handle that holds the live compiled artifact plus the
+  serializable bytes. On compile failure, `can_parse_as_module_out` reports
+  the detect-module signal without a second parse.
+- `unofficial_napi_bytecode_deserialize(bytes, text, filename, shape, ...)` —
+  restores a live artifact from persisted bytes (V8: `kConsumeCodeCache`
+  compile; QuickJS: `JS_ReadObject`). Rejection is synchronous:
+  `*rejected_out = true` and no handle — the caller falls back to text and
+  drops the sidecar.
+- `unofficial_napi_bytecode_serialize(handle)` — bytes for persistence.
+- `unofficial_napi_bytecode_release(handle)`.
+
+Shapes: `script` (vm.Script), `cjs_function` (function compiled with params —
+the CJS wrapper), `module` (ES module). A handle is only usable by APIs
+compiling the same shape; the sidecar header records it (flags bit 0 = CJS,
+bit 1 = ESM) and cross-shape consumption is rejected at validation.
+
+Engine notes:
+- V8 code caches are consumed **against the original source text**, so handles
+  retain the text — giving every consumer automatic fallback.
+- QuickJS payloads are **self-validating**, mirroring V8's CachedData: the
+  provider writes a 20-byte `QJSB` header [filename XXH3-64, payload XXH3-64]
+  at serialize time and validates it at deserialize. The payload hash guards
+  corruption (`JS_ReadObject` is not hardened); the filename hash guards
+  relocation (QuickJS bytecode embeds the compile-time path/URL —
+  import.meta.url would silently go stale). A filename hash of 0 means
+  unenforced: `vm.SourceTextModule#createCachedData` writes 0 because Node
+  numbers vm module identifiers (`vm:module(N)`).
+- Neither engine validates SOURCE identity below the container on QuickJS:
+  that lives in Edge. Sidecar/builtins containers record the source hash;
+  user-facing vm cachedData buffers on QuickJS carry an Edge-owned `QJSC` +
+  XXH3-64(source) prefix (`edge_bytecode_cache::Wrap/UnwrapVmCachedData`),
+  validated and stripped before bytes reach the provider. On V8 both are
+  pass-throughs (CachedData validates natively; buffers stay Node-parity
+  raw).
+- QuickJS `JS_ReadObject` of module bytecode resolves import requests eagerly
+  at read time; since this embedding links modules explicitly afterwards
+  (`JS_SetModuleRequestModule`), `deserialize` installs a **stub module
+  loader** (RAII guard returning no-op `JS_NewCModule` entries) around the
+  read. Stubs are keyed by specifier strings, real modules by full `file://`
+  URLs — no collision; explicit linking overrides resolution.
+- QuickJS `import.meta`/dynamic-import hooks are keyed by `JSModuleDef*` →
+  record, so bytecode-restored modules behave identically once registered.
+  Caveat discovered on the real-app validation: quickjs's `js_import_meta`
+  resolves the executing module **by name** through `ctx->loaded_modules`, so
+  stub modules must NOT be registered under real URLs — they get unique
+  `edge-bytecode-stub:N` names (regression-tested: import.meta inside an
+  imported cached module).
+- `module_wrap_create_source_text`'s 8th param is a host-defined-option
+  **Symbol only** again (load-bearing for dynamic `import()` dispatch); cached
+  data travels inside the JSSource.
+
 ## Sidecar format
 
-Fixed 64-byte little-endian header + engine tag + opaque engine payload
-(`src/edge_bytecode_cache.h`):
+Fixed 48-byte little-endian header + engine tag + opaque self-validating
+engine payload (`src/edge_bytecode_cache.h`). The container is fully
+engine-agnostic — anything engine-specific (QuickJS filename + corruption
+guards) lives inside the payload, written/parsed by the provider:
 
 | field | notes |
 |---|---|
 | magic `EDGEJSBC` | |
-| format_version u32 | bump when the compile shape changes (wrapper text, params, shebang handling) |
-| flags u32 | bit0 = CJS function-compile shape v1 |
-| engine_tag_len u32 | |
-| source_len + source_hash u64 | FNV-1a-64 over the exact source string handed to the compiler (BOM/TS-stripping/shebang concerns vanish) |
-| filename_hash u64 | QuickJS writes + enforces it (its bytecode embeds the compile-time path); V8 writes 0 and stays relocatable |
-| payload_len + payload_hash u64 | corruption guard |
-| engine tag | `v8-<EDGE_EMBEDDED_V8_VERSION>` / `qjs-ng-<EDGE_EMBEDDED_QUICKJS_VERSION>` |
+| format_version u32 | bump when a compile shape or the encoding changes (wrapper text, params, shebang handling) |
+| flags u32 | bit0 = CJS function shape, bit1 = ESM module shape (one-hot; the script shape never sidecars) |
+| source_len u64 + source_hash u64 | XXH3-64 over the exact source string handed to the compiler |
+| payload_len u64 | pins the file structure — truncated/padded files reject |
+| tag_len u32 + engine tag | `v8-<EDGE_EMBEDDED_V8_VERSION>` / `qjs-ng-<EDGE_EMBEDDED_QUICKJS_VERSION>` |
+| payload | rest of file: V8 raw CachedData / QuickJS `QJSB`-headered bytecode |
 
-Validation order: magic → version → flags → tag → source hash → filename hash
-→ payload hash. Any miss = "no cache". V8 additionally self-validates
-(`CachedData::rejected`); a rejected sidecar is deleted so the next run
-rewrites it instead of re-rejecting forever.
+Validation order: magic → version → flags → structure (payload_len) → tag →
+source hash; payload integrity/identity then validates inside the engine
+provider at deserialize. Any miss = "no cache". An engine-rejected-but-
+header-valid sidecar is deleted so the next run rewrites it.
 
 ## Implementation map
 
-No JS under `lib/` was touched — the feature is invisible to the Node-ported
-loader. All logic is C++:
+No JS under `lib/` was touched. All logic is C++:
 
 - `src/edge_bytecode_cache.{h,cc}` — container format, validation, hashing,
-  atomic writes, enable state. Engine identity comes from compile defines
-  (`EDGE_EMBEDDED_V8_VERSION` / `EDGE_EMBEDDED_QUICKJS_VERSION`, the latter
-  parsed from `quickjs.h` in the root `CMakeLists.txt`).
-- `src/edge_module_loader.cc` `ContextifyCompileFunctionForCJSLoaderCallback`
-  — the single runtime hook. The JS loader's `wrapSafe` already calls this
-  binding for every user CJS module; it now reads the sidecar before the
-  compile, passes the payload as cached data into the (pre-existing)
-  `unofficial_napi_contextify_compile_function` cache parameters, and
-  writes/removes the sidecar afterwards. The JS-visible result shape is
-  unchanged.
-- `napi/v8/src/unofficial_napi_contextify.cc` — already supported cached-data
-  consume/produce. Only change: compile with `kEagerCompile` when producing a
-  cache so inner functions are serialized too (matches Node's compile cache).
-- `napi/quickjs/src/internal/napi_contextify.cc` — `compile_cjs_function` now
-  consumes (`JS_ReadObject` + `JS_EvalFunction`; exception ⇒ rejected ⇒ text
-  compile) and produces (`JS_WriteObject` on the `COMPILE_ONLY` result), and
-  `compile_function` reports `cachedData`/`cachedDataProduced`/
-  `cachedDataRejected` exactly like the V8 provider.
-- `src/edge_precompile.{h,cc}` — the `--precompile` driver (file walk, package
-  `type` scope resolution with a per-directory cache, compile-only, summary,
-  exit 1 if any file failed).
-- `src/edge_cli.cc` — `CliMode::kPrecompile`, flag registration, conflicts,
-  `SetEnabledFromCli(false)` for `--no-bytecode-cache`/`--check`.
+  atomic writes, enable state.
+- `src/edge_module_loader.cc` — CJS hook in
+  `ContextifyCompileFunctionForCJSLoaderCallback` (deserialize sidecar →
+  JSSource, or compile→serialize→write, then execute the same handle); vm
+  bindings (`vm.Script` ctor/`createCachedData`, `vm.compileFunction`) build
+  JSSource handles and set `cachedData`/`cachedDataProduced`/
+  `cachedDataRejected` themselves.
+- `src/internal_binding/binding_module_wrap.cc` — ESM hook in `ModuleWrapCtor`
+  (gated to default-loader, `file://`-backed source-text modules; vm modules
+  with user cachedData take a deserialize path that fixed the previously
+  silent no-op of `vm.SourceTextModule({cachedData})` on V8).
+- `src/edge_url.{h,cc}` — `edge_url::PathToFileURLString()` (byte-identical to
+  the JS loader's `pathToFileURL`; QuickJS bakes the URL into module
+  bytecode).
+- `src/edge_precompile.{h,cc}` — uniform driver: `bytecode_compile` →
+  `bytecode_serialize` → `WriteSidecar` per shape.
+- Providers: `napi/v8/src/unofficial_napi_contextify.cc` (BytecodeRecord +
+  shape-dispatched eager compile/consume; artifact reuse for the CJS loader
+  fast path), `napi/quickjs/src/internal/napi_contextify.cc` +
+  `napi_module_wrap.cc` (record in `napi_bytecode.h`; stub-loader guard;
+  `create_cached_data` now real — backs `vm.SourceTextModule#createCachedData`).
+- Wasm bridge: shims updated + 4 new `snapi_bridge_unofficial_bytecode_*`
+  entries with a dedicated handle table (`napi/src/napi_bridge_init.cc`,
+  `snapi.rs`, `guest/napi.rs`).
 
 ## Tests
 
 - `tests/runners/test_7_bytecode_cache_phase05.cc` (gtest, V8 lane): header
-  encode/decode round-trip + every corruption mode, plus spawned-binary e2e
-  (write-on-first-run, precompile-without-executing, corrupted/stale fallback,
-  `--check` cleanliness, conflict exits, ESM skip).
+  round-trip, every corruption mode, shape cross-rejection, spawned-binary
+  e2e. XXH3 known vectors; the container-level payload-corruption assertion
+  is engine-conditional (V8 writes no payload hash).
+- `tests/runners/test_8_builtin_bytecode.cc` (gtest): builtins container
+  round-trip, bad magic/version/tag, truncation, trailing garbage,
+  corrupt-entry drop semantics, cache-file path shape.
 - `scripts/test-bytecode-cache.sh` (both engines): `make test-bytecode-cache`
-  / `make test-bytecode-cache-quickjs`. Covers the same scenarios plus
-  read-only trees, shebang/BOM sources, `type: module` scoping and env-var
-  opt-out, asserting via `EDGE_BYTECODE_CACHE_TRACE`.
+  / `make test-bytecode-cache-quickjs` — 28 scenarios covering CJS + ESM
+  write/consume, import chains, dynamic import, `import.meta`, TLA,
+  corruption/staleness, opt-outs, read-only trees, `type: module` scoping,
+  detect-module, `--check` cleanliness, `vm.Script`/`vm.compileFunction`/
+  `vm.SourceTextModule` cachedData round-trips, and the builtins cache
+  (write/hit, corrupt-rewrite, opt-outs, read-only bin dir, output parity,
+  worker smoke — the last V8-only while QuickJS worker_threads hangs).
 
 ## Benchmark
 
-`benchmarks/bench-bytecode-cache.sh` (hyperfine; `EDGE_BIN` selects engine).
-`benchmarks/generate-bytecode-workload.mjs` generates a deterministic ~3.4 MB
-CJS app (150 modules + 1.5 MB vendor bundle). Lanes: cold
-(`--no-bytecode-cache`), first run (compile + write), warm (precompiled
-sidecars). Results land in `benchmarks/results/bytecode-cache-<engine>.*` with
-a printed speedup summary.
+`benchmarks/bench-bytecode-cache.sh` (hyperfine; `EDGE_BIN` selects engine)
+now runs **CJS and ESM lanes** over deterministic ~3.4 MB twin apps generated
+by `benchmarks/generate-bytecode-workload.mjs` (`gen/` CJS, `gen-esm/` ESM).
+Results land in `benchmarks/results/bytecode-cache-<engine>-<lane>.*`.
 
-Measured 2026-06-11 (Apple Silicon, warmup 3, 20 runs; empty-startup baseline
-37 ms V8 / 55 ms QuickJS):
+Measured 2026-06-11 after phase 3 (Apple Silicon, low-noise runs; the warm
+column includes the builtins cache, the cold column runs
+`--no-bytecode-cache`):
 
-| engine | cold | first run (writes) | warm | full-startup speedup | module-load portion |
-|---|---|---|---|---|---|
-| V8 | 92.4 ms ± 2.5 | 137.6 ms ± 6.9 | 74.4 ms ± 2.7 | **1.24×** | 55 ms → 37 ms |
-| QuickJS | 184.9 ms ± 4.7 | 248.4 ms ± 7.7 | 143.4 ms ± 3.4 | **1.29×** | 130 ms → 89 ms |
+| engine / lane | cold | warm | speedup |
+|---|---|---|---|
+| V8 / CJS | 194.0 ms | 105.0 ms | 1.85× |
+| V8 / ESM | 183.9 ms | 128.7 ms | 1.43× |
+| V8 / empty startup | 69.1 ms | 33.8 ms | 2.04× |
+| QuickJS / CJS | 178.2 ms | 88.4 ms | 2.02× |
+| QuickJS / ESM | 202.8 ms | 118.6 ms | 1.71× |
+| QuickJS / empty startup | 81.4 ms | 35.7 ms | 2.28× |
 
-All 152 modules report `hit` under `EDGE_BYTECODE_CACHE_TRACE=1` on both
-engines (no rejects). The fixed cost that remains is builtin bootstrap —
-the phase-3 item below; gains grow with app size since the cached portion
-scales with user code.
+Real-app validation (Astro server, 7.3 MB ESM + React CJS, 167 sidecars,
+time-to-first-HTTP-response, 8 runs each): QuickJS 525.1 → 402.6 ms
+(**−122 ms, 23%**); V8 204.4 → 195.3 ms (**−9 ms** — flipped from the
+pre-phase-3 net-zero once sidecar reads got cheap and builtins stopped
+compiling). Per-stage: QuickJS to-listen 193 → 143 ms, first-request
+332 → 260 ms.
 
-## Known limitations / phase 2+
+## Phase 3: fast sidecar reads + consolidated builtins cache
 
-- **ESM (`.mjs`, `type: module`) is not cached yet.** V8 plumbing exists
-  (`unofficial_napi_module_wrap_create_source_text` accepts cached data and
-  `unofficial_napi_module_wrap_create_cached_data` is implemented); QuickJS
-  needs the stub in `napi/quickjs/src/internal/napi_module_wrap.cc`
-  (`create_cached_data`) implemented with `JS_WRITE_OBJ_BYTECODE`, plus a
-  consume path. The runtime hook belongs in the module_wrap binding layer,
-  same no-`lib/` approach.
-- **Builtins are not cached.** Embedded builtins compile on every boot via
-  `EvaluateJsModule`; a build-time bytecode catalog would speed up *empty*
-  startup and is likely the biggest absolute win. Separate initiative.
-- QuickJS sidecars are keyed to the absolute file path (stack-trace fidelity);
-  relocated trees recompile once and rewrite. V8 sidecars are relocatable.
+Shipped 2026-06-11. Two independent wins:
+
+**A. Sidecar read path (container format v2).**
+- Container hashing switched FNV-1a → **XXH3-64** (vendored official xxhash
+  v0.8.2 single-header at `deps/xxhash/` and
+  `napi/quickjs/src/internal/xxhash.h`; zstd's bundled xxhash hard-defines
+  `XXH_NO_XXH3`, hence the copies). Ownership split: Edge owns the
+  engine-agnostic container (source identity + structure) and the vm
+  cachedData source-hash wrapper; the QuickJS provider owns its payload's
+  self-validation (`QJSB` header: filename + corruption hashes), mirroring
+  what V8's CachedData does internally. `kFormatVersion` is 4 — older
+  sidecars recompile once and rewrite.
+- The payload hash is engine-conditional like the filename hash: V8 writes 0
+  and skips the check (CachedData self-validates; `rejected` already falls
+  back), QuickJS keeps it (its reader is not hardened).
+- `ReadSidecar` does one sized `fread` into `SidecarPayload` and validates in
+  place; `DecodeSidecar` returns payload offset/length instead of copying.
+  Measured on the Astro app (167 hits): read+hash dropped **~20 → 5.6 ms** on
+  V8 (3.8 MB of payloads) and **~40 → 3.7 ms** on QuickJS (9.6 MB).
+
+**B. Builtins consolidated bytecode cache (`src/edge_builtin_bytecode.{h,cc}`).**
+- One file next to the binary: `<exec-path>.builtins.v8b` / `.qjsb` (magic
+  `EDGEJSBB`; entries `[kind, id_len, payload_len, source_xxh3, payload_xxh3,
+  id, payload]`). Kinds 0–5 pin the compile shape: four cjs-function
+  parameter shapes (per-context / bootstrap-realm / bootstrap-main / lazy
+  builtin) plus the two `EvaluateJsModule` wrapper-script shapes; the source
+  hash covers the exact string handed to the compiler, so wrapper or
+  parameter drift self-invalidates.
+- All three builtin compile paths consult it (`BuiltinsCompileFunctionCallback`,
+  `ExecuteBuiltinFromNative`, and the builtin branch of `EvaluateJsModule`,
+  the latter via `unofficial_napi_contextify_run_script` with a null sandbox);
+  any bytecode failure falls back to the original text path and its exact
+  error shaping. ~96 entries (≈1.5 MB V8 / ≈3.6 MB QuickJS) by an empty boot.
+- The store is process-global (mutex; workers record into the same map);
+  `FlushIfDirty()` runs once at `RunWithFreshEnv` teardown with an atomic
+  tmp+rename. Read-only install dirs are a silent no-op. Same opt-outs as
+  sidecars (`--no-bytecode-cache`, `EDGE_BYTECODE_CACHE=0`, `--check`).
+- V8's generic `unofficial_napi_contextify_compile_function` gained the
+  artifact fast path the cjs_loader variant already had (guarded on context,
+  params, offsets, filename, and host-defined-option symbol incl. the
+  relaxed CJS default), so builtin hits consume the code cache once, not
+  twice — empty-startup warm went 47 → 34 ms with it.
+- Trace lines (`EDGE_BYTECODE_CACHE_TRACE=1`): `builtin-hit/builtin-miss/`
+  `builtins-load/builtins-write/builtins-write-failed/builtins-load-failed`.
+
+## Known limitations / follow-ups
+
+- **V8 flag drift thrashes the builtins file**: V8's flags hash is part of
+  CachedData validation, so alternating flag sets (e.g. `--prof` on/off)
+  reject + rewrite all builtin entries each run. Folding the V8 flags hash
+  into the engine tag is a follow-up.
+- Multi-process first-boot races on the builtins file are last-writer-wins
+  (both writers produce valid files; losers recompile next run).
+- `worker_threads` hangs on QuickJS (parent never receives messages) —
+  pre-existing engine issue independent of the cache (reproduces on a clean
+  tree with `--no-bytecode-cache`); the worker e2e scenario is V8-only until
+  that is fixed.
+- QuickJS payloads are keyed to the absolute path/URL (stack-trace and
+  `import.meta.url` fidelity) via the provider's `QJSB` filename hash;
+  relocated trees recompile once and rewrite (e2e-covered). V8 sidecars are
+  relocatable.
+- On V8, the ESM consume path deserializes the cache twice per module (once at
+  `deserialize` for synchronous rejection, once inside `create_source_text`
+  with the loader's host-defined-options) — still far cheaper than a parse;
+  optimization candidate.
+- vm semantics now match Node where they previously didn't:
+  `vm.Script({cachedData})` validates and reports `cachedDataRejected`
+  honestly (any ArrayBufferView flavor accepted, incl. Float16Array/DataView);
+  `vm.SourceTextModule({cachedData})` consumes for real and throws
+  `ERR_VM_MODULE_CACHED_DATA_REJECTED` on mismatch (the constructor throw
+  lives in the C++ binding since the ported lib omits the JS-side check).
+  `test-vm-cached-data.js`, `test-vm-createcacheddata.js` and
+  `test-vm-module-cached-data.js` pass on both engines (not CI-gated).
+  `script.run*` still compiles from text (as before); QuickJS cannot
+  engine-validate `vm.compileFunction` cachedData against mismatched params
+  (bytecode encodes them) — sidecar paths always use fixed params.
+- The Node test harness lanes run with `EDGE_BYTECODE_CACHE=0` so
+  write-on-first-run does not spray sidecars into `test/fixtures/`. Both lanes
+  were verified green with the cache enabled too.
 - Node's `module.enableCompileCache()` stubs remain disabled; sidecars
   supersede them.
-- `vm.compileFunction` with `produceCachedData` now compiles eagerly under V8
-  (better cache coverage, marginally slower compile) — intentional deviation.
-- The Node test harness lanes (`make test-only` / `test-quickjs-only`) run with
-  `EDGE_BYTECODE_CACHE=0` so write-on-first-run does not spray sidecars into
-  `test/fixtures/`. Both lanes were verified green with the cache enabled too;
-  dedicated cache coverage lives in the suites above.

--- a/plans/bytecode-precompilation/plan.md
+++ b/plans/bytecode-precompilation/plan.md
@@ -77,21 +77,26 @@ bit 1 = ESM) and cross-shape consumption is rejected at validation.
 Engine notes:
 - V8 code caches are consumed **against the original source text**, so handles
   retain the text — giving every consumer automatic fallback.
-- QuickJS payloads are **self-validating**, mirroring V8's CachedData: the
-  provider writes a 20-byte `QJSB` header [filename XXH3-64, payload XXH3-64]
-  at serialize time and validates it at deserialize. The payload hash guards
-  corruption (`JS_ReadObject` is not hardened); the filename hash guards
-  relocation (QuickJS bytecode embeds the compile-time path/URL —
-  import.meta.url would silently go stale). A filename hash of 0 means
-  unenforced: `vm.SourceTextModule#createCachedData` writes 0 because Node
-  numbers vm module identifiers (`vm:module(N)`).
-- Neither engine validates SOURCE identity below the container on QuickJS:
-  that lives in Edge. Sidecar/builtins containers record the source hash;
-  user-facing vm cachedData buffers on QuickJS carry an Edge-owned `QJSC` +
-  XXH3-64(source) prefix (`edge_bytecode_cache::Wrap/UnwrapVmCachedData`),
-  validated and stripped before bytes reach the provider. On V8 both are
-  pass-throughs (CachedData validates natively; buffers stay Node-parity
-  raw).
+- QuickJS payloads are **fully self-validating**, mirroring everything V8's
+  CachedData checks natively: the provider writes a 40-byte `QJSB` header
+  `[magic, version, shape u8, reserved, source XXH3, params XXH3, filename
+  XXH3, payload XXH3]` at serialize time and rejects any mismatch at
+  deserialize. shape/source/params reject bytes compiled from a different
+  compile shape, a different source, or a different CJS parameter list (a
+  whole-script cache fed to `compileFunction`, or `params:['a']` consumed as
+  `['x']` — all of which V8 rejects too). The payload hash guards corruption
+  (`JS_ReadObject` is not hardened). The filename hash guards relocation
+  (QuickJS bytecode embeds the compile-time path/URL — `import.meta.url` would
+  silently go stale); a stored hash of 0 is unenforced, written by
+  `vm.SourceTextModule#createCachedData` because Node numbers vm module
+  identifiers (`vm:module(N)`).
+- Because the QJSB header covers source identity, **the NAPI providers
+  self-validate untrusted vm cachedData directly** — Edge hands user buffers
+  straight to `bytecode_deserialize` and trusts `rejected_out`. There is no
+  Edge-side cachedData wrapper on either engine (V8 CachedData validates
+  natively and stays Node-parity raw; QuickJS validates via QJSB).
+  Sidecar/builtins containers also record their own source hash, so their
+  payloads are double-checked but never wrapped.
 - QuickJS `JS_ReadObject` of module bytecode resolves import requests eagerly
   at read time; since this embedding links modules explicitly afterwards
   (`JS_SetModuleRequestModule`), `deserialize` installs a **stub module
@@ -215,11 +220,12 @@ Shipped 2026-06-11. Two independent wins:
   v0.8.2 single-header at `deps/xxhash/` and
   `napi/quickjs/src/internal/xxhash.h`; zstd's bundled xxhash hard-defines
   `XXH_NO_XXH3`, hence the copies). Ownership split: Edge owns the
-  engine-agnostic container (source identity + structure) and the vm
-  cachedData source-hash wrapper; the QuickJS provider owns its payload's
-  self-validation (`QJSB` header: filename + corruption hashes), mirroring
-  what V8's CachedData does internally. `kFormatVersion` is 4 — older
-  sidecars recompile once and rewrite.
+  engine-agnostic container (source identity + structure); the QuickJS
+  provider owns its payload's full self-validation (`QJSB` header: shape,
+  source, params, filename, and corruption hashes), mirroring what V8's
+  CachedData does internally — so there is no Edge-side cachedData wrapper on
+  either engine. `kFormatVersion` is 4 — older sidecars recompile once and
+  rewrite.
 - The payload hash is engine-conditional like the filename hash: V8 writes 0
   and skips the check (CachedData self-validates; `rejected` already falls
   back), QuickJS keeps it (its reader is not hardened).

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -118,6 +118,30 @@ out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
 [ "$out" = "changed" ] || fail "stale sidecar served old code: $out"
 pass
 
+# --- relocated tree ---------------------------------------------------------------
+# QuickJS bytecode embeds the compile-time path/URL (import.meta.url, stack
+# traces), so its self-validating payload header rejects relocated sidecars
+# and the runtime recompiles + rewrites. V8 caches are relocatable and keep
+# hitting. Either way: correct output, no stale paths.
+begin "relocated tree recompiles (quickjs) or keeps hitting (v8)"
+DIR="$WORKDIR/relocate-src"
+mkdir -p "$DIR"
+cat > "$DIR/main.mjs" <<'RELOC_EOF'
+console.log(import.meta.url.endsWith('relocate-dst/main.mjs') ? 'url-ok' : 'url-stale');
+RELOC_EOF
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
+[ -f "$DIR/main.mjs$SUFFIX" ] || fail "missing sidecar before relocation"
+mv "$DIR" "$WORKDIR/relocate-dst"
+out="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$WORKDIR/relocate-dst/main.mjs" 2>"$WORKDIR/reloc.txt")"
+[ "$out" = "url-ok" ] || fail "relocated import.meta.url is stale: $out"
+if [ "$SUFFIX" = ".qjsb" ]; then
+  grep -q "remove $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "quickjs did not drop the relocated sidecar"
+  grep -q "write $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "quickjs did not rewrite the relocated sidecar"
+else
+  grep -q "hit $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "v8 should consume relocated sidecars"
+fi
+pass
+
 # --- opt-outs ------------------------------------------------------------------
 begin "--no-bytecode-cache writes and reads nothing"
 DIR="$WORKDIR/optout-flag"

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -166,8 +166,156 @@ echo '{ "type": "module" }' > "$DIR/package.json"
 echo 'export const x = 1;' > "$DIR/esm.js"
 echo 'module.exports = 1;' > "$DIR/legacy.cjs"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
-[ ! -f "$DIR/esm.js$SUFFIX" ] || fail ".js in type=module scope must be skipped"
+[ -f "$DIR/esm.js$SUFFIX" ] || fail ".js in type=module scope must get an ESM-shape sidecar"
 [ -f "$DIR/legacy.cjs$SUFFIX" ] || fail ".cjs must be precompiled regardless of scope"
+pass
+
+# --- ESM sidecars -----------------------------------------------------------------
+begin "esm write-on-first-run then consume"
+DIR="$WORKDIR/esm-first-run"
+mkdir -p "$DIR"
+cat > "$DIR/lib.mjs" <<'EOF'
+export const value = 21;
+EOF
+cat > "$DIR/main.mjs" <<'EOF'
+import { value } from './lib.mjs';
+console.log(value * 2);
+EOF
+out1="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.mjs" 2>"$WORKDIR/etrace1.txt")"
+[ "$out1" = "42" ] || fail "first run output: $out1"
+grep -q "write $DIR/main.mjs$SUFFIX" "$WORKDIR/etrace1.txt" || fail "first run did not write esm sidecar"
+out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.mjs" 2>"$WORKDIR/etrace2.txt")"
+[ "$out2" = "42" ] || fail "second run output: $out2"
+grep -q "hit $DIR/main.mjs$SUFFIX" "$WORKDIR/etrace2.txt" || fail "second run did not consume esm sidecar"
+grep -q "hit $DIR/lib.mjs$SUFFIX" "$WORKDIR/etrace2.txt" || fail "imported module did not consume esm sidecar"
+pass
+
+begin "esm import chain fully cached"
+DIR="$WORKDIR/esm-chain"
+mkdir -p "$DIR"
+echo 'export const c = 7;' > "$DIR/c.mjs"
+printf "import { c } from './c.mjs';\nexport const b = c * 2;\n" > "$DIR/b.mjs"
+printf "import { b } from './b.mjs';\nconsole.log(b * 3);\n" > "$DIR/a.mjs"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
+out="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/a.mjs" 2>"$WORKDIR/chain.txt")"
+[ "$out" = "42" ] || fail "chain output: $out"
+hits="$(grep -c "hit " "$WORKDIR/chain.txt")"
+[ "$hits" -eq 3 ] || fail "expected 3 cache hits, got $hits"
+pass
+
+begin "dynamic import and import.meta from cached modules"
+DIR="$WORKDIR/esm-dynamic"
+mkdir -p "$DIR"
+echo 'export const value = 5;' > "$DIR/lib.mjs"
+cat > "$DIR/main.mjs" <<'EOF'
+const mod = await import('./lib.mjs');
+console.log(mod.value, import.meta.url.endsWith('main.mjs'));
+EOF
+"$EDGE_BIN" "$DIR/main.mjs" >/dev/null 2>&1
+out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
+[ "$out" = "5 true" ] || fail "cached dynamic import / import.meta: $out"
+pass
+
+# Regression: import.meta inside an IMPORTED cached module. The importer's
+# bytecode read used to register stub modules under the dependency's real URL,
+# shadowing the real module in quickjs's name-based import.meta lookup.
+begin "import.meta in imported cached module"
+DIR="$WORKDIR/esm-meta-dep"
+mkdir -p "$DIR"
+cat > "$DIR/dep.mjs" <<'EOF'
+export const fromDep = import.meta.url;
+EOF
+cat > "$DIR/main.mjs" <<'EOF'
+import { fromDep } from './dep.mjs';
+console.log(typeof fromDep, String(fromDep).endsWith('dep.mjs'));
+EOF
+"$EDGE_BIN" "$DIR/main.mjs" >/dev/null 2>&1
+out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
+[ "$out" = "string true" ] || fail "import.meta in imported cached module: $out"
+pass
+
+begin "top-level await module cached"
+DIR="$WORKDIR/esm-tla"
+mkdir -p "$DIR"
+cat > "$DIR/main.mjs" <<'EOF'
+const v = await Promise.resolve('tla-ok');
+console.log(v);
+EOF
+"$EDGE_BIN" "$DIR/main.mjs" >/dev/null 2>&1
+out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
+[ "$out" = "tla-ok" ] || fail "cached TLA module: $out"
+pass
+
+begin "corrupted esm sidecar falls back"
+DIR="$WORKDIR/esm-corrupt"
+mkdir -p "$DIR"
+echo 'console.log("esm-fine");' > "$DIR/main.mjs"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
+printf 'garbage' > "$DIR/main.mjs$SUFFIX"
+out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
+[ "$out" = "esm-fine" ] || fail "corrupted esm sidecar broke execution: $out"
+pass
+
+begin "stale esm sidecar falls back"
+DIR="$WORKDIR/esm-stale"
+mkdir -p "$DIR"
+echo 'console.log("esm-old");' > "$DIR/main.mjs"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
+echo 'console.log("esm-new");' > "$DIR/main.mjs"
+out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
+[ "$out" = "esm-new" ] || fail "stale esm sidecar served old code: $out"
+pass
+
+begin "detect-module .js precompiles as ESM and runs cached"
+DIR="$WORKDIR/esm-detect"
+mkdir -p "$DIR"
+echo 'export default 1; console.log("detected");' > "$DIR/ambiguous.js"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
+[ -f "$DIR/ambiguous.js$SUFFIX" ] || fail "ESM-syntax .js should get an ESM-shape sidecar"
+out="$("$EDGE_BIN" "$DIR/ambiguous.js" 2>/dev/null)"
+[ "$out" = "detected" ] || fail "detect-module run with sidecar: $out"
+pass
+
+# --- vm cachedData round-trips ----------------------------------------------------
+begin "vm.Script and vm.compileFunction cachedData round-trip"
+DIR="$WORKDIR/vm-cache"
+mkdir -p "$DIR"
+cat > "$DIR/vm-test.cjs" <<'EOF'
+const vm = require('node:vm');
+const script = new vm.Script('1 + 41', { produceCachedData: true });
+if (!script.cachedData || script.cachedData.length === 0) throw new Error('no script cachedData');
+const script2 = new vm.Script('1 + 41', { cachedData: script.cachedData });
+if (script2.cachedDataRejected !== false) throw new Error('script cachedData rejected: ' + script2.cachedDataRejected);
+if (script2.runInThisContext() !== 42) throw new Error('script2 result');
+const fn = vm.compileFunction('return a + b;', ['a', 'b'], { produceCachedData: true, filename: 'fn-test.js' });
+if (!fn.cachedData || fn.cachedData.length === 0) throw new Error('no fn cachedData');
+const fn2 = vm.compileFunction('return a + b;', ['a', 'b'], { cachedData: fn.cachedData, filename: 'fn-test.js' });
+if (fn2(40, 2) !== 42) throw new Error('fn2 result');
+console.log('vm-ok');
+EOF
+out="$("$EDGE_BIN" --no-bytecode-cache "$DIR/vm-test.cjs" 2>&1)"
+[ "$out" = "vm-ok" ] || fail "vm cachedData round-trip: $out"
+pass
+
+begin "vm.SourceTextModule cachedData round-trip"
+DIR="$WORKDIR/vm-module"
+mkdir -p "$DIR"
+cat > "$DIR/vm-module-test.cjs" <<'EOF'
+const vm = require('node:vm');
+async function main() {
+  const m1 = new vm.SourceTextModule('export const x = 42;');
+  const cached = m1.createCachedData();
+  if (!cached || cached.length === 0) throw new Error('no module cachedData');
+  const m2 = new vm.SourceTextModule('export const x = 42;', { cachedData: cached });
+  await m2.link(() => { throw new Error('no links expected'); });
+  await m2.evaluate();
+  if (m2.namespace.x !== 42) throw new Error('module namespace');
+  console.log('vm-module-ok');
+}
+main().catch((err) => { console.error(err.message); process.exit(1); });
+EOF
+out="$("$EDGE_BIN" --no-bytecode-cache --no-warnings --experimental-vm-modules "$DIR/vm-module-test.cjs" 2>/dev/null)"
+[ "$out" = "vm-module-ok" ] || fail "vm.SourceTextModule cachedData round-trip: $out"
 pass
 
 # --- --check stays clean ---------------------------------------------------------

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -342,6 +342,54 @@ out="$("$EDGE_BIN" --no-bytecode-cache --no-warnings --experimental-vm-modules "
 [ "$out" = "vm-module-ok" ] || fail "vm.SourceTextModule cachedData round-trip: $out"
 pass
 
+# --- vm cachedData cross-shape is never executed during compile -------------------
+# A whole-script cache fed to vm.compileFunction must not run the script body
+# while compiling (the QJSB shape tag / V8 compile-kind guard reject it). Both
+# engines.
+begin "vm cachedData cross-shape does not execute body"
+DIR="$WORKDIR/vm-xshape"
+mkdir -p "$DIR"
+cat > "$DIR/xshape.cjs" <<'EOF'
+const vm = require('node:vm');
+globalThis.__hit = 0;
+const s = new vm.Script("globalThis.__hit++; 7", { produceCachedData: true });
+if (globalThis.__hit !== 0) throw new Error('Script ctor ran body');
+// Feed the script cache to compileFunction (wrong shape). Must not execute.
+const f = vm.compileFunction("globalThis.__hit++; 7", [], { cachedData: s.cachedData });
+if (globalThis.__hit !== 0) throw new Error('cross-shape executed body during compile');
+console.log('xshape-ok');
+EOF
+out="$("$EDGE_BIN" --no-bytecode-cache "$DIR/xshape.cjs" 2>&1)"
+[ "$out" = "xshape-ok" ] || fail "vm cross-shape body execution: $out"
+pass
+
+# --- QuickJS self-validating payload rejects wrong source/params ------------------
+# QuickJS bytecode carries no source identity natively, so the provider's QJSB
+# header enforces source + params. (V8's CompileFunction code cache is not
+# source-validated — matching Node — so this strict check is QuickJS-only.)
+if [ "$SUFFIX" = ".qjsb" ]; then
+  begin "quickjs cachedData rejects wrong source and params"
+  DIR="$WORKDIR/vm-strict"
+  mkdir -p "$DIR"
+  cat > "$DIR/strict.cjs" <<'EOF'
+const vm = require('node:vm');
+// Different source.
+const a = vm.compileFunction("return 1", [], { produceCachedData: true });
+const b = vm.compileFunction("return 2", [], { cachedData: a.cachedData });
+if (b.cachedDataRejected !== true) throw new Error('wrong-source not rejected');
+if (b() !== 2) throw new Error('recompiled body wrong: ' + b());
+// Different params.
+const c = vm.compileFunction("return p", ["p", "q"], { produceCachedData: true });
+const d = vm.compileFunction("return p", ["p"], { cachedData: c.cachedData });
+if (d.cachedDataRejected !== true) throw new Error('wrong-params not rejected');
+if (d(5) !== 5) throw new Error('recompiled params wrong: ' + d(5));
+console.log('strict-ok');
+EOF
+  out="$("$EDGE_BIN" --no-bytecode-cache "$DIR/strict.cjs" 2>&1)"
+  [ "$out" = "strict-ok" ] || fail "quickjs strict cachedData rejection: $out"
+  pass
+fi
+
 # --- --check stays clean ---------------------------------------------------------
 begin "--check writes no sidecars"
 DIR="$WORKDIR/checkmode"

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -199,7 +199,7 @@ printf "import { b } from './b.mjs';\nconsole.log(b * 3);\n" > "$DIR/a.mjs"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
 out="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/a.mjs" 2>"$WORKDIR/chain.txt")"
 [ "$out" = "42" ] || fail "chain output: $out"
-hits="$(grep -c "hit " "$WORKDIR/chain.txt")"
+hits="$(grep -c "] hit " "$WORKDIR/chain.txt")"  # sidecar hits only, not builtin-hit
 [ "$hits" -eq 3 ] || fail "expected 3 cache hits, got $hits"
 pass
 
@@ -332,6 +332,116 @@ begin "--precompile conflict validation"
 "$EDGE_BIN" --precompile --check x.js >/dev/null 2>&1 && fail "--precompile --check should fail"
 "$EDGE_BIN" --precompile --no-bytecode-cache x >/dev/null 2>&1 && fail "--precompile --no-bytecode-cache should fail"
 pass
+
+# === Builtins consolidated bytecode cache (<binary>.builtins<suffix>) ==============
+# The cache lands next to the binary, so each scenario gets its own COPY of
+# the binary (copy, not symlink: the exec-path lookup resolves symlinks).
+BUILTINS_FILE_NAME="edge.builtins$SUFFIX"
+
+make_builtins_bin() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cp "$EDGE_BIN" "$dir/edge"
+  echo 'console.log(1 + 1);' > "$dir/app.js"
+}
+
+# --- first run writes, second run hits --------------------------------------------
+begin "builtins cache write then hit"
+DIR="$WORKDIR/builtins-basic"
+make_builtins_bin "$DIR"
+out1="$(EDGE_BYTECODE_CACHE_TRACE=1 "$DIR/edge" "$DIR/app.js" 2>"$DIR/trace1.txt")"
+[ "$out1" = "2" ] || fail "first run output: $out1"
+[ -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "missing $BUILTINS_FILE_NAME after first run"
+grep -q "builtins-write" "$DIR/trace1.txt" || fail "first run did not trace builtins-write"
+out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$DIR/edge" "$DIR/app.js" 2>"$DIR/trace2.txt")"
+[ "$out2" = "2" ] || fail "second run output: $out2"
+grep -q "builtin-hit" "$DIR/trace2.txt" || fail "second run had no builtin-hit"
+grep -q "builtins-write" "$DIR/trace2.txt" && fail "second run rewrote the builtins cache"
+grep -q "builtin-miss" "$DIR/trace2.txt" && fail "second run had builtin-miss lines"
+pass
+
+# --- corrupted builtins file: output parity + rewrite ------------------------------
+begin "corrupted builtins cache falls back and rewrites"
+DIR="$WORKDIR/builtins-corrupt"
+make_builtins_bin "$DIR"
+"$DIR/edge" "$DIR/app.js" >/dev/null 2>&1
+[ -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "missing builtins cache to corrupt"
+# Truncate mid-file: structural validation fails, all entries recompile.
+head -c 100 "$DIR/$BUILTINS_FILE_NAME" > "$DIR/$BUILTINS_FILE_NAME.tmp"
+mv "$DIR/$BUILTINS_FILE_NAME.tmp" "$DIR/$BUILTINS_FILE_NAME"
+out="$(EDGE_BYTECODE_CACHE_TRACE=1 "$DIR/edge" "$DIR/app.js" 2>"$DIR/trace.txt")"
+[ "$out" = "2" ] || fail "corrupted-cache run output: $out"
+grep -q "builtins-load-failed" "$DIR/trace.txt" || fail "no builtins-load-failed trace"
+grep -q "builtins-write" "$DIR/trace.txt" || fail "corrupt cache was not rewritten"
+out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$DIR/edge" "$DIR/app.js" 2>"$DIR/trace2.txt")"
+[ "$out2" = "2" ] || fail "post-rewrite run output: $out2"
+grep -q "builtin-hit" "$DIR/trace2.txt" || fail "rewritten cache produced no hits"
+pass
+
+# --- opt-outs write no builtins file -----------------------------------------------
+begin "builtins cache opt-outs write nothing"
+DIR="$WORKDIR/builtins-optout"
+make_builtins_bin "$DIR"
+"$DIR/edge" --no-bytecode-cache "$DIR/app.js" >/dev/null 2>&1
+[ ! -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "--no-bytecode-cache wrote builtins cache"
+EDGE_BYTECODE_CACHE=0 "$DIR/edge" "$DIR/app.js" >/dev/null 2>&1
+[ ! -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "EDGE_BYTECODE_CACHE=0 wrote builtins cache"
+"$DIR/edge" --check "$DIR/app.js" >/dev/null 2>&1
+[ ! -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "--check wrote builtins cache"
+pass
+
+# --- read-only binary dir: silent no-op --------------------------------------------
+begin "read-only binary dir runs fine without builtins cache"
+DIR="$WORKDIR/builtins-readonly"
+make_builtins_bin "$DIR"
+chmod a-w "$DIR"
+out="$("$DIR/edge" "$DIR/app.js" 2>/dev/null)"
+chmod u+w "$DIR"
+[ "$out" = "2" ] || fail "read-only dir run output: $out"
+[ ! -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "builtins cache appeared in read-only dir"
+pass
+
+# --- cached vs disabled output parity ----------------------------------------------
+begin "builtins cached output matches disabled output"
+DIR="$WORKDIR/builtins-parity"
+make_builtins_bin "$DIR"
+cat > "$DIR/app.js" <<'EOF'
+const os = require('node:os');
+const path = require('node:path');
+const { Buffer } = require('node:buffer');
+console.log(typeof os.platform(), path.join('a', 'b'), Buffer.from('hi').toString('hex'));
+process.nextTick(() => console.log('tick'));
+EOF
+expected="$("$DIR/edge" --no-bytecode-cache "$DIR/app.js" 2>/dev/null)"
+"$DIR/edge" "$DIR/app.js" >/dev/null 2>&1  # seed
+warm="$("$DIR/edge" "$DIR/app.js" 2>/dev/null)"
+[ "$warm" = "$expected" ] || fail "cached output differs: '$warm' vs '$expected'"
+pass
+
+# --- worker_threads smoke -----------------------------------------------------------
+# Skipped on QuickJS: worker_threads hangs there independently of the bytecode
+# cache (the parent never receives worker messages; pre-existing engine issue,
+# reproducible on a clean tree with --no-bytecode-cache).
+if [ "$SUFFIX" = ".qjsb" ]; then
+  echo "skip: builtins cache worker_threads smoke (worker_threads hangs on quickjs)"
+else
+  begin "builtins cache worker_threads smoke"
+  DIR="$WORKDIR/builtins-worker"
+  make_builtins_bin "$DIR"
+  cat > "$DIR/app.js" <<'EOF'
+const { Worker } = require('node:worker_threads');
+const worker = new Worker("require('node:worker_threads').parentPort.postMessage(40 + 2);", { eval: true });
+worker.on('message', (value) => { console.log(value); });
+setTimeout(() => { console.error('worker timed out'); process.exit(1); }, 20000);
+EOF
+  out1="$("$DIR/edge" "$DIR/app.js" 2>/dev/null)"
+  [ "$out1" = "42" ] || fail "worker first run output: $out1"
+  [ -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "worker run wrote no builtins cache"
+  out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$DIR/edge" "$DIR/app.js" 2>"$DIR/trace2.txt")"
+  [ "$out2" = "42" ] || fail "worker second run output: $out2"
+  grep -q "builtin-hit" "$DIR/trace2.txt" || fail "worker second run had no builtin-hit"
+  pass
+fi
 
 echo
 if [ "$FAILURES" -gt 0 ]; then

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# End-to-end tests for bytecode sidecar caches (.v8b / .qjsb).
+# Usage: EDGE_BIN=./build-edge/edge ./scripts/test-bytecode-cache.sh
+set -u
+
+EDGE_BIN="${EDGE_BIN:?usage: EDGE_BIN=<path-to-edge> $0}"
+EDGE_BIN="$(cd "$(dirname "$EDGE_BIN")" && pwd)/$(basename "$EDGE_BIN")"
+
+if [ ! -x "$EDGE_BIN" ]; then
+  echo "error: EDGE_BIN is not executable: $EDGE_BIN" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/edge-bytecode-cache-test.XXXXXX")"
+# Resolve symlinked temp roots (macOS /var -> /private/var) so trace-output
+# greps match the canonical paths the runtime reports.
+WORKDIR="$(cd "$WORKDIR" && pwd -P)"
+trap 'chmod -R u+w "$WORKDIR" 2>/dev/null; rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+CURRENT=""
+CURRENT_FAILURES=0
+
+begin() {
+  CURRENT="$1"
+  CURRENT_FAILURES=$FAILURES
+}
+
+fail() {
+  echo "FAIL: $CURRENT: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  if [ "$FAILURES" -eq "$CURRENT_FAILURES" ]; then
+    echo "ok: $CURRENT"
+  fi
+}
+
+sidecar_suffix() {
+  # Detect which suffix this binary writes.
+  local dir="$WORKDIR/suffix-probe"
+  mkdir -p "$dir"
+  echo "module.exports = 1;" > "$dir/probe.js"
+  "$EDGE_BIN" --precompile "$dir" >/dev/null 2>&1
+  if [ -f "$dir/probe.js.v8b" ]; then
+    echo ".v8b"
+  elif [ -f "$dir/probe.js.qjsb" ]; then
+    echo ".qjsb"
+  else
+    echo ""
+  fi
+}
+
+SUFFIX="$(sidecar_suffix)"
+if [ -z "$SUFFIX" ]; then
+  echo "error: could not determine sidecar suffix (precompile probe wrote nothing)" >&2
+  exit 1
+fi
+echo "testing $EDGE_BIN (sidecar suffix: $SUFFIX)"
+
+make_project() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/lib.js" <<'EOF'
+module.exports = { value: 21 };
+EOF
+  cat > "$dir/main.js" <<'EOF'
+const lib = require('./lib.js');
+console.log(lib.value * 2);
+EOF
+}
+
+# --- precompile writes sidecars and the cached run output is identical -------
+begin "precompile then run"
+DIR="$WORKDIR/precompile"
+make_project "$DIR"
+baseline="$("$EDGE_BIN" --no-bytecode-cache "$DIR/main.js" 2>/dev/null)"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
+[ -f "$DIR/main.js$SUFFIX" ] || fail "missing main.js$SUFFIX"
+[ -f "$DIR/lib.js$SUFFIX" ] || fail "missing lib.js$SUFFIX"
+cached="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace.txt")"
+[ "$cached" = "$baseline" ] || fail "output mismatch: '$cached' vs '$baseline'"
+grep -q "hit $DIR/main.js$SUFFIX" "$WORKDIR/trace.txt" || fail "expected a cache hit for main.js"
+pass
+
+# --- write-on-first-run -------------------------------------------------------
+begin "write-on-first-run then consume"
+DIR="$WORKDIR/first-run"
+make_project "$DIR"
+out1="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace1.txt")"
+[ "$out1" = "42" ] || fail "first run output: $out1"
+grep -q "write $DIR/main.js$SUFFIX" "$WORKDIR/trace1.txt" || fail "first run did not write sidecar"
+out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace2.txt")"
+[ "$out2" = "42" ] || fail "second run output: $out2"
+grep -q "hit $DIR/main.js$SUFFIX" "$WORKDIR/trace2.txt" || fail "second run did not consume sidecar"
+pass
+
+# --- corrupted sidecar falls back and is rewritten ----------------------------
+begin "corrupted sidecar falls back"
+DIR="$WORKDIR/corrupt"
+make_project "$DIR"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
+printf 'garbage' > "$DIR/main.js$SUFFIX"
+out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
+[ "$out" = "42" ] || fail "corrupted sidecar broke execution: $out"
+size="$(wc -c < "$DIR/main.js$SUFFIX")"
+[ "$size" -gt 64 ] || fail "corrupted sidecar was not rewritten (size=$size)"
+pass
+
+# --- stale sidecar (source edited) falls back ---------------------------------
+begin "stale sidecar falls back"
+DIR="$WORKDIR/stale"
+make_project "$DIR"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
+echo "console.log('changed');" > "$DIR/main.js"
+out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
+[ "$out" = "changed" ] || fail "stale sidecar served old code: $out"
+pass
+
+# --- opt-outs ------------------------------------------------------------------
+begin "--no-bytecode-cache writes and reads nothing"
+DIR="$WORKDIR/optout-flag"
+make_project "$DIR"
+"$EDGE_BIN" --no-bytecode-cache "$DIR/main.js" >/dev/null 2>&1
+[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar written despite --no-bytecode-cache"
+pass
+
+begin "EDGE_BYTECODE_CACHE=0 writes and reads nothing"
+DIR="$WORKDIR/optout-env"
+make_project "$DIR"
+EDGE_BYTECODE_CACHE=0 "$EDGE_BIN" "$DIR/main.js" >/dev/null 2>&1
+[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar written despite EDGE_BYTECODE_CACHE=0"
+pass
+
+# --- read-only tree ------------------------------------------------------------
+begin "read-only directory still runs"
+DIR="$WORKDIR/readonly"
+make_project "$DIR"
+chmod -R a-w "$DIR"
+out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
+chmod -R u+w "$DIR"
+[ "$out" = "42" ] || fail "read-only tree broke execution: $out"
+[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar appeared in read-only tree"
+pass
+
+# --- shebang and BOM -----------------------------------------------------------
+begin "shebang and BOM sources round-trip"
+DIR="$WORKDIR/encodings"
+mkdir -p "$DIR"
+printf '#!/usr/bin/env node\nconsole.log("shebang");\n' > "$DIR/shebang.js"
+printf '\xef\xbb\xbfconsole.log("bom");\n' > "$DIR/bom.js"
+out_a1="$("$EDGE_BIN" "$DIR/shebang.js" 2>/dev/null)"
+out_a2="$("$EDGE_BIN" "$DIR/shebang.js" 2>/dev/null)"
+[ "$out_a1" = "shebang" ] && [ "$out_a2" = "shebang" ] || fail "shebang: '$out_a1' / '$out_a2'"
+out_b1="$("$EDGE_BIN" "$DIR/bom.js" 2>/dev/null)"
+out_b2="$("$EDGE_BIN" "$DIR/bom.js" 2>/dev/null)"
+[ "$out_b1" = "bom" ] && [ "$out_b2" = "bom" ] || fail "bom: '$out_b1' / '$out_b2'"
+pass
+
+# --- package type rules ---------------------------------------------------------
+begin "precompile respects package.json type=module"
+DIR="$WORKDIR/typemodule"
+mkdir -p "$DIR"
+echo '{ "type": "module" }' > "$DIR/package.json"
+echo 'export const x = 1;' > "$DIR/esm.js"
+echo 'module.exports = 1;' > "$DIR/legacy.cjs"
+"$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
+[ ! -f "$DIR/esm.js$SUFFIX" ] || fail ".js in type=module scope must be skipped"
+[ -f "$DIR/legacy.cjs$SUFFIX" ] || fail ".cjs must be precompiled regardless of scope"
+pass
+
+# --- --check stays clean ---------------------------------------------------------
+begin "--check writes no sidecars"
+DIR="$WORKDIR/checkmode"
+make_project "$DIR"
+"$EDGE_BIN" --check "$DIR/main.js" >/dev/null 2>&1
+[ ! -f "$DIR/main.js$SUFFIX" ] || fail "--check wrote a sidecar"
+pass
+
+# --- conflicts -------------------------------------------------------------------
+begin "--precompile conflict validation"
+"$EDGE_BIN" --precompile >/dev/null 2>&1 && fail "--precompile with no paths should fail"
+"$EDGE_BIN" --precompile --check x.js >/dev/null 2>&1 && fail "--precompile --check should fail"
+"$EDGE_BIN" --precompile --no-bytecode-cache x >/dev/null 2>&1 && fail "--precompile --no-bytecode-cache should fail"
+pass
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES failure(s)" >&2
+  exit 1
+fi
+echo "all bytecode-cache tests passed"

--- a/scripts/test-bytecode-cache.sh
+++ b/scripts/test-bytecode-cache.sh
@@ -11,6 +11,12 @@ if [ ! -x "$EDGE_BIN" ]; then
   exit 1
 fi
 
+# Per-file (user) sidecars are OFF by default; this suite exercises their
+# mechanics, so opt in globally. Kill-switch scenarios (--no-bytecode-cache,
+# EDGE_BYTECODE_CACHE=0, --check) override per-run, and the default-policy
+# scenario clears it with `env -u` to assert the shipped default.
+export EDGE_BYTECODE_CACHE=1
+
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/edge-bytecode-cache-test.XXXXXX")"
 # Resolve symlinked temp roots (macOS /var -> /private/var) so trace-output
 # greps match the canonical paths the runtime reports.
@@ -37,27 +43,46 @@ pass() {
   fi
 }
 
-sidecar_suffix() {
-  # Detect which suffix this binary writes.
-  local dir="$WORKDIR/suffix-probe"
+# User-file caches live in a per-directory subdir, PEP 3147 __pycache__ style:
+#   <dir>/app.js -> <dir>/__edgecache__/app.js.<engine-tag>.jsc
+# The full source filename (extension kept) keys the entry; the engine/version
+# tag is not known statically, so locate caches by glob and detect the engine
+# from the tag the precompile probe writes.
+sidecar_glob_dir() { dirname "$1"; }
+sidecar_name() { basename "$1"; }
+
+sidecar_path() {  # $1 = source file -> first matching cache file, or empty
+  local dir name matches
+  dir="$(sidecar_glob_dir "$1")"; name="$(sidecar_name "$1")"
+  matches=("$dir"/__edgecache__/"$name".*.jsc)
+  [ -e "${matches[0]}" ] && printf '%s\n' "${matches[0]}"
+}
+sidecar_exists() { [ -n "$(sidecar_path "$1")" ]; }
+sidecar_event() {  # $1 = event (hit/write/remove)  $2 = source file  $3 = trace file
+  grep -F "__edgecache__/$(sidecar_name "$2")." "$3" | grep -q "] $1 "
+}
+
+detect_engine() {
+  local dir="$WORKDIR/engine-probe" f
   mkdir -p "$dir"
   echo "module.exports = 1;" > "$dir/probe.js"
   "$EDGE_BIN" --precompile "$dir" >/dev/null 2>&1
-  if [ -f "$dir/probe.js.v8b" ]; then
-    echo ".v8b"
-  elif [ -f "$dir/probe.js.qjsb" ]; then
-    echo ".qjsb"
-  else
-    echo ""
-  fi
+  f="$(basename "$(sidecar_path "$dir/probe.js")" 2>/dev/null)"
+  case "$f" in
+    probe.js.v8-*) echo "v8" ;;
+    probe.js.qjs-*) echo "qjs" ;;
+    *) echo "" ;;
+  esac
 }
 
-SUFFIX="$(sidecar_suffix)"
-if [ -z "$SUFFIX" ]; then
-  echo "error: could not determine sidecar suffix (precompile probe wrote nothing)" >&2
+ENGINE="$(detect_engine)"
+if [ -z "$ENGINE" ]; then
+  echo "error: could not determine engine (precompile probe wrote no __edgecache__/*.jsc)" >&2
   exit 1
 fi
-echo "testing $EDGE_BIN (sidecar suffix: $SUFFIX)"
+# The consolidated builtins cache keeps its engine suffix (one file by the binary).
+if [ "$ENGINE" = "v8" ]; then SUFFIX=".v8b"; else SUFFIX=".qjsb"; fi
+echo "testing $EDGE_BIN (engine: $ENGINE, builtins suffix: $SUFFIX)"
 
 make_project() {
   local dir="$1"
@@ -77,11 +102,11 @@ DIR="$WORKDIR/precompile"
 make_project "$DIR"
 baseline="$("$EDGE_BIN" --no-bytecode-cache "$DIR/main.js" 2>/dev/null)"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
-[ -f "$DIR/main.js$SUFFIX" ] || fail "missing main.js$SUFFIX"
-[ -f "$DIR/lib.js$SUFFIX" ] || fail "missing lib.js$SUFFIX"
+sidecar_exists "$DIR/main.js" || fail "missing main.js cache"
+sidecar_exists "$DIR/lib.js" || fail "missing lib.js cache"
 cached="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace.txt")"
 [ "$cached" = "$baseline" ] || fail "output mismatch: '$cached' vs '$baseline'"
-grep -q "hit $DIR/main.js$SUFFIX" "$WORKDIR/trace.txt" || fail "expected a cache hit for main.js"
+sidecar_event hit "$DIR/main.js" "$WORKDIR/trace.txt" || fail "expected a cache hit for main.js"
 pass
 
 # --- write-on-first-run -------------------------------------------------------
@@ -90,10 +115,10 @@ DIR="$WORKDIR/first-run"
 make_project "$DIR"
 out1="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace1.txt")"
 [ "$out1" = "42" ] || fail "first run output: $out1"
-grep -q "write $DIR/main.js$SUFFIX" "$WORKDIR/trace1.txt" || fail "first run did not write sidecar"
+sidecar_event write "$DIR/main.js" "$WORKDIR/trace1.txt" || fail "first run did not write sidecar"
 out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.js" 2>"$WORKDIR/trace2.txt")"
 [ "$out2" = "42" ] || fail "second run output: $out2"
-grep -q "hit $DIR/main.js$SUFFIX" "$WORKDIR/trace2.txt" || fail "second run did not consume sidecar"
+sidecar_event hit "$DIR/main.js" "$WORKDIR/trace2.txt" || fail "second run did not consume sidecar"
 pass
 
 # --- corrupted sidecar falls back and is rewritten ----------------------------
@@ -101,10 +126,10 @@ begin "corrupted sidecar falls back"
 DIR="$WORKDIR/corrupt"
 make_project "$DIR"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
-printf 'garbage' > "$DIR/main.js$SUFFIX"
+printf 'garbage' > "$(sidecar_path "$DIR/main.js")"
 out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
 [ "$out" = "42" ] || fail "corrupted sidecar broke execution: $out"
-size="$(wc -c < "$DIR/main.js$SUFFIX")"
+size="$(wc -c < "$(sidecar_path "$DIR/main.js")")"
 [ "$size" -gt 64 ] || fail "corrupted sidecar was not rewritten (size=$size)"
 pass
 
@@ -130,15 +155,15 @@ cat > "$DIR/main.mjs" <<'RELOC_EOF'
 console.log(import.meta.url.endsWith('relocate-dst/main.mjs') ? 'url-ok' : 'url-stale');
 RELOC_EOF
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
-[ -f "$DIR/main.mjs$SUFFIX" ] || fail "missing sidecar before relocation"
+sidecar_exists "$DIR/main.mjs" || fail "missing sidecar before relocation"
 mv "$DIR" "$WORKDIR/relocate-dst"
 out="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$WORKDIR/relocate-dst/main.mjs" 2>"$WORKDIR/reloc.txt")"
 [ "$out" = "url-ok" ] || fail "relocated import.meta.url is stale: $out"
-if [ "$SUFFIX" = ".qjsb" ]; then
-  grep -q "remove $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "quickjs did not drop the relocated sidecar"
-  grep -q "write $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "quickjs did not rewrite the relocated sidecar"
+if [ "$ENGINE" = "qjs" ]; then
+  sidecar_event remove "$WORKDIR/relocate-dst/main.mjs" "$WORKDIR/reloc.txt" || fail "quickjs did not drop the relocated sidecar"
+  sidecar_event write "$WORKDIR/relocate-dst/main.mjs" "$WORKDIR/reloc.txt" || fail "quickjs did not rewrite the relocated sidecar"
 else
-  grep -q "hit $WORKDIR/relocate-dst/main.mjs$SUFFIX" "$WORKDIR/reloc.txt" || fail "v8 should consume relocated sidecars"
+  sidecar_event hit "$WORKDIR/relocate-dst/main.mjs" "$WORKDIR/reloc.txt" || fail "v8 should consume relocated sidecars"
 fi
 pass
 
@@ -147,14 +172,14 @@ begin "--no-bytecode-cache writes and reads nothing"
 DIR="$WORKDIR/optout-flag"
 make_project "$DIR"
 "$EDGE_BIN" --no-bytecode-cache "$DIR/main.js" >/dev/null 2>&1
-[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar written despite --no-bytecode-cache"
+! sidecar_exists "$DIR/main.js" || fail "sidecar written despite --no-bytecode-cache"
 pass
 
 begin "EDGE_BYTECODE_CACHE=0 writes and reads nothing"
 DIR="$WORKDIR/optout-env"
 make_project "$DIR"
 EDGE_BYTECODE_CACHE=0 "$EDGE_BIN" "$DIR/main.js" >/dev/null 2>&1
-[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar written despite EDGE_BYTECODE_CACHE=0"
+! sidecar_exists "$DIR/main.js" || fail "sidecar written despite EDGE_BYTECODE_CACHE=0"
 pass
 
 # --- read-only tree ------------------------------------------------------------
@@ -165,7 +190,7 @@ chmod -R a-w "$DIR"
 out="$("$EDGE_BIN" "$DIR/main.js" 2>/dev/null)"
 chmod -R u+w "$DIR"
 [ "$out" = "42" ] || fail "read-only tree broke execution: $out"
-[ ! -f "$DIR/main.js$SUFFIX" ] || fail "sidecar appeared in read-only tree"
+! sidecar_exists "$DIR/main.js" || fail "sidecar appeared in read-only tree"
 pass
 
 # --- shebang and BOM -----------------------------------------------------------
@@ -190,8 +215,8 @@ echo '{ "type": "module" }' > "$DIR/package.json"
 echo 'export const x = 1;' > "$DIR/esm.js"
 echo 'module.exports = 1;' > "$DIR/legacy.cjs"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
-[ -f "$DIR/esm.js$SUFFIX" ] || fail ".js in type=module scope must get an ESM-shape sidecar"
-[ -f "$DIR/legacy.cjs$SUFFIX" ] || fail ".cjs must be precompiled regardless of scope"
+sidecar_exists "$DIR/esm.js" || fail ".js in type=module scope must get an ESM-shape sidecar"
+sidecar_exists "$DIR/legacy.cjs" || fail ".cjs must be precompiled regardless of scope"
 pass
 
 # --- ESM sidecars -----------------------------------------------------------------
@@ -207,11 +232,11 @@ console.log(value * 2);
 EOF
 out1="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.mjs" 2>"$WORKDIR/etrace1.txt")"
 [ "$out1" = "42" ] || fail "first run output: $out1"
-grep -q "write $DIR/main.mjs$SUFFIX" "$WORKDIR/etrace1.txt" || fail "first run did not write esm sidecar"
+sidecar_event write "$DIR/main.mjs" "$WORKDIR/etrace1.txt" || fail "first run did not write esm sidecar"
 out2="$(EDGE_BYTECODE_CACHE_TRACE=1 "$EDGE_BIN" "$DIR/main.mjs" 2>"$WORKDIR/etrace2.txt")"
 [ "$out2" = "42" ] || fail "second run output: $out2"
-grep -q "hit $DIR/main.mjs$SUFFIX" "$WORKDIR/etrace2.txt" || fail "second run did not consume esm sidecar"
-grep -q "hit $DIR/lib.mjs$SUFFIX" "$WORKDIR/etrace2.txt" || fail "imported module did not consume esm sidecar"
+sidecar_event hit "$DIR/main.mjs" "$WORKDIR/etrace2.txt" || fail "second run did not consume esm sidecar"
+sidecar_event hit "$DIR/lib.mjs" "$WORKDIR/etrace2.txt" || fail "imported module did not consume esm sidecar"
 pass
 
 begin "esm import chain fully cached"
@@ -275,7 +300,7 @@ DIR="$WORKDIR/esm-corrupt"
 mkdir -p "$DIR"
 echo 'console.log("esm-fine");' > "$DIR/main.mjs"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1
-printf 'garbage' > "$DIR/main.mjs$SUFFIX"
+printf 'garbage' > "$(sidecar_path "$DIR/main.mjs")"
 out="$("$EDGE_BIN" "$DIR/main.mjs" 2>/dev/null)"
 [ "$out" = "esm-fine" ] || fail "corrupted esm sidecar broke execution: $out"
 pass
@@ -295,7 +320,7 @@ DIR="$WORKDIR/esm-detect"
 mkdir -p "$DIR"
 echo 'export default 1; console.log("detected");' > "$DIR/ambiguous.js"
 "$EDGE_BIN" --precompile "$DIR" >/dev/null 2>&1 || fail "precompile exited non-zero"
-[ -f "$DIR/ambiguous.js$SUFFIX" ] || fail "ESM-syntax .js should get an ESM-shape sidecar"
+sidecar_exists "$DIR/ambiguous.js" || fail "ESM-syntax .js should get an ESM-shape sidecar"
 out="$("$EDGE_BIN" "$DIR/ambiguous.js" 2>/dev/null)"
 [ "$out" = "detected" ] || fail "detect-module run with sidecar: $out"
 pass
@@ -395,7 +420,7 @@ begin "--check writes no sidecars"
 DIR="$WORKDIR/checkmode"
 make_project "$DIR"
 "$EDGE_BIN" --check "$DIR/main.js" >/dev/null 2>&1
-[ ! -f "$DIR/main.js$SUFFIX" ] || fail "--check wrote a sidecar"
+! sidecar_exists "$DIR/main.js" || fail "--check wrote a sidecar"
 pass
 
 # --- conflicts -------------------------------------------------------------------
@@ -416,6 +441,25 @@ make_builtins_bin() {
   cp "$EDGE_BIN" "$dir/edge"
   echo 'console.log(1 + 1);' > "$dir/app.js"
 }
+
+# --- shipped default: builtins on, user sidecars off ------------------------------
+# Clear EDGE_BYTECODE_CACHE to see the real default. The builtins cache should
+# be written (on by default), but no per-file user sidecar — that needs opt-in.
+begin "default policy: builtins cached, user sidecars off until opt-in"
+DIR="$WORKDIR/default-policy"
+make_builtins_bin "$DIR"
+out="$(env -u EDGE_BYTECODE_CACHE "$DIR/edge" "$DIR/app.js" 2>/dev/null)"
+[ "$out" = "2" ] || fail "default run output: $out"
+[ -f "$DIR/$BUILTINS_FILE_NAME" ] || fail "builtins cache not written by default"
+! sidecar_exists "$DIR/app.js" || fail "user sidecar written without opt-in"
+# Opt in: --bytecode-cache writes the per-file sidecar.
+env -u EDGE_BYTECODE_CACHE "$DIR/edge" --bytecode-cache "$DIR/app.js" >/dev/null 2>&1
+sidecar_exists "$DIR/app.js" || fail "--bytecode-cache did not write a user sidecar"
+# EDGE_BYTECODE_CACHE=1 also opts in.
+rm -rf "$DIR/__edgecache__"
+EDGE_BYTECODE_CACHE=1 "$DIR/edge" "$DIR/app.js" >/dev/null 2>&1
+sidecar_exists "$DIR/app.js" || fail "EDGE_BYTECODE_CACHE=1 did not write a user sidecar"
+pass
 
 # --- first run writes, second run hits --------------------------------------------
 begin "builtins cache write then hit"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(EDGE_RUNTIME_CORE_SOURCES
 
 set(EDGE_LOADER_SOURCES
   "${CMAKE_CURRENT_LIST_DIR}/builtin_catalog.cc"
+  "${CMAKE_CURRENT_LIST_DIR}/edge_builtin_bytecode.cc"
   "${CMAKE_CURRENT_LIST_DIR}/edge_bytecode_cache.cc"
   "${CMAKE_CURRENT_LIST_DIR}/edge_module_loader.cc"
   "${CMAKE_CURRENT_LIST_DIR}/edge_precompile.cc"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,9 @@ set(EDGE_RUNTIME_CORE_SOURCES
 
 set(EDGE_LOADER_SOURCES
   "${CMAKE_CURRENT_LIST_DIR}/builtin_catalog.cc"
+  "${CMAKE_CURRENT_LIST_DIR}/edge_bytecode_cache.cc"
   "${CMAKE_CURRENT_LIST_DIR}/edge_module_loader.cc"
+  "${CMAKE_CURRENT_LIST_DIR}/edge_precompile.cc"
 )
 
 set(EDGE_LLHTTP_SOURCES

--- a/src/edge_builtin_bytecode.cc
+++ b/src/edge_builtin_bytecode.cc
@@ -2,24 +2,24 @@
 
 #include <cstdio>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
 #include <map>
 #include <mutex>
-#include <system_error>
+#include <string>
 #include <utility>
 
 #include "edge_bytecode_cache.h"
+#include "edge_bytecode_io.h"
 #include "edge_process.h"
-
-#if defined(_WIN32)
-#include <process.h>
-#else
-#include <unistd.h>
-#endif
 
 namespace edge_builtin_bytecode {
 namespace {
+
+using edge_bytecode_cache::io::ReadU16;
+using edge_bytecode_cache::io::ReadU32;
+using edge_bytecode_cache::io::ReadU64;
+using edge_bytecode_cache::io::WriteU16;
+using edge_bytecode_cache::io::WriteU32;
+using edge_bytecode_cache::io::WriteU64;
 
 constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'B'};
 constexpr size_t kHeaderSize = 32;
@@ -34,44 +34,6 @@ void Trace(const char* event, const std::string& subject, const char* detail = n
   } else {
     std::fprintf(stderr, "[edge-bytecode-cache] %s %s\n", event, subject.c_str());
   }
-}
-
-void WriteU16(std::vector<uint8_t>* out, size_t offset, uint16_t value) {
-  (*out)[offset + 0] = static_cast<uint8_t>(value);
-  (*out)[offset + 1] = static_cast<uint8_t>(value >> 8);
-}
-
-void WriteU32(std::vector<uint8_t>* out, size_t offset, uint32_t value) {
-  for (int i = 0; i < 4; ++i) {
-    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
-  }
-}
-
-void WriteU64(std::vector<uint8_t>* out, size_t offset, uint64_t value) {
-  for (int i = 0; i < 8; ++i) {
-    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
-  }
-}
-
-uint16_t ReadU16(const uint8_t* data, size_t offset) {
-  return static_cast<uint16_t>(static_cast<uint16_t>(data[offset]) |
-                               (static_cast<uint16_t>(data[offset + 1]) << 8));
-}
-
-uint32_t ReadU32(const uint8_t* data, size_t offset) {
-  uint32_t value = 0;
-  for (int i = 0; i < 4; ++i) {
-    value |= static_cast<uint32_t>(data[offset + i]) << (8 * i);
-  }
-  return value;
-}
-
-uint64_t ReadU64(const uint8_t* data, size_t offset) {
-  uint64_t value = 0;
-  for (int i = 0; i < 8; ++i) {
-    value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
-  }
-  return value;
 }
 
 // Walks every entry in a decoded-from-disk file. fn(kind, id, source_hash,
@@ -153,23 +115,8 @@ void EnsureLoadedLocked(Store& store) {
   store.load_attempted = true;
 
   const std::string path = BuiltinCacheFilePath();
-  std::FILE* in = std::fopen(path.c_str(), "rb");
-  if (in == nullptr) return;
-  if (std::fseek(in, 0, SEEK_END) != 0) {
-    std::fclose(in);
-    return;
-  }
-  const long file_size = std::ftell(in);
-  if (file_size <= 0 || std::fseek(in, 0, SEEK_SET) != 0) {
-    std::fclose(in);
-    return;
-  }
-  store.file_bytes.resize(static_cast<size_t>(file_size));
-  const size_t read = std::fread(store.file_bytes.data(), 1, store.file_bytes.size(), in);
-  std::fclose(in);
-  if (read != store.file_bytes.size()) {
-    store.file_bytes.clear();
-    Trace("builtins-load-failed", path, "read-error");
+  // Missing file is the common no-cache case (first run); not a load failure.
+  if (!edge_bytecode_cache::io::ReadFileFully(path, &store.file_bytes)) {
     return;
   }
 
@@ -274,41 +221,9 @@ void FlushIfDirty() {
   const std::vector<uint8_t> contents =
       EncodeFile(edge_bytecode_cache::EngineCacheTag(), entries);
 
-#if defined(_WIN32)
-  const int pid = _getpid();
-#else
-  const int pid = static_cast<int>(getpid());
-#endif
-  const std::string tmp_path = path + "." + std::to_string(pid) + ".tmp";
-
-  std::error_code ec;
-  {
-    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
-    if (!out.is_open()) {
-      Trace("builtins-write-failed", path, "open");
-      return;
-    }
-    out.write(reinterpret_cast<const char*>(contents.data()),
-              static_cast<std::streamsize>(contents.size()));
-    out.flush();
-    if (!out.good()) {
-      out.close();
-      std::filesystem::remove(tmp_path, ec);
-      Trace("builtins-write-failed", path, "write");
-      return;
-    }
-  }
-
-  std::filesystem::rename(tmp_path, path, ec);
-  if (ec) {
-    // Windows rename does not replace an existing destination.
-    std::filesystem::remove(path, ec);
-    std::filesystem::rename(tmp_path, path, ec);
-    if (ec) {
-      std::filesystem::remove(tmp_path, ec);
-      Trace("builtins-write-failed", path, "rename");
-      return;
-    }
+  if (!edge_bytecode_cache::io::AtomicWriteFile(path, contents.data(), contents.size())) {
+    Trace("builtins-write-failed", path);
+    return;
   }
   store.dirty.clear();
   if (edge_bytecode_cache::TraceEnabled()) {

--- a/src/edge_builtin_bytecode.cc
+++ b/src/edge_builtin_bytecode.cc
@@ -23,9 +23,8 @@ namespace {
 
 constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'B'};
 constexpr size_t kHeaderSize = 32;
-// kind u8, reserved u8, id_len u16, payload_len u32, source_xxh3 u64,
-// payload_xxh3 u64.
-constexpr size_t kEntryFixedSize = 24;
+// kind u8, reserved u8, id_len u16, payload_len u32, source_xxh3 u64.
+constexpr size_t kEntryFixedSize = 16;
 constexpr size_t kMaxKind = 5;
 
 void Trace(const char* event, const std::string& subject, const char* detail = nullptr) {
@@ -75,21 +74,10 @@ uint64_t ReadU64(const uint8_t* data, size_t offset) {
   return value;
 }
 
-uint64_t PayloadHashForWrite(const uint8_t* payload, size_t payload_size) {
-#if defined(EDGE_NAPI_QUICKJS)
-  // QuickJS's bytecode reader is not hardened against corrupt input.
-  return edge_bytecode_cache::Hash64(payload, payload_size);
-#else
-  // V8 CachedData self-validates (rejected -> fallback); skip the extra pass.
-  (void)payload;
-  (void)payload_size;
-  return 0;
-#endif
-}
-
 // Walks every entry in a decoded-from-disk file. fn(kind, id, source_hash,
-// payload_hash, payload_offset, payload_size); a malformed entry aborts the
-// walk. Returns false on any structural problem.
+// payload_offset, payload_size); a malformed entry aborts the walk. Returns
+// false on any structural problem. Payload integrity is the engine's job
+// (V8 CachedData / the QuickJS provider's QJSB payload header).
 template <typename Fn>
 bool ForEachEntry(const uint8_t* data,
                   size_t size,
@@ -113,14 +101,12 @@ bool ForEachEntry(const uint8_t* data,
     const uint16_t id_len = ReadU16(data, offset + 2);
     const uint32_t payload_len = ReadU32(data, offset + 4);
     const uint64_t source_hash = ReadU64(data, offset + 8);
-    const uint64_t payload_hash = ReadU64(data, offset + 16);
     offset += kEntryFixedSize;
     if (kind > kMaxKind) return false;
     if (size - offset < static_cast<size_t>(id_len) + payload_len) return false;
     const std::string_view id(reinterpret_cast<const char*>(data + offset), id_len);
     offset += id_len;
-    fn(static_cast<Kind>(kind), id, source_hash, payload_hash, offset,
-       static_cast<size_t>(payload_len));
+    fn(static_cast<Kind>(kind), id, source_hash, offset, static_cast<size_t>(payload_len));
     offset += payload_len;
   }
   return offset == size;
@@ -190,13 +176,8 @@ void EnsureLoadedLocked(Store& store) {
   const uint8_t* data = store.file_bytes.data();
   const bool ok = ForEachEntry(
       data, store.file_bytes.size(), edge_bytecode_cache::EngineCacheTag(),
-      [&](Kind kind, std::string_view id, uint64_t source_hash, uint64_t payload_hash,
-          size_t payload_offset, size_t payload_size) {
-        if (payload_hash != 0 &&
-            payload_hash != edge_bytecode_cache::Hash64(data + payload_offset, payload_size)) {
-          Trace("builtin-corrupt", std::string(id));
-          return;  // dropped -> miss -> recompile + rewrite at flush
-        }
+      [&](Kind kind, std::string_view id, uint64_t source_hash, size_t payload_offset,
+          size_t payload_size) {
         store.loaded[EntryKey(kind, id)] = LoadedEntry{source_hash, payload_offset, payload_size};
       });
   if (!ok) {
@@ -360,8 +341,6 @@ std::vector<uint8_t> EncodeFile(std::string_view engine_tag,
     WriteU16(&out, offset + 2, static_cast<uint16_t>(entry.id.size()));
     WriteU32(&out, offset + 4, static_cast<uint32_t>(entry.payload.size()));
     WriteU64(&out, offset + 8, entry.source_hash);
-    WriteU64(&out, offset + 16,
-             PayloadHashForWrite(entry.payload.data(), entry.payload.size()));
     offset += kEntryFixedSize;
     std::memcpy(out.data() + offset, entry.id.data(), entry.id.size());
     offset += entry.id.size();
@@ -379,12 +358,8 @@ bool DecodeFile(const uint8_t* data,
   out->clear();
   return ForEachEntry(
       data, size, engine_tag,
-      [&](Kind kind, std::string_view id, uint64_t source_hash, uint64_t payload_hash,
-          size_t payload_offset, size_t payload_size) {
-        if (payload_hash != 0 &&
-            payload_hash != edge_bytecode_cache::Hash64(data + payload_offset, payload_size)) {
-          return;  // mirror the loader: corrupt entries are dropped, not fatal
-        }
+      [&](Kind kind, std::string_view id, uint64_t source_hash, size_t payload_offset,
+          size_t payload_size) {
         FileEntry entry;
         entry.kind = kind;
         entry.id.assign(id);

--- a/src/edge_builtin_bytecode.cc
+++ b/src/edge_builtin_bytecode.cc
@@ -151,7 +151,7 @@ bool TryGet(Kind kind, std::string_view id, std::string_view source_utf8, Payloa
   if (out == nullptr) return false;
   out->data = nullptr;
   out->size = 0;
-  if (!edge_bytecode_cache::Enabled()) return false;
+  if (!edge_bytecode_cache::BuiltinsCacheEnabled()) return false;
 
   Store& store = GetStore();
   std::lock_guard<std::mutex> lock(store.mutex);
@@ -177,7 +177,7 @@ void Record(Kind kind,
             std::string_view source_utf8,
             const uint8_t* payload,
             size_t payload_size) {
-  if (!edge_bytecode_cache::Enabled()) return;
+  if (!edge_bytecode_cache::BuiltinsCacheEnabled()) return;
   if (payload == nullptr || payload_size == 0) return;
 
   Store& store = GetStore();
@@ -188,7 +188,7 @@ void Record(Kind kind,
 }
 
 void FlushIfDirty() {
-  if (!edge_bytecode_cache::Enabled()) return;
+  if (!edge_bytecode_cache::BuiltinsCacheEnabled()) return;
 
   Store& store = GetStore();
   std::lock_guard<std::mutex> lock(store.mutex);

--- a/src/edge_builtin_bytecode.cc
+++ b/src/edge_builtin_bytecode.cc
@@ -1,0 +1,397 @@
+#include "edge_builtin_bytecode.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <system_error>
+#include <utility>
+
+#include "edge_bytecode_cache.h"
+#include "edge_process.h"
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace edge_builtin_bytecode {
+namespace {
+
+constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'B'};
+constexpr size_t kHeaderSize = 32;
+// kind u8, reserved u8, id_len u16, payload_len u32, source_xxh3 u64,
+// payload_xxh3 u64.
+constexpr size_t kEntryFixedSize = 24;
+constexpr size_t kMaxKind = 5;
+
+void Trace(const char* event, const std::string& subject, const char* detail = nullptr) {
+  if (!edge_bytecode_cache::TraceEnabled()) return;
+  if (detail != nullptr) {
+    std::fprintf(stderr, "[edge-bytecode-cache] %s %s (%s)\n", event, subject.c_str(), detail);
+  } else {
+    std::fprintf(stderr, "[edge-bytecode-cache] %s %s\n", event, subject.c_str());
+  }
+}
+
+void WriteU16(std::vector<uint8_t>* out, size_t offset, uint16_t value) {
+  (*out)[offset + 0] = static_cast<uint8_t>(value);
+  (*out)[offset + 1] = static_cast<uint8_t>(value >> 8);
+}
+
+void WriteU32(std::vector<uint8_t>* out, size_t offset, uint32_t value) {
+  for (int i = 0; i < 4; ++i) {
+    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
+  }
+}
+
+void WriteU64(std::vector<uint8_t>* out, size_t offset, uint64_t value) {
+  for (int i = 0; i < 8; ++i) {
+    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
+  }
+}
+
+uint16_t ReadU16(const uint8_t* data, size_t offset) {
+  return static_cast<uint16_t>(static_cast<uint16_t>(data[offset]) |
+                               (static_cast<uint16_t>(data[offset + 1]) << 8));
+}
+
+uint32_t ReadU32(const uint8_t* data, size_t offset) {
+  uint32_t value = 0;
+  for (int i = 0; i < 4; ++i) {
+    value |= static_cast<uint32_t>(data[offset + i]) << (8 * i);
+  }
+  return value;
+}
+
+uint64_t ReadU64(const uint8_t* data, size_t offset) {
+  uint64_t value = 0;
+  for (int i = 0; i < 8; ++i) {
+    value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
+  }
+  return value;
+}
+
+uint64_t PayloadHashForWrite(const uint8_t* payload, size_t payload_size) {
+#if defined(EDGE_NAPI_QUICKJS)
+  // QuickJS's bytecode reader is not hardened against corrupt input.
+  return edge_bytecode_cache::Hash64(payload, payload_size);
+#else
+  // V8 CachedData self-validates (rejected -> fallback); skip the extra pass.
+  (void)payload;
+  (void)payload_size;
+  return 0;
+#endif
+}
+
+// Walks every entry in a decoded-from-disk file. fn(kind, id, source_hash,
+// payload_hash, payload_offset, payload_size); a malformed entry aborts the
+// walk. Returns false on any structural problem.
+template <typename Fn>
+bool ForEachEntry(const uint8_t* data,
+                  size_t size,
+                  std::string_view engine_tag,
+                  Fn fn) {
+  if (data == nullptr || size < kHeaderSize) return false;
+  if (std::memcmp(data, kMagic, sizeof(kMagic)) != 0) return false;
+  if (ReadU32(data, 8) != kFormatVersion) return false;
+  const uint32_t entry_count = ReadU32(data, 12);
+  const uint32_t tag_len = ReadU32(data, 16);
+  if (size < kHeaderSize + tag_len) return false;
+  if (tag_len != engine_tag.size() ||
+      std::memcmp(data + kHeaderSize, engine_tag.data(), engine_tag.size()) != 0) {
+    return false;
+  }
+
+  size_t offset = kHeaderSize + tag_len;
+  for (uint32_t i = 0; i < entry_count; ++i) {
+    if (size - offset < kEntryFixedSize) return false;
+    const uint8_t kind = data[offset];
+    const uint16_t id_len = ReadU16(data, offset + 2);
+    const uint32_t payload_len = ReadU32(data, offset + 4);
+    const uint64_t source_hash = ReadU64(data, offset + 8);
+    const uint64_t payload_hash = ReadU64(data, offset + 16);
+    offset += kEntryFixedSize;
+    if (kind > kMaxKind) return false;
+    if (size - offset < static_cast<size_t>(id_len) + payload_len) return false;
+    const std::string_view id(reinterpret_cast<const char*>(data + offset), id_len);
+    offset += id_len;
+    fn(static_cast<Kind>(kind), id, source_hash, payload_hash, offset,
+       static_cast<size_t>(payload_len));
+    offset += payload_len;
+  }
+  return offset == size;
+}
+
+std::string EntryKey(Kind kind, std::string_view id) {
+  std::string key;
+  key.reserve(id.size() + 1);
+  key.push_back(static_cast<char>(kind));
+  key.append(id);
+  return key;
+}
+
+struct LoadedEntry {
+  uint64_t source_hash = 0;
+  size_t payload_offset = 0;
+  size_t payload_size = 0;
+};
+
+struct DirtyEntry {
+  uint64_t source_hash = 0;
+  std::vector<uint8_t> payload;
+};
+
+// Process-global: workers bootstrap concurrently against the same store and
+// the main env teardown flushes once for everyone. Intentionally leaked (the
+// codebase avoids static destructors).
+struct Store {
+  std::mutex mutex;
+  bool load_attempted = false;
+  std::vector<uint8_t> file_bytes;            // backs every PayloadView handed out
+  std::map<std::string, LoadedEntry> loaded;  // key: kind byte + id
+  std::map<std::string, DirtyEntry> dirty;
+};
+
+Store& GetStore() {
+  static Store* store = new Store();
+  return *store;
+}
+
+// Caller holds store.mutex.
+void EnsureLoadedLocked(Store& store) {
+  if (store.load_attempted) return;
+  store.load_attempted = true;
+
+  const std::string path = BuiltinCacheFilePath();
+  std::FILE* in = std::fopen(path.c_str(), "rb");
+  if (in == nullptr) return;
+  if (std::fseek(in, 0, SEEK_END) != 0) {
+    std::fclose(in);
+    return;
+  }
+  const long file_size = std::ftell(in);
+  if (file_size <= 0 || std::fseek(in, 0, SEEK_SET) != 0) {
+    std::fclose(in);
+    return;
+  }
+  store.file_bytes.resize(static_cast<size_t>(file_size));
+  const size_t read = std::fread(store.file_bytes.data(), 1, store.file_bytes.size(), in);
+  std::fclose(in);
+  if (read != store.file_bytes.size()) {
+    store.file_bytes.clear();
+    Trace("builtins-load-failed", path, "read-error");
+    return;
+  }
+
+  const uint8_t* data = store.file_bytes.data();
+  const bool ok = ForEachEntry(
+      data, store.file_bytes.size(), edge_bytecode_cache::EngineCacheTag(),
+      [&](Kind kind, std::string_view id, uint64_t source_hash, uint64_t payload_hash,
+          size_t payload_offset, size_t payload_size) {
+        if (payload_hash != 0 &&
+            payload_hash != edge_bytecode_cache::Hash64(data + payload_offset, payload_size)) {
+          Trace("builtin-corrupt", std::string(id));
+          return;  // dropped -> miss -> recompile + rewrite at flush
+        }
+        store.loaded[EntryKey(kind, id)] = LoadedEntry{source_hash, payload_offset, payload_size};
+      });
+  if (!ok) {
+    store.loaded.clear();
+    store.file_bytes.clear();
+    Trace("builtins-load-failed", path, "invalid-or-stale");
+    return;
+  }
+  if (edge_bytecode_cache::TraceEnabled()) {
+    char detail[48];
+    std::snprintf(detail, sizeof(detail), "entries=%zu bytes=%zu", store.loaded.size(),
+                  store.file_bytes.size());
+    Trace("builtins-load", path, detail);
+  }
+}
+
+}  // namespace
+
+std::string BuiltinCacheFilePath() {
+  return EdgeGetProcessExecPath() + ".builtins" + edge_bytecode_cache::SidecarSuffix();
+}
+
+bool TryGet(Kind kind, std::string_view id, std::string_view source_utf8, PayloadView* out) {
+  if (out == nullptr) return false;
+  out->data = nullptr;
+  out->size = 0;
+  if (!edge_bytecode_cache::Enabled()) return false;
+
+  Store& store = GetStore();
+  std::lock_guard<std::mutex> lock(store.mutex);
+  EnsureLoadedLocked(store);
+  const auto it = store.loaded.find(EntryKey(kind, id));
+  if (it == store.loaded.end()) {
+    Trace("builtin-miss", std::string(id));
+    return false;
+  }
+  if (it->second.source_hash !=
+      edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size())) {
+    Trace("builtin-miss", std::string(id), "source-mismatch");
+    return false;
+  }
+  out->data = store.file_bytes.data() + it->second.payload_offset;
+  out->size = it->second.payload_size;
+  Trace("builtin-hit", std::string(id));
+  return true;
+}
+
+void Record(Kind kind,
+            std::string_view id,
+            std::string_view source_utf8,
+            const uint8_t* payload,
+            size_t payload_size) {
+  if (!edge_bytecode_cache::Enabled()) return;
+  if (payload == nullptr || payload_size == 0) return;
+
+  Store& store = GetStore();
+  std::lock_guard<std::mutex> lock(store.mutex);
+  DirtyEntry& entry = store.dirty[EntryKey(kind, id)];
+  entry.source_hash = edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size());
+  entry.payload.assign(payload, payload + payload_size);
+}
+
+void FlushIfDirty() {
+  if (!edge_bytecode_cache::Enabled()) return;
+
+  Store& store = GetStore();
+  std::lock_guard<std::mutex> lock(store.mutex);
+  if (store.dirty.empty()) return;
+  EnsureLoadedLocked(store);
+
+  // Merge: recorded entries supersede loaded ones with the same key.
+  std::vector<FileEntry> entries;
+  entries.reserve(store.loaded.size() + store.dirty.size());
+  for (const auto& [key, loaded] : store.loaded) {
+    if (store.dirty.count(key) != 0) continue;
+    FileEntry entry;
+    entry.kind = static_cast<Kind>(key[0]);
+    entry.id = key.substr(1);
+    entry.source_hash = loaded.source_hash;
+    entry.payload.assign(store.file_bytes.data() + loaded.payload_offset,
+                         store.file_bytes.data() + loaded.payload_offset + loaded.payload_size);
+    entries.push_back(std::move(entry));
+  }
+  for (const auto& [key, dirty] : store.dirty) {
+    FileEntry entry;
+    entry.kind = static_cast<Kind>(key[0]);
+    entry.id = key.substr(1);
+    entry.source_hash = dirty.source_hash;
+    entry.payload = dirty.payload;
+    entries.push_back(std::move(entry));
+  }
+
+  const std::string path = BuiltinCacheFilePath();
+  const std::vector<uint8_t> contents =
+      EncodeFile(edge_bytecode_cache::EngineCacheTag(), entries);
+
+#if defined(_WIN32)
+  const int pid = _getpid();
+#else
+  const int pid = static_cast<int>(getpid());
+#endif
+  const std::string tmp_path = path + "." + std::to_string(pid) + ".tmp";
+
+  std::error_code ec;
+  {
+    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+      Trace("builtins-write-failed", path, "open");
+      return;
+    }
+    out.write(reinterpret_cast<const char*>(contents.data()),
+              static_cast<std::streamsize>(contents.size()));
+    out.flush();
+    if (!out.good()) {
+      out.close();
+      std::filesystem::remove(tmp_path, ec);
+      Trace("builtins-write-failed", path, "write");
+      return;
+    }
+  }
+
+  std::filesystem::rename(tmp_path, path, ec);
+  if (ec) {
+    // Windows rename does not replace an existing destination.
+    std::filesystem::remove(path, ec);
+    std::filesystem::rename(tmp_path, path, ec);
+    if (ec) {
+      std::filesystem::remove(tmp_path, ec);
+      Trace("builtins-write-failed", path, "rename");
+      return;
+    }
+  }
+  store.dirty.clear();
+  if (edge_bytecode_cache::TraceEnabled()) {
+    char detail[48];
+    std::snprintf(detail, sizeof(detail), "entries=%zu bytes=%zu", entries.size(),
+                  contents.size());
+    Trace("builtins-write", path, detail);
+  }
+}
+
+std::vector<uint8_t> EncodeFile(std::string_view engine_tag,
+                                const std::vector<FileEntry>& entries) {
+  size_t total = kHeaderSize + engine_tag.size();
+  for (const FileEntry& entry : entries) {
+    total += kEntryFixedSize + entry.id.size() + entry.payload.size();
+  }
+
+  std::vector<uint8_t> out(total);
+  std::memcpy(out.data(), kMagic, sizeof(kMagic));
+  WriteU32(&out, 8, kFormatVersion);
+  WriteU32(&out, 12, static_cast<uint32_t>(entries.size()));
+  WriteU32(&out, 16, static_cast<uint32_t>(engine_tag.size()));
+  // 20..31 reserved (zeroed).
+  std::memcpy(out.data() + kHeaderSize, engine_tag.data(), engine_tag.size());
+
+  size_t offset = kHeaderSize + engine_tag.size();
+  for (const FileEntry& entry : entries) {
+    out[offset] = static_cast<uint8_t>(entry.kind);
+    out[offset + 1] = 0;
+    WriteU16(&out, offset + 2, static_cast<uint16_t>(entry.id.size()));
+    WriteU32(&out, offset + 4, static_cast<uint32_t>(entry.payload.size()));
+    WriteU64(&out, offset + 8, entry.source_hash);
+    WriteU64(&out, offset + 16,
+             PayloadHashForWrite(entry.payload.data(), entry.payload.size()));
+    offset += kEntryFixedSize;
+    std::memcpy(out.data() + offset, entry.id.data(), entry.id.size());
+    offset += entry.id.size();
+    std::memcpy(out.data() + offset, entry.payload.data(), entry.payload.size());
+    offset += entry.payload.size();
+  }
+  return out;
+}
+
+bool DecodeFile(const uint8_t* data,
+                size_t size,
+                std::string_view engine_tag,
+                std::vector<FileEntry>* out) {
+  if (out == nullptr) return false;
+  out->clear();
+  return ForEachEntry(
+      data, size, engine_tag,
+      [&](Kind kind, std::string_view id, uint64_t source_hash, uint64_t payload_hash,
+          size_t payload_offset, size_t payload_size) {
+        if (payload_hash != 0 &&
+            payload_hash != edge_bytecode_cache::Hash64(data + payload_offset, payload_size)) {
+          return;  // mirror the loader: corrupt entries are dropped, not fatal
+        }
+        FileEntry entry;
+        entry.kind = kind;
+        entry.id.assign(id);
+        entry.source_hash = source_hash;
+        entry.payload.assign(data + payload_offset, data + payload_offset + payload_size);
+        out->push_back(std::move(entry));
+      });
+}
+
+}  // namespace edge_builtin_bytecode

--- a/src/edge_builtin_bytecode.h
+++ b/src/edge_builtin_bytecode.h
@@ -15,8 +15,10 @@
 // container format, validation, and the process-global entry store only.
 namespace edge_builtin_bytecode {
 
-// Bump when the container layout or the hashing scheme changes.
-constexpr uint32_t kFormatVersion = 1;
+// Bump when the container layout or the payload encoding changes (v2: raw
+// payloads; v3: entries dropped the engine-conditional payload hash — engine
+// payloads self-validate, so the container carries source identity only).
+constexpr uint32_t kFormatVersion = 3;
 
 // Compile shape of an entry. Each kind pins the compile path, parameter list,
 // and wrapper that produced the payload; the entry's source hash covers the

--- a/src/edge_builtin_bytecode.h
+++ b/src/edge_builtin_bytecode.h
@@ -1,0 +1,81 @@
+#ifndef EDGE_BUILTIN_BYTECODE_H_
+#define EDGE_BUILTIN_BYTECODE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Consolidated bytecode cache for embedded builtins, stored in a single file
+// next to the binary ("edge" -> "edge.builtins.v8b" / "edge.builtins.qjsb").
+// Builtins ship inside the binary, so unlike user-file sidecars there is one
+// store per installed binary, loaded once per process and flushed (merged)
+// once at teardown. Payloads are opaque engine data; this module owns the
+// container format, validation, and the process-global entry store only.
+namespace edge_builtin_bytecode {
+
+// Bump when the container layout or the hashing scheme changes.
+constexpr uint32_t kFormatVersion = 1;
+
+// Compile shape of an entry. Each kind pins the compile path, parameter list,
+// and wrapper that produced the payload; the entry's source hash covers the
+// exact string handed to the engine compiler (raw builtin source for the
+// function kinds, the full wrapped IIFE text for the wrapper kinds), so any
+// wrapper or parameter drift self-invalidates.
+enum class Kind : uint8_t {
+  kFnPerContext = 0,      // [exports, primordials, privateSymbols, perIsolateSymbols]
+  kFnBootstrapRealm = 1,  // [process, getLinkedBinding, getInternalBinding, primordials]
+  kFnBootstrapMain = 2,   // [process, require, internalBinding, primordials]
+  kFnLazyBuiltin = 3,     // [exports, require, module, process, internalBinding, primordials]
+  kWrapperStandard = 4,   // (function(internalBinding, primordials){...}) script
+  kWrapperPerContext = 5, // (function(primordials, privateSymbols, perIsolateSymbols){...}) script
+};
+
+// View into the loaded store's buffer; valid for the process lifetime.
+struct PayloadView {
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+};
+
+// Cache file path: process executable path + ".builtins" + engine suffix.
+std::string BuiltinCacheFilePath();
+
+// Looks up (kind, id) in the consolidated cache, validating the entry was
+// compiled from exactly source_utf8. Loads the file lazily on first call
+// (one read, validated in place). False on miss/disabled; never throws.
+bool TryGet(Kind kind,
+            std::string_view id,
+            std::string_view source_utf8,
+            PayloadView* out);
+
+// Queues serialized bytecode for (kind, id) to be persisted by FlushIfDirty.
+// Workers bootstrap concurrently with the main thread; safe from any thread.
+void Record(Kind kind,
+            std::string_view id,
+            std::string_view source_utf8,
+            const uint8_t* payload,
+            size_t payload_size);
+
+// Writes loaded-merged-with-recorded entries atomically (temp file + rename)
+// if anything was recorded this run. Failures (read-only install dir, ...)
+// are silent: the next run simply recompiles.
+void FlushIfDirty();
+
+// Serialization helpers exposed for tests.
+struct FileEntry {
+  Kind kind = Kind::kFnLazyBuiltin;
+  std::string id;
+  uint64_t source_hash = 0;
+  std::vector<uint8_t> payload;
+};
+std::vector<uint8_t> EncodeFile(std::string_view engine_tag,
+                                const std::vector<FileEntry>& entries);
+bool DecodeFile(const uint8_t* data,
+                size_t size,
+                std::string_view engine_tag,
+                std::vector<FileEntry>* out);
+
+}  // namespace edge_builtin_bytecode
+
+#endif  // EDGE_BUILTIN_BYTECODE_H_

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -1,0 +1,292 @@
+#include "edge_bytecode_cache.h"
+
+#include <atomic>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <system_error>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace edge_bytecode_cache {
+namespace {
+
+constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'C'};
+constexpr size_t kHeaderSize = 64;
+
+std::atomic<bool> g_cli_enabled{true};
+
+bool IsFalsyEnvValue(const char* value) {
+  if (value == nullptr || value[0] == '\0') return false;
+  std::string normalized(value);
+  for (char& ch : normalized) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return normalized == "0" || normalized == "false" || normalized == "no" ||
+         normalized == "off";
+}
+
+bool TraceEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("EDGE_BYTECODE_CACHE_TRACE");
+    return value != nullptr && value[0] != '\0' && !IsFalsyEnvValue(value);
+  }();
+  return enabled;
+}
+
+void Trace(const char* event, const std::string& path, const char* detail = nullptr) {
+  if (!TraceEnabled()) return;
+  if (detail != nullptr) {
+    std::fprintf(stderr, "[edge-bytecode-cache] %s %s (%s)\n", event, path.c_str(), detail);
+  } else {
+    std::fprintf(stderr, "[edge-bytecode-cache] %s %s\n", event, path.c_str());
+  }
+}
+
+void WriteU32(std::vector<uint8_t>* out, size_t offset, uint32_t value) {
+  (*out)[offset + 0] = static_cast<uint8_t>(value);
+  (*out)[offset + 1] = static_cast<uint8_t>(value >> 8);
+  (*out)[offset + 2] = static_cast<uint8_t>(value >> 16);
+  (*out)[offset + 3] = static_cast<uint8_t>(value >> 24);
+}
+
+void WriteU64(std::vector<uint8_t>* out, size_t offset, uint64_t value) {
+  for (int i = 0; i < 8; ++i) {
+    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
+  }
+}
+
+uint32_t ReadU32(const uint8_t* data, size_t offset) {
+  return static_cast<uint32_t>(data[offset]) |
+         (static_cast<uint32_t>(data[offset + 1]) << 8) |
+         (static_cast<uint32_t>(data[offset + 2]) << 16) |
+         (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+uint64_t ReadU64(const uint8_t* data, size_t offset) {
+  uint64_t value = 0;
+  for (int i = 0; i < 8; ++i) {
+    value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
+  }
+  return value;
+}
+
+// QuickJS bytecode embeds the compile-time filename in its debug info, so a
+// sidecar from another location would surface stale paths in stack traces;
+// keying on the filename forces a recompile instead. V8 code caches carry no
+// filename (it only enters ScriptOrigin) and stay relocatable.
+uint64_t FilenameHashForSource(const std::string& source_path) {
+#if defined(EDGE_NAPI_QUICKJS)
+  return Fnv1a64(source_path.data(), source_path.size());
+#else
+  (void)source_path;
+  return 0;
+#endif
+}
+
+}  // namespace
+
+const char* SidecarSuffix() {
+#if defined(EDGE_BUNDLED_NAPI_V8)
+  return ".v8b";
+#elif defined(EDGE_NAPI_QUICKJS)
+  return ".qjsb";
+#else
+  return "";
+#endif
+}
+
+const std::string& EngineCacheTag() {
+  static const std::string tag = [] {
+#if defined(EDGE_BUNDLED_NAPI_V8) && defined(EDGE_EMBEDDED_V8_VERSION)
+    return std::string("v8-") + EDGE_EMBEDDED_V8_VERSION;
+#elif defined(EDGE_NAPI_QUICKJS) && defined(EDGE_EMBEDDED_QUICKJS_VERSION)
+    return std::string("qjs-ng-") + EDGE_EMBEDDED_QUICKJS_VERSION;
+#else
+    return std::string();
+#endif
+  }();
+  return tag;
+}
+
+uint64_t Fnv1a64(const void* data, size_t size) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint64_t hash = 0xcbf29ce484222325ull;
+  for (size_t i = 0; i < size; ++i) {
+    hash ^= bytes[i];
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+void SetEnabledFromCli(bool enabled) {
+  g_cli_enabled.store(enabled, std::memory_order_relaxed);
+}
+
+bool Enabled() {
+  static const bool env_enabled =
+      !IsFalsyEnvValue(std::getenv("EDGE_BYTECODE_CACHE"));
+  return env_enabled && !EngineCacheTag().empty() &&
+         g_cli_enabled.load(std::memory_order_relaxed);
+}
+
+std::string SidecarPathForSource(const std::string& source_path) {
+  return source_path + SidecarSuffix();
+}
+
+std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
+                                   std::string_view source_utf8,
+                                   uint64_t filename_hash,
+                                   const uint8_t* payload,
+                                   size_t payload_size) {
+  std::vector<uint8_t> out(kHeaderSize + engine_tag.size() + payload_size);
+  std::memcpy(out.data(), kMagic, sizeof(kMagic));
+  WriteU32(&out, 8, kFormatVersion);
+  WriteU32(&out, 12, kFlagCjsFunctionV1);
+  WriteU32(&out, 16, static_cast<uint32_t>(engine_tag.size()));
+  WriteU64(&out, 20, source_utf8.size());
+  WriteU64(&out, 28, Fnv1a64(source_utf8.data(), source_utf8.size()));
+  WriteU64(&out, 36, filename_hash);
+  WriteU64(&out, 44, payload_size);
+  WriteU64(&out, 52, Fnv1a64(payload, payload_size));
+  WriteU32(&out, 60, 0);
+  std::memcpy(out.data() + kHeaderSize, engine_tag.data(), engine_tag.size());
+  if (payload_size > 0) {
+    std::memcpy(out.data() + kHeaderSize + engine_tag.size(), payload, payload_size);
+  }
+  return out;
+}
+
+bool DecodeSidecar(const uint8_t* data,
+                   size_t size,
+                   std::string_view engine_tag,
+                   std::string_view source_utf8,
+                   uint64_t expected_filename_hash,
+                   std::vector<uint8_t>* payload_out) {
+  if (payload_out == nullptr) return false;
+  payload_out->clear();
+  if (data == nullptr || size < kHeaderSize) return false;
+  if (std::memcmp(data, kMagic, sizeof(kMagic)) != 0) return false;
+  if (ReadU32(data, 8) != kFormatVersion) return false;
+  if (ReadU32(data, 12) != kFlagCjsFunctionV1) return false;
+
+  const uint64_t tag_len = ReadU32(data, 16);
+  const uint64_t source_len = ReadU64(data, 20);
+  const uint64_t source_hash = ReadU64(data, 28);
+  const uint64_t filename_hash = ReadU64(data, 36);
+  const uint64_t payload_len = ReadU64(data, 44);
+  const uint64_t payload_hash = ReadU64(data, 52);
+
+  if (size != kHeaderSize + tag_len + payload_len) return false;
+  if (tag_len != engine_tag.size() ||
+      std::memcmp(data + kHeaderSize, engine_tag.data(), engine_tag.size()) != 0) {
+    return false;
+  }
+  if (source_len != source_utf8.size() ||
+      source_hash != Fnv1a64(source_utf8.data(), source_utf8.size())) {
+    return false;
+  }
+  if (filename_hash != 0 && filename_hash != expected_filename_hash) return false;
+
+  const uint8_t* payload = data + kHeaderSize + tag_len;
+  if (payload_hash != Fnv1a64(payload, payload_len)) return false;
+
+  payload_out->assign(payload, payload + payload_len);
+  return true;
+}
+
+bool ReadSidecar(const std::string& source_path,
+                 std::string_view source_utf8,
+                 std::vector<uint8_t>* payload_out) {
+  if (payload_out == nullptr) return false;
+  payload_out->clear();
+  if (!Enabled()) return false;
+
+  const std::string sidecar_path = SidecarPathForSource(source_path);
+  std::ifstream in(sidecar_path, std::ios::binary);
+  if (!in.is_open()) return false;
+
+  std::vector<uint8_t> contents((std::istreambuf_iterator<char>(in)),
+                                std::istreambuf_iterator<char>());
+  if (in.bad()) {
+    Trace("miss", sidecar_path, "read-error");
+    return false;
+  }
+  if (!DecodeSidecar(contents.data(), contents.size(), EngineCacheTag(),
+                     source_utf8, FilenameHashForSource(source_path),
+                     payload_out)) {
+    Trace("miss", sidecar_path, "invalid-or-stale");
+    return false;
+  }
+  Trace("hit", sidecar_path);
+  return true;
+}
+
+bool WriteSidecar(const std::string& source_path,
+                  std::string_view source_utf8,
+                  const uint8_t* payload,
+                  size_t payload_size) {
+  if (!Enabled() || payload == nullptr || payload_size == 0) return false;
+
+  const std::string sidecar_path = SidecarPathForSource(source_path);
+  const std::vector<uint8_t> contents =
+      EncodeSidecar(EngineCacheTag(), source_utf8,
+                    FilenameHashForSource(source_path), payload, payload_size);
+
+#if defined(_WIN32)
+  const int pid = _getpid();
+#else
+  const int pid = static_cast<int>(getpid());
+#endif
+  const std::string tmp_path = sidecar_path + "." + std::to_string(pid) + ".tmp";
+
+  std::error_code ec;
+  {
+    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+      Trace("write-failed", sidecar_path, "open");
+      return false;
+    }
+    out.write(reinterpret_cast<const char*>(contents.data()),
+              static_cast<std::streamsize>(contents.size()));
+    out.flush();
+    if (!out.good()) {
+      out.close();
+      std::filesystem::remove(tmp_path, ec);
+      Trace("write-failed", sidecar_path, "write");
+      return false;
+    }
+  }
+
+  std::filesystem::rename(tmp_path, sidecar_path, ec);
+  if (ec) {
+    // Windows rename does not replace an existing destination.
+    std::filesystem::remove(sidecar_path, ec);
+    std::filesystem::rename(tmp_path, sidecar_path, ec);
+    if (ec) {
+      std::filesystem::remove(tmp_path, ec);
+      Trace("write-failed", sidecar_path, "rename");
+      return false;
+    }
+  }
+  Trace("write", sidecar_path);
+  return true;
+}
+
+bool RemoveSidecar(const std::string& source_path) {
+  const std::string sidecar_path = SidecarPathForSource(source_path);
+  std::error_code ec;
+  const bool removed = std::filesystem::remove(sidecar_path, ec);
+  if (removed) Trace("remove", sidecar_path);
+  return removed && !ec;
+}
+
+}  // namespace edge_bytecode_cache

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -21,7 +21,8 @@ namespace {
 constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'C'};
 constexpr size_t kHeaderSize = 48;
 
-std::atomic<bool> g_cli_enabled{true};
+// CLI cache override: 0 = none, +1 = force user sidecars on, -1 = force all off.
+std::atomic<int> g_cli_enabled{0};
 
 bool IsFalsyEnvValue(const char* value) {
   if (value == nullptr || value[0] == '\0') return false;
@@ -72,19 +73,84 @@ const std::string& EngineCacheTag() {
   return tag;
 }
 
+namespace {
+// "13.6.233.17-node.0" -> "13-6"; "0.14.0" -> "0-14". Major.minor only, dots
+// as dashes, so it stays filename-clean.
+std::string MajorMinorDashed(const char* version) {
+  std::string out;
+  int dots = 0;
+  for (const char* p = version; *p != '\0'; ++p) {
+    if (*p == '.') {
+      if (++dots >= 2) break;
+      out.push_back('-');
+    } else if ((*p >= '0' && *p <= '9')) {
+      out.push_back(*p);
+    } else {
+      break;  // stop at the first non-numeric (e.g. "-node...")
+    }
+  }
+  return out;
+}
+}  // namespace
+
+const std::string& EngineFileTag() {
+  // Short, human-readable engine tag for the cache *filename* only (the header
+  // keeps the full EngineCacheTag for the precise staleness check). Coarser
+  // than the header tag, so two patch builds sharing a major.minor reuse one
+  // filename — the header still rejects the stale one and rewrites.
+  static const std::string tag = [] {
+#if defined(EDGE_BUNDLED_NAPI_V8) && defined(EDGE_EMBEDDED_V8_VERSION)
+    return std::string("v8-") + MajorMinorDashed(EDGE_EMBEDDED_V8_VERSION);
+#elif defined(EDGE_NAPI_QUICKJS) && defined(EDGE_EMBEDDED_QUICKJS_VERSION)
+    return std::string("qjs-") + MajorMinorDashed(EDGE_EMBEDDED_QUICKJS_VERSION);
+#else
+    return std::string();
+#endif
+  }();
+  return tag;
+}
+
 uint64_t Hash64(const void* data, size_t size) {
   return XXH3_64bits(data, size);
 }
 
-void SetEnabledFromCli(bool enabled) {
-  g_cli_enabled.store(enabled, std::memory_order_relaxed);
+// Cache control is a tri-state: -1 force-off (kill switch), +1 force-on
+// (opt-in user sidecars), 0 default. The CLI override (set from flags) wins
+// over the EDGE_BYTECODE_CACHE env var, which wins over the built-in default.
+//
+//   builtins cache  : ON  unless something forces off (default-on, our own
+//                     tested lib code; the biggest startup win at low risk).
+//   user sidecars   : OFF unless something forces on (opt-in, since arbitrary
+//                     user code is less battle-tested).
+namespace {
+int EnvOverride() {
+  static const int v = [] {
+    const char* e = std::getenv("EDGE_BYTECODE_CACHE");
+    if (e == nullptr || e[0] == '\0') return 0;
+    return IsFalsyEnvValue(e) ? -1 : 1;  // explicit falsy kills; truthy opts in
+  }();
+  return v;
+}
+int EffectiveOverride() {
+  const int cli = g_cli_enabled.load(std::memory_order_relaxed);
+  return cli != 0 ? cli : EnvOverride();
+}
+}  // namespace
+
+void SetCacheDisabledFromCli() {
+  g_cli_enabled.store(-1, std::memory_order_relaxed);
+}
+
+void SetSidecarsEnabledFromCli() {
+  g_cli_enabled.store(1, std::memory_order_relaxed);
+}
+
+bool BuiltinsCacheEnabled() {
+  return !EngineCacheTag().empty() && EffectiveOverride() != -1;
 }
 
 bool Enabled() {
-  static const bool env_enabled =
-      !IsFalsyEnvValue(std::getenv("EDGE_BYTECODE_CACHE"));
-  return env_enabled && !EngineCacheTag().empty() &&
-         g_cli_enabled.load(std::memory_order_relaxed);
+  return !EngineCacheTag().empty() && EffectiveOverride() == 1;
 }
 
 bool TraceEnabled() {
@@ -96,7 +162,16 @@ bool TraceEnabled() {
 }
 
 std::string SidecarPathForSource(const std::string& source_path) {
-  return source_path + SidecarSuffix();
+  // Caches live in a per-directory "__edgecache__" subdir (PEP 3147
+  // __pycache__ style): "dir/app.js" -> "dir/__edgecache__/app.js.<file-tag>.jsc"
+  // (e.g. "app.js.v8-13-6.jsc" / "app.mjs.qjs-0-14.jsc"). The full source
+  // filename (extension included) keys the entry, so it is unique within the
+  // directory — ".js"/".mjs"/".cjs" siblings never collide. The short engine
+  // tag lets different engines/major.minor versions coexist; the source
+  // identity and full engine version are still validated by the header.
+  const std::filesystem::path source(source_path);
+  const std::string name = source.filename().string() + "." + EngineFileTag() + ".jsc";
+  return (source.parent_path() / "__edgecache__" / name).string();
 }
 
 // Engine-agnostic header (48 bytes): the payload is opaque self-validating
@@ -212,6 +287,12 @@ bool WriteSidecar(const std::string& source_path,
   const std::string sidecar_path = SidecarPathForSource(source_path);
   const std::vector<uint8_t> contents =
       EncodeSidecar(EngineCacheTag(), source_utf8, flags, payload, payload_size);
+
+  // Ensure the __edgecache__ subdir exists (idempotent). The atomic write's
+  // temp file lives inside it, so it must be present first. A read-only tree
+  // makes this fail silently, like the write itself.
+  std::error_code dir_ec;
+  std::filesystem::create_directories(std::filesystem::path(sidecar_path).parent_path(), dir_ec);
 
   if (!io::AtomicWriteFile(sidecar_path, contents.data(), contents.size())) {
     Trace("write-failed", sidecar_path);

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cctype>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -144,13 +145,14 @@ std::string SidecarPathForSource(const std::string& source_path) {
 
 std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
                                    std::string_view source_utf8,
+                                   uint32_t flags,
                                    uint64_t filename_hash,
                                    const uint8_t* payload,
                                    size_t payload_size) {
   std::vector<uint8_t> out(kHeaderSize + engine_tag.size() + payload_size);
   std::memcpy(out.data(), kMagic, sizeof(kMagic));
   WriteU32(&out, 8, kFormatVersion);
-  WriteU32(&out, 12, kFlagCjsFunctionV1);
+  WriteU32(&out, 12, flags);
   WriteU32(&out, 16, static_cast<uint32_t>(engine_tag.size()));
   WriteU64(&out, 20, source_utf8.size());
   WriteU64(&out, 28, Fnv1a64(source_utf8.data(), source_utf8.size()));
@@ -169,6 +171,7 @@ bool DecodeSidecar(const uint8_t* data,
                    size_t size,
                    std::string_view engine_tag,
                    std::string_view source_utf8,
+                   uint32_t expected_flags,
                    uint64_t expected_filename_hash,
                    std::vector<uint8_t>* payload_out) {
   if (payload_out == nullptr) return false;
@@ -176,7 +179,7 @@ bool DecodeSidecar(const uint8_t* data,
   if (data == nullptr || size < kHeaderSize) return false;
   if (std::memcmp(data, kMagic, sizeof(kMagic)) != 0) return false;
   if (ReadU32(data, 8) != kFormatVersion) return false;
-  if (ReadU32(data, 12) != kFlagCjsFunctionV1) return false;
+  if (ReadU32(data, 12) != expected_flags) return false;
 
   const uint64_t tag_len = ReadU32(data, 16);
   const uint64_t source_len = ReadU64(data, 20);
@@ -205,11 +208,13 @@ bool DecodeSidecar(const uint8_t* data,
 
 bool ReadSidecar(const std::string& source_path,
                  std::string_view source_utf8,
+                 uint32_t expected_flags,
                  std::vector<uint8_t>* payload_out) {
   if (payload_out == nullptr) return false;
   payload_out->clear();
   if (!Enabled()) return false;
 
+  const auto started = std::chrono::steady_clock::now();
   const std::string sidecar_path = SidecarPathForSource(source_path);
   std::ifstream in(sidecar_path, std::ios::binary);
   if (!in.is_open()) return false;
@@ -221,24 +226,33 @@ bool ReadSidecar(const std::string& source_path,
     return false;
   }
   if (!DecodeSidecar(contents.data(), contents.size(), EngineCacheTag(),
-                     source_utf8, FilenameHashForSource(source_path),
-                     payload_out)) {
+                     source_utf8, expected_flags,
+                     FilenameHashForSource(source_path), payload_out)) {
     Trace("miss", sidecar_path, "invalid-or-stale");
     return false;
   }
-  Trace("hit", sidecar_path);
+  if (TraceEnabled()) {
+    const auto micros = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - started)
+                            .count();
+    char detail[64];
+    std::snprintf(detail, sizeof(detail), "read+hash=%lldus payload=%zub",
+                  static_cast<long long>(micros), payload_out->size());
+    Trace("hit", sidecar_path, detail);
+  }
   return true;
 }
 
 bool WriteSidecar(const std::string& source_path,
                   std::string_view source_utf8,
+                  uint32_t flags,
                   const uint8_t* payload,
                   size_t payload_size) {
   if (!Enabled() || payload == nullptr || payload_size == 0) return false;
 
   const std::string sidecar_path = SidecarPathForSource(source_path);
   const std::vector<uint8_t> contents =
-      EncodeSidecar(EngineCacheTag(), source_utf8,
+      EncodeSidecar(EngineCacheTag(), source_utf8, flags,
                     FilenameHashForSource(source_path), payload, payload_size);
 
 #if defined(_WIN32)

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -24,7 +24,7 @@ namespace edge_bytecode_cache {
 namespace {
 
 constexpr char kMagic[8] = {'E', 'D', 'G', 'E', 'J', 'S', 'B', 'C'};
-constexpr size_t kHeaderSize = 64;
+constexpr size_t kHeaderSize = 48;
 
 std::atomic<bool> g_cli_enabled{true};
 
@@ -73,19 +73,6 @@ uint64_t ReadU64(const uint8_t* data, size_t offset) {
     value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
   }
   return value;
-}
-
-// QuickJS bytecode embeds the compile-time filename in its debug info, so a
-// sidecar from another location would surface stale paths in stack traces;
-// keying on the filename forces a recompile instead. V8 code caches carry no
-// filename (it only enters ScriptOrigin) and stay relocatable.
-uint64_t FilenameHashForSource(const std::string& source_path) {
-#if defined(EDGE_NAPI_QUICKJS)
-  return Hash64(source_path.data(), source_path.size());
-#else
-  (void)source_path;
-  return 0;
-#endif
 }
 
 }  // namespace
@@ -140,30 +127,23 @@ std::string SidecarPathForSource(const std::string& source_path) {
   return source_path + SidecarSuffix();
 }
 
+// Engine-agnostic header (48 bytes): the payload is opaque self-validating
+// engine data (V8 CachedData; QuickJS bytecode behind the provider's QJSB
+// header), so the container carries only source identity and structure.
 std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
                                    std::string_view source_utf8,
                                    uint32_t flags,
-                                   uint64_t filename_hash,
                                    const uint8_t* payload,
                                    size_t payload_size) {
   std::vector<uint8_t> out(kHeaderSize + engine_tag.size() + payload_size);
   std::memcpy(out.data(), kMagic, sizeof(kMagic));
   WriteU32(&out, 8, kFormatVersion);
   WriteU32(&out, 12, flags);
-  WriteU32(&out, 16, static_cast<uint32_t>(engine_tag.size()));
-  WriteU64(&out, 20, source_utf8.size());
-  WriteU64(&out, 28, Hash64(source_utf8.data(), source_utf8.size()));
-  WriteU64(&out, 36, filename_hash);
-  WriteU64(&out, 44, payload_size);
-#if defined(EDGE_NAPI_QUICKJS)
-  // QuickJS's bytecode reader is not hardened against corrupt input.
-  WriteU64(&out, 52, Hash64(payload, payload_size));
-#else
-  // V8 CachedData self-validates (rejected -> fallback); skip the extra pass.
-  (void)payload;
-  WriteU64(&out, 52, 0);
-#endif
-  WriteU32(&out, 60, 0);
+  WriteU64(&out, 16, source_utf8.size());
+  WriteU64(&out, 24, Hash64(source_utf8.data(), source_utf8.size()));
+  WriteU64(&out, 32, payload_size);
+  WriteU32(&out, 40, static_cast<uint32_t>(engine_tag.size()));
+  WriteU32(&out, 44, 0);  // reserved
   std::memcpy(out.data() + kHeaderSize, engine_tag.data(), engine_tag.size());
   if (payload_size > 0) {
     std::memcpy(out.data() + kHeaderSize + engine_tag.size(), payload, payload_size);
@@ -176,7 +156,6 @@ bool DecodeSidecar(const uint8_t* data,
                    std::string_view engine_tag,
                    std::string_view source_utf8,
                    uint32_t expected_flags,
-                   uint64_t expected_filename_hash,
                    size_t* payload_offset_out,
                    size_t* payload_size_out) {
   if (payload_offset_out == nullptr || payload_size_out == nullptr) return false;
@@ -187,13 +166,12 @@ bool DecodeSidecar(const uint8_t* data,
   if (ReadU32(data, 8) != kFormatVersion) return false;
   if (ReadU32(data, 12) != expected_flags) return false;
 
-  const uint64_t tag_len = ReadU32(data, 16);
-  const uint64_t source_len = ReadU64(data, 20);
-  const uint64_t source_hash = ReadU64(data, 28);
-  const uint64_t filename_hash = ReadU64(data, 36);
-  const uint64_t payload_len = ReadU64(data, 44);
-  const uint64_t payload_hash = ReadU64(data, 52);
+  const uint64_t source_len = ReadU64(data, 16);
+  const uint64_t source_hash = ReadU64(data, 24);
+  const uint64_t payload_len = ReadU64(data, 32);
+  const uint64_t tag_len = ReadU32(data, 40);
 
+  // payload_len pins the file's structure: truncated or padded files reject.
   if (size != kHeaderSize + tag_len + payload_len) return false;
   if (tag_len != engine_tag.size() ||
       std::memcmp(data + kHeaderSize, engine_tag.data(), engine_tag.size()) != 0) {
@@ -203,10 +181,6 @@ bool DecodeSidecar(const uint8_t* data,
       source_hash != Hash64(source_utf8.data(), source_utf8.size())) {
     return false;
   }
-  if (filename_hash != 0 && filename_hash != expected_filename_hash) return false;
-
-  const uint8_t* payload = data + kHeaderSize + tag_len;
-  if (payload_hash != 0 && payload_hash != Hash64(payload, payload_len)) return false;
 
   *payload_offset_out = kHeaderSize + tag_len;
   *payload_size_out = payload_len;
@@ -250,7 +224,7 @@ bool ReadSidecar(const std::string& source_path,
   }
 
   if (!DecodeSidecar(out->file_bytes.data(), out->file_bytes.size(), EngineCacheTag(),
-                     source_utf8, expected_flags, FilenameHashForSource(source_path),
+                     source_utf8, expected_flags,
                      &out->payload_offset, &out->payload_size)) {
     out->file_bytes.clear();
     Trace("miss", sidecar_path, "invalid-or-stale");
@@ -277,8 +251,7 @@ bool WriteSidecar(const std::string& source_path,
 
   const std::string sidecar_path = SidecarPathForSource(source_path);
   const std::vector<uint8_t> contents =
-      EncodeSidecar(EngineCacheTag(), source_utf8, flags,
-                    FilenameHashForSource(source_path), payload, payload_size);
+      EncodeSidecar(EngineCacheTag(), source_utf8, flags, payload, payload_size);
 
 #if defined(_WIN32)
   const int pid = _getpid();
@@ -326,6 +299,63 @@ bool RemoveSidecar(const std::string& source_path) {
   const bool removed = std::filesystem::remove(sidecar_path, ec);
   if (removed) Trace("remove", sidecar_path);
   return removed && !ec;
+}
+
+namespace {
+// Layout (and on-disk compatibility) of the QuickJS vm cachedData prefix:
+// 4 magic bytes + XXH3-64(source) little-endian.
+constexpr char kVmPrefixMagic[4] = {'Q', 'J', 'S', 'C'};
+constexpr size_t kVmPrefixSize = 12;
+}  // namespace
+
+bool VmCachedDataNeedsWrapper() {
+#if defined(EDGE_NAPI_QUICKJS)
+  return true;
+#else
+  return false;
+#endif
+}
+
+std::vector<uint8_t> WrapVmCachedData(uint64_t source_hash,
+                                      const uint8_t* payload,
+                                      size_t payload_size) {
+  if (payload == nullptr) payload_size = 0;
+  if (!VmCachedDataNeedsWrapper()) {
+    return std::vector<uint8_t>(payload, payload + payload_size);
+  }
+  std::vector<uint8_t> out;
+  out.reserve(kVmPrefixSize + payload_size);
+  out.insert(out.end(), kVmPrefixMagic, kVmPrefixMagic + sizeof(kVmPrefixMagic));
+  for (int i = 0; i < 8; ++i) {
+    out.push_back(static_cast<uint8_t>(source_hash >> (8 * i)));
+  }
+  out.insert(out.end(), payload, payload + payload_size);
+  return out;
+}
+
+bool UnwrapVmCachedData(uint64_t expected_source_hash,
+                        const uint8_t* data,
+                        size_t size,
+                        size_t* payload_offset_out,
+                        size_t* payload_size_out) {
+  if (payload_offset_out == nullptr || payload_size_out == nullptr) return false;
+  *payload_offset_out = 0;
+  *payload_size_out = 0;
+  if (data == nullptr || size == 0) return false;
+  if (!VmCachedDataNeedsWrapper()) {
+    *payload_size_out = size;
+    return true;
+  }
+  if (size <= kVmPrefixSize) return false;
+  if (std::memcmp(data, kVmPrefixMagic, sizeof(kVmPrefixMagic)) != 0) return false;
+  uint64_t stored = 0;
+  for (int i = 0; i < 8; ++i) {
+    stored |= static_cast<uint64_t>(data[4 + i]) << (8 * i);
+  }
+  if (stored != expected_source_hash) return false;
+  *payload_offset_out = kVmPrefixSize;
+  *payload_size_out = size - kVmPrefixSize;
+  return true;
 }
 
 }  // namespace edge_bytecode_cache

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -10,15 +10,10 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
-#include <fstream>
-#include <iterator>
+#include <string>
 #include <system_error>
 
-#if defined(_WIN32)
-#include <process.h>
-#else
-#include <unistd.h>
-#endif
+#include "edge_bytecode_io.h"
 
 namespace edge_bytecode_cache {
 namespace {
@@ -47,33 +42,10 @@ void Trace(const char* event, const std::string& path, const char* detail = null
   }
 }
 
-void WriteU32(std::vector<uint8_t>* out, size_t offset, uint32_t value) {
-  (*out)[offset + 0] = static_cast<uint8_t>(value);
-  (*out)[offset + 1] = static_cast<uint8_t>(value >> 8);
-  (*out)[offset + 2] = static_cast<uint8_t>(value >> 16);
-  (*out)[offset + 3] = static_cast<uint8_t>(value >> 24);
-}
-
-void WriteU64(std::vector<uint8_t>* out, size_t offset, uint64_t value) {
-  for (int i = 0; i < 8; ++i) {
-    (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
-  }
-}
-
-uint32_t ReadU32(const uint8_t* data, size_t offset) {
-  return static_cast<uint32_t>(data[offset]) |
-         (static_cast<uint32_t>(data[offset + 1]) << 8) |
-         (static_cast<uint32_t>(data[offset + 2]) << 16) |
-         (static_cast<uint32_t>(data[offset + 3]) << 24);
-}
-
-uint64_t ReadU64(const uint8_t* data, size_t offset) {
-  uint64_t value = 0;
-  for (int i = 0; i < 8; ++i) {
-    value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
-  }
-  return value;
-}
+using io::ReadU32;
+using io::ReadU64;
+using io::WriteU32;
+using io::WriteU64;
 
 }  // namespace
 
@@ -203,27 +175,11 @@ bool ReadSidecar(const std::string& source_path,
 
   const auto started = std::chrono::steady_clock::now();
   const std::string sidecar_path = SidecarPathForSource(source_path);
-  std::FILE* in = std::fopen(sidecar_path.c_str(), "rb");
-  if (in == nullptr) return false;
 
-  // One sized read; validation happens in place over the same buffer.
-  if (std::fseek(in, 0, SEEK_END) != 0) {
-    std::fclose(in);
-    Trace("miss", sidecar_path, "read-error");
-    return false;
-  }
-  const long file_size = std::ftell(in);
-  if (file_size <= 0 || std::fseek(in, 0, SEEK_SET) != 0) {
-    std::fclose(in);
-    Trace("miss", sidecar_path, "read-error");
-    return false;
-  }
-  out->file_bytes.resize(static_cast<size_t>(file_size));
-  const size_t read = std::fread(out->file_bytes.data(), 1, out->file_bytes.size(), in);
-  std::fclose(in);
-  if (read != out->file_bytes.size()) {
-    out->file_bytes.clear();
-    Trace("miss", sidecar_path, "read-error");
+  // One sized read; validation happens in place over the same buffer. A
+  // missing file is the common no-cache case, not a read error.
+  if (!io::ReadFileFully(sidecar_path, &out->file_bytes)) {
+    if (std::filesystem::exists(sidecar_path)) Trace("miss", sidecar_path, "read-error");
     return false;
   }
 
@@ -257,41 +213,9 @@ bool WriteSidecar(const std::string& source_path,
   const std::vector<uint8_t> contents =
       EncodeSidecar(EngineCacheTag(), source_utf8, flags, payload, payload_size);
 
-#if defined(_WIN32)
-  const int pid = _getpid();
-#else
-  const int pid = static_cast<int>(getpid());
-#endif
-  const std::string tmp_path = sidecar_path + "." + std::to_string(pid) + ".tmp";
-
-  std::error_code ec;
-  {
-    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
-    if (!out.is_open()) {
-      Trace("write-failed", sidecar_path, "open");
-      return false;
-    }
-    out.write(reinterpret_cast<const char*>(contents.data()),
-              static_cast<std::streamsize>(contents.size()));
-    out.flush();
-    if (!out.good()) {
-      out.close();
-      std::filesystem::remove(tmp_path, ec);
-      Trace("write-failed", sidecar_path, "write");
-      return false;
-    }
-  }
-
-  std::filesystem::rename(tmp_path, sidecar_path, ec);
-  if (ec) {
-    // Windows rename does not replace an existing destination.
-    std::filesystem::remove(sidecar_path, ec);
-    std::filesystem::rename(tmp_path, sidecar_path, ec);
-    if (ec) {
-      std::filesystem::remove(tmp_path, ec);
-      Trace("write-failed", sidecar_path, "rename");
-      return false;
-    }
+  if (!io::AtomicWriteFile(sidecar_path, contents.data(), contents.size())) {
+    Trace("write-failed", sidecar_path);
+    return false;
   }
   Trace("write", sidecar_path);
   return true;

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -1,5 +1,8 @@
 #include "edge_bytecode_cache.h"
 
+#define XXH_INLINE_ALL
+#include "xxhash/xxhash.h"
+
 #include <atomic>
 #include <cctype>
 #include <chrono>
@@ -33,14 +36,6 @@ bool IsFalsyEnvValue(const char* value) {
   }
   return normalized == "0" || normalized == "false" || normalized == "no" ||
          normalized == "off";
-}
-
-bool TraceEnabled() {
-  static const bool enabled = [] {
-    const char* value = std::getenv("EDGE_BYTECODE_CACHE_TRACE");
-    return value != nullptr && value[0] != '\0' && !IsFalsyEnvValue(value);
-  }();
-  return enabled;
 }
 
 void Trace(const char* event, const std::string& path, const char* detail = nullptr) {
@@ -86,7 +81,7 @@ uint64_t ReadU64(const uint8_t* data, size_t offset) {
 // filename (it only enters ScriptOrigin) and stay relocatable.
 uint64_t FilenameHashForSource(const std::string& source_path) {
 #if defined(EDGE_NAPI_QUICKJS)
-  return Fnv1a64(source_path.data(), source_path.size());
+  return Hash64(source_path.data(), source_path.size());
 #else
   (void)source_path;
   return 0;
@@ -118,14 +113,8 @@ const std::string& EngineCacheTag() {
   return tag;
 }
 
-uint64_t Fnv1a64(const void* data, size_t size) {
-  const auto* bytes = static_cast<const uint8_t*>(data);
-  uint64_t hash = 0xcbf29ce484222325ull;
-  for (size_t i = 0; i < size; ++i) {
-    hash ^= bytes[i];
-    hash *= 1099511628211ull;
-  }
-  return hash;
+uint64_t Hash64(const void* data, size_t size) {
+  return XXH3_64bits(data, size);
 }
 
 void SetEnabledFromCli(bool enabled) {
@@ -137,6 +126,14 @@ bool Enabled() {
       !IsFalsyEnvValue(std::getenv("EDGE_BYTECODE_CACHE"));
   return env_enabled && !EngineCacheTag().empty() &&
          g_cli_enabled.load(std::memory_order_relaxed);
+}
+
+bool TraceEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("EDGE_BYTECODE_CACHE_TRACE");
+    return value != nullptr && value[0] != '\0' && !IsFalsyEnvValue(value);
+  }();
+  return enabled;
 }
 
 std::string SidecarPathForSource(const std::string& source_path) {
@@ -155,10 +152,17 @@ std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
   WriteU32(&out, 12, flags);
   WriteU32(&out, 16, static_cast<uint32_t>(engine_tag.size()));
   WriteU64(&out, 20, source_utf8.size());
-  WriteU64(&out, 28, Fnv1a64(source_utf8.data(), source_utf8.size()));
+  WriteU64(&out, 28, Hash64(source_utf8.data(), source_utf8.size()));
   WriteU64(&out, 36, filename_hash);
   WriteU64(&out, 44, payload_size);
-  WriteU64(&out, 52, Fnv1a64(payload, payload_size));
+#if defined(EDGE_NAPI_QUICKJS)
+  // QuickJS's bytecode reader is not hardened against corrupt input.
+  WriteU64(&out, 52, Hash64(payload, payload_size));
+#else
+  // V8 CachedData self-validates (rejected -> fallback); skip the extra pass.
+  (void)payload;
+  WriteU64(&out, 52, 0);
+#endif
   WriteU32(&out, 60, 0);
   std::memcpy(out.data() + kHeaderSize, engine_tag.data(), engine_tag.size());
   if (payload_size > 0) {
@@ -173,9 +177,11 @@ bool DecodeSidecar(const uint8_t* data,
                    std::string_view source_utf8,
                    uint32_t expected_flags,
                    uint64_t expected_filename_hash,
-                   std::vector<uint8_t>* payload_out) {
-  if (payload_out == nullptr) return false;
-  payload_out->clear();
+                   size_t* payload_offset_out,
+                   size_t* payload_size_out) {
+  if (payload_offset_out == nullptr || payload_size_out == nullptr) return false;
+  *payload_offset_out = 0;
+  *payload_size_out = 0;
   if (data == nullptr || size < kHeaderSize) return false;
   if (std::memcmp(data, kMagic, sizeof(kMagic)) != 0) return false;
   if (ReadU32(data, 8) != kFormatVersion) return false;
@@ -194,40 +200,59 @@ bool DecodeSidecar(const uint8_t* data,
     return false;
   }
   if (source_len != source_utf8.size() ||
-      source_hash != Fnv1a64(source_utf8.data(), source_utf8.size())) {
+      source_hash != Hash64(source_utf8.data(), source_utf8.size())) {
     return false;
   }
   if (filename_hash != 0 && filename_hash != expected_filename_hash) return false;
 
   const uint8_t* payload = data + kHeaderSize + tag_len;
-  if (payload_hash != Fnv1a64(payload, payload_len)) return false;
+  if (payload_hash != 0 && payload_hash != Hash64(payload, payload_len)) return false;
 
-  payload_out->assign(payload, payload + payload_len);
+  *payload_offset_out = kHeaderSize + tag_len;
+  *payload_size_out = payload_len;
   return true;
 }
 
 bool ReadSidecar(const std::string& source_path,
                  std::string_view source_utf8,
                  uint32_t expected_flags,
-                 std::vector<uint8_t>* payload_out) {
-  if (payload_out == nullptr) return false;
-  payload_out->clear();
+                 SidecarPayload* out) {
+  if (out == nullptr) return false;
+  out->file_bytes.clear();
+  out->payload_offset = 0;
+  out->payload_size = 0;
   if (!Enabled()) return false;
 
   const auto started = std::chrono::steady_clock::now();
   const std::string sidecar_path = SidecarPathForSource(source_path);
-  std::ifstream in(sidecar_path, std::ios::binary);
-  if (!in.is_open()) return false;
+  std::FILE* in = std::fopen(sidecar_path.c_str(), "rb");
+  if (in == nullptr) return false;
 
-  std::vector<uint8_t> contents((std::istreambuf_iterator<char>(in)),
-                                std::istreambuf_iterator<char>());
-  if (in.bad()) {
+  // One sized read; validation happens in place over the same buffer.
+  if (std::fseek(in, 0, SEEK_END) != 0) {
+    std::fclose(in);
     Trace("miss", sidecar_path, "read-error");
     return false;
   }
-  if (!DecodeSidecar(contents.data(), contents.size(), EngineCacheTag(),
-                     source_utf8, expected_flags,
-                     FilenameHashForSource(source_path), payload_out)) {
+  const long file_size = std::ftell(in);
+  if (file_size <= 0 || std::fseek(in, 0, SEEK_SET) != 0) {
+    std::fclose(in);
+    Trace("miss", sidecar_path, "read-error");
+    return false;
+  }
+  out->file_bytes.resize(static_cast<size_t>(file_size));
+  const size_t read = std::fread(out->file_bytes.data(), 1, out->file_bytes.size(), in);
+  std::fclose(in);
+  if (read != out->file_bytes.size()) {
+    out->file_bytes.clear();
+    Trace("miss", sidecar_path, "read-error");
+    return false;
+  }
+
+  if (!DecodeSidecar(out->file_bytes.data(), out->file_bytes.size(), EngineCacheTag(),
+                     source_utf8, expected_flags, FilenameHashForSource(source_path),
+                     &out->payload_offset, &out->payload_size)) {
+    out->file_bytes.clear();
     Trace("miss", sidecar_path, "invalid-or-stale");
     return false;
   }
@@ -237,7 +262,7 @@ bool ReadSidecar(const std::string& source_path,
                             .count();
     char detail[64];
     std::snprintf(detail, sizeof(detail), "read+hash=%lldus payload=%zub",
-                  static_cast<long long>(micros), payload_out->size());
+                  static_cast<long long>(micros), out->payload_size);
     Trace("hit", sidecar_path, detail);
   }
   return true;

--- a/src/edge_bytecode_cache.cc
+++ b/src/edge_bytecode_cache.cc
@@ -171,8 +171,12 @@ bool DecodeSidecar(const uint8_t* data,
   const uint64_t payload_len = ReadU64(data, 32);
   const uint64_t tag_len = ReadU32(data, 40);
 
-  // payload_len pins the file's structure: truncated or padded files reject.
-  if (size != kHeaderSize + tag_len + payload_len) return false;
+  // Bounds first: the tag/payload lengths come from untrusted file bytes, so
+  // validate the structure additively (never `kHeaderSize + tag_len +
+  // payload_len`, which can wrap past 2^64 and let an out-of-bounds tag/payload
+  // span through). `size >= kHeaderSize` is already established above.
+  if (tag_len > size - kHeaderSize) return false;
+  if (payload_len != size - kHeaderSize - tag_len) return false;
   if (tag_len != engine_tag.size() ||
       std::memcmp(data + kHeaderSize, engine_tag.data(), engine_tag.size()) != 0) {
     return false;
@@ -299,63 +303,6 @@ bool RemoveSidecar(const std::string& source_path) {
   const bool removed = std::filesystem::remove(sidecar_path, ec);
   if (removed) Trace("remove", sidecar_path);
   return removed && !ec;
-}
-
-namespace {
-// Layout (and on-disk compatibility) of the QuickJS vm cachedData prefix:
-// 4 magic bytes + XXH3-64(source) little-endian.
-constexpr char kVmPrefixMagic[4] = {'Q', 'J', 'S', 'C'};
-constexpr size_t kVmPrefixSize = 12;
-}  // namespace
-
-bool VmCachedDataNeedsWrapper() {
-#if defined(EDGE_NAPI_QUICKJS)
-  return true;
-#else
-  return false;
-#endif
-}
-
-std::vector<uint8_t> WrapVmCachedData(uint64_t source_hash,
-                                      const uint8_t* payload,
-                                      size_t payload_size) {
-  if (payload == nullptr) payload_size = 0;
-  if (!VmCachedDataNeedsWrapper()) {
-    return std::vector<uint8_t>(payload, payload + payload_size);
-  }
-  std::vector<uint8_t> out;
-  out.reserve(kVmPrefixSize + payload_size);
-  out.insert(out.end(), kVmPrefixMagic, kVmPrefixMagic + sizeof(kVmPrefixMagic));
-  for (int i = 0; i < 8; ++i) {
-    out.push_back(static_cast<uint8_t>(source_hash >> (8 * i)));
-  }
-  out.insert(out.end(), payload, payload + payload_size);
-  return out;
-}
-
-bool UnwrapVmCachedData(uint64_t expected_source_hash,
-                        const uint8_t* data,
-                        size_t size,
-                        size_t* payload_offset_out,
-                        size_t* payload_size_out) {
-  if (payload_offset_out == nullptr || payload_size_out == nullptr) return false;
-  *payload_offset_out = 0;
-  *payload_size_out = 0;
-  if (data == nullptr || size == 0) return false;
-  if (!VmCachedDataNeedsWrapper()) {
-    *payload_size_out = size;
-    return true;
-  }
-  if (size <= kVmPrefixSize) return false;
-  if (std::memcmp(data, kVmPrefixMagic, sizeof(kVmPrefixMagic)) != 0) return false;
-  uint64_t stored = 0;
-  for (int i = 0; i < 8; ++i) {
-    stored |= static_cast<uint64_t>(data[4 + i]) << (8 * i);
-  }
-  if (stored != expected_source_hash) return false;
-  *payload_offset_out = kVmPrefixSize;
-  *payload_size_out = size - kVmPrefixSize;
-  return true;
 }
 
 }  // namespace edge_bytecode_cache

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -15,8 +15,11 @@ namespace edge_bytecode_cache {
 
 // Bump whenever the bytes handed to the engine compiler for a given source
 // file change shape (CJS wrapper text, parameter list, shebang handling, ...)
-// or the container hashing changes (v2: XXH3 instead of FNV-1a).
-constexpr uint32_t kFormatVersion = 2;
+// or the container/payload encoding changes (v2: XXH3 instead of FNV-1a;
+// v3: payloads lost the in-provider source-hash prefix; v4: engine-agnostic
+// 48-byte header — engine-specific validation lives inside the QuickJS
+// payload itself, mirroring V8's CachedData).
+constexpr uint32_t kFormatVersion = 4;
 
 // Compile shape of the payload; a sidecar is only consumed by the exact shape
 // that produced it.
@@ -82,7 +85,6 @@ bool RemoveSidecar(const std::string& source_path);
 std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
                                    std::string_view source_utf8,
                                    uint32_t flags,
-                                   uint64_t filename_hash,
                                    const uint8_t* payload,
                                    size_t payload_size);
 bool DecodeSidecar(const uint8_t* data,
@@ -90,9 +92,34 @@ bool DecodeSidecar(const uint8_t* data,
                    std::string_view engine_tag,
                    std::string_view source_utf8,
                    uint32_t expected_flags,
-                   uint64_t expected_filename_hash,
                    size_t* payload_offset_out,
                    size_t* payload_size_out);
+
+// vm cachedData wrapper. Engine payloads self-validate integrity (V8
+// CachedData; QuickJS via the provider's QJSB header) but QuickJS cannot
+// detect bytecode compiled from different SOURCE. User-facing vm buffers
+// (vm.Script/compileFunction/SourceTextModule cachedData) on QuickJS
+// therefore carry an Edge-owned 12-byte prefix [QJSC + XXH3(source)] that is
+// validated and stripped before the bytes reach the engine. On V8 both
+// helpers are pass-throughs (offset 0), keeping byte-parity with Node's
+// CachedData. Sidecar/builtins payloads carry no Edge prefix — their
+// containers already record the source hash.
+bool VmCachedDataNeedsWrapper();
+
+// Prefix + payload as a fresh buffer (pass-through copy on V8).
+std::vector<uint8_t> WrapVmCachedData(uint64_t source_hash,
+                                      const uint8_t* payload,
+                                      size_t payload_size);
+
+// Validates the prefix against the expected source hash and returns the raw
+// payload span. False means wrong/missing prefix or wrong source — callers
+// report cachedData as rejected without touching the engine. On V8 always
+// true with the identity span.
+bool UnwrapVmCachedData(uint64_t expected_source_hash,
+                        const uint8_t* data,
+                        size_t size,
+                        size_t* payload_offset_out,
+                        size_t* payload_size_out);
 
 }  // namespace edge_bytecode_cache
 

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -17,9 +17,13 @@ namespace edge_bytecode_cache {
 // file change shape (CJS wrapper text, parameter list, shebang handling, ...).
 constexpr uint32_t kFormatVersion = 1;
 
-// flags bit 0: payload was produced by the CJS function-compile path with
-// params (exports, require, module, __filename, __dirname).
+// Compile shape of the payload; a sidecar is only consumed by the exact shape
+// that produced it.
+// bit 0: CJS function-compile with params (exports, require, module,
+//        __filename, __dirname).
 constexpr uint32_t kFlagCjsFunctionV1 = 1u << 0;
+// bit 1: ES module compile (ModuleWrap / module shape).
+constexpr uint32_t kFlagEsmModuleV1 = 1u << 1;
 
 // Suffix appended to the full source filename. Empty when the active NAPI
 // provider has no bytecode-cache support.
@@ -42,10 +46,11 @@ bool Enabled();
 std::string SidecarPathForSource(const std::string& source_path);
 
 // Reads <source_path><suffix> and validates it against the exact source text
-// about to be compiled. False (and empty payload) on any mismatch; never
-// throws.
+// about to be compiled and the expected compile shape. False (and empty
+// payload) on any mismatch; never throws.
 bool ReadSidecar(const std::string& source_path,
                  std::string_view source_utf8,
+                 uint32_t expected_flags,
                  std::vector<uint8_t>* payload_out);
 
 // Atomically writes the sidecar next to the source (temp file + rename).
@@ -53,6 +58,7 @@ bool ReadSidecar(const std::string& source_path,
 // false, never throws.
 bool WriteSidecar(const std::string& source_path,
                   std::string_view source_utf8,
+                  uint32_t flags,
                   const uint8_t* payload,
                   size_t payload_size);
 
@@ -61,6 +67,7 @@ bool RemoveSidecar(const std::string& source_path);
 // Serialization helpers exposed for tests.
 std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
                                    std::string_view source_utf8,
+                                   uint32_t flags,
                                    uint64_t filename_hash,
                                    const uint8_t* payload,
                                    size_t payload_size);
@@ -68,6 +75,7 @@ bool DecodeSidecar(const uint8_t* data,
                    size_t size,
                    std::string_view engine_tag,
                    std::string_view source_utf8,
+                   uint32_t expected_flags,
                    uint64_t expected_filename_hash,
                    std::vector<uint8_t>* payload_out);
 

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -7,8 +7,9 @@
 #include <string_view>
 #include <vector>
 
-// Sidecar bytecode caches: engine-serialized compiled code stored next to the
-// source file ("app.js" -> "app.js.v8b" / "app.js.qjsb"). The payload is
+// Sidecar bytecode caches: engine-serialized compiled code stored in a
+// per-directory "__edgecache__" subdir next to the source, PEP 3147 style
+// ("dir/app.js" -> "dir/__edgecache__/app.js.v8-13-6.jsc"). The payload is
 // opaque engine data (V8 code cache / QuickJS JS_WriteObject bytecode); this
 // module owns the container format and its validation only.
 namespace edge_bytecode_cache {
@@ -29,23 +30,38 @@ constexpr uint32_t kFlagCjsFunctionV1 = 1u << 0;
 // bit 1: ES module compile (ModuleWrap / module shape).
 constexpr uint32_t kFlagEsmModuleV1 = 1u << 1;
 
-// Suffix appended to the full source filename. Empty when the active NAPI
-// provider has no bytecode-cache support.
+// Engine suffix for the consolidated builtins cache file next to the binary
+// (".v8b" / ".qjsb"). User-file sidecars use the
+// __edgecache__/<filename>.<tag>.jsc scheme instead; see SidecarPathForSource.
+// Empty when the active NAPI provider has no bytecode-cache support.
 const char* SidecarSuffix();
 
 // Engine identity baked into sidecar headers, e.g. "v8-11.9.169.7-node.0" or
 // "qjs-ng-0.14.0". Empty disables the cache entirely.
 const std::string& EngineCacheTag();
 
+// Short engine tag for the cache *filename* only (e.g. "v8-13-6" / "qjs-0-14").
+// Coarser than EngineCacheTag (engine + major.minor); the header still carries
+// the full version for the staleness check.
+const std::string& EngineFileTag();
+
 // XXH3-64 over arbitrary bytes (container hashing).
 uint64_t Hash64(const void* data, size_t size);
 
-// The CLI calls this when --no-bytecode-cache is in effect or the mode should
-// never touch sidecars (e.g. --check).
-void SetEnabledFromCli(bool enabled);
+// CLI overrides (win over the EDGE_BYTECODE_CACHE env var):
+//   --no-bytecode-cache / --check  -> SetCacheDisabledFromCli (kill switch)
+//   --bytecode-cache / --precompile -> SetSidecarsEnabledFromCli (opt in)
+void SetCacheDisabledFromCli();
+void SetSidecarsEnabledFromCli();
 
-// True when the provider supports caching, the CLI did not disable it, and
-// EDGE_BYTECODE_CACHE is not set to a falsy value.
+// True when the consolidated builtins (lib/) cache may be read/written. ON by
+// default; off only via the kill switch (--no-bytecode-cache,
+// EDGE_BYTECODE_CACHE=0, --check) or when the provider has no cache support.
+bool BuiltinsCacheEnabled();
+
+// True when per-file user sidecars may be read/written. OFF by default;
+// on only when explicitly opted in (--bytecode-cache, EDGE_BYTECODE_CACHE
+// truthy, or --precompile) and not killed.
 bool Enabled();
 
 // True when EDGE_BYTECODE_CACHE_TRACE is set (shared by the builtins cache).

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -14,8 +14,9 @@
 namespace edge_bytecode_cache {
 
 // Bump whenever the bytes handed to the engine compiler for a given source
-// file change shape (CJS wrapper text, parameter list, shebang handling, ...).
-constexpr uint32_t kFormatVersion = 1;
+// file change shape (CJS wrapper text, parameter list, shebang handling, ...)
+// or the container hashing changes (v2: XXH3 instead of FNV-1a).
+constexpr uint32_t kFormatVersion = 2;
 
 // Compile shape of the payload; a sidecar is only consumed by the exact shape
 // that produced it.
@@ -33,7 +34,8 @@ const char* SidecarSuffix();
 // "qjs-ng-0.14.0". Empty disables the cache entirely.
 const std::string& EngineCacheTag();
 
-uint64_t Fnv1a64(const void* data, size_t size);
+// XXH3-64 over arbitrary bytes (container hashing).
+uint64_t Hash64(const void* data, size_t size);
 
 // The CLI calls this when --no-bytecode-cache is in effect or the mode should
 // never touch sidecars (e.g. --check).
@@ -43,7 +45,19 @@ void SetEnabledFromCli(bool enabled);
 // EDGE_BYTECODE_CACHE is not set to a falsy value.
 bool Enabled();
 
+// True when EDGE_BYTECODE_CACHE_TRACE is set (shared by the builtins cache).
+bool TraceEnabled();
+
 std::string SidecarPathForSource(const std::string& source_path);
+
+// A validated sidecar: the whole file is read once and the payload is a view
+// into that buffer (no intermediate copies).
+struct SidecarPayload {
+  std::vector<uint8_t> file_bytes;
+  size_t payload_offset = 0;
+  size_t payload_size = 0;
+  const uint8_t* data() const { return file_bytes.data() + payload_offset; }
+};
 
 // Reads <source_path><suffix> and validates it against the exact source text
 // about to be compiled and the expected compile shape. False (and empty
@@ -51,7 +65,7 @@ std::string SidecarPathForSource(const std::string& source_path);
 bool ReadSidecar(const std::string& source_path,
                  std::string_view source_utf8,
                  uint32_t expected_flags,
-                 std::vector<uint8_t>* payload_out);
+                 SidecarPayload* out);
 
 // Atomically writes the sidecar next to the source (temp file + rename).
 // Failures (read-only filesystem, permissions, ...) are silent: returns
@@ -77,7 +91,8 @@ bool DecodeSidecar(const uint8_t* data,
                    std::string_view source_utf8,
                    uint32_t expected_flags,
                    uint64_t expected_filename_hash,
-                   std::vector<uint8_t>* payload_out);
+                   size_t* payload_offset_out,
+                   size_t* payload_size_out);
 
 }  // namespace edge_bytecode_cache
 

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -1,0 +1,76 @@
+#ifndef EDGE_BYTECODE_CACHE_H_
+#define EDGE_BYTECODE_CACHE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Sidecar bytecode caches: engine-serialized compiled code stored next to the
+// source file ("app.js" -> "app.js.v8b" / "app.js.qjsb"). The payload is
+// opaque engine data (V8 code cache / QuickJS JS_WriteObject bytecode); this
+// module owns the container format and its validation only.
+namespace edge_bytecode_cache {
+
+// Bump whenever the bytes handed to the engine compiler for a given source
+// file change shape (CJS wrapper text, parameter list, shebang handling, ...).
+constexpr uint32_t kFormatVersion = 1;
+
+// flags bit 0: payload was produced by the CJS function-compile path with
+// params (exports, require, module, __filename, __dirname).
+constexpr uint32_t kFlagCjsFunctionV1 = 1u << 0;
+
+// Suffix appended to the full source filename. Empty when the active NAPI
+// provider has no bytecode-cache support.
+const char* SidecarSuffix();
+
+// Engine identity baked into sidecar headers, e.g. "v8-11.9.169.7-node.0" or
+// "qjs-ng-0.14.0". Empty disables the cache entirely.
+const std::string& EngineCacheTag();
+
+uint64_t Fnv1a64(const void* data, size_t size);
+
+// The CLI calls this when --no-bytecode-cache is in effect or the mode should
+// never touch sidecars (e.g. --check).
+void SetEnabledFromCli(bool enabled);
+
+// True when the provider supports caching, the CLI did not disable it, and
+// EDGE_BYTECODE_CACHE is not set to a falsy value.
+bool Enabled();
+
+std::string SidecarPathForSource(const std::string& source_path);
+
+// Reads <source_path><suffix> and validates it against the exact source text
+// about to be compiled. False (and empty payload) on any mismatch; never
+// throws.
+bool ReadSidecar(const std::string& source_path,
+                 std::string_view source_utf8,
+                 std::vector<uint8_t>* payload_out);
+
+// Atomically writes the sidecar next to the source (temp file + rename).
+// Failures (read-only filesystem, permissions, ...) are silent: returns
+// false, never throws.
+bool WriteSidecar(const std::string& source_path,
+                  std::string_view source_utf8,
+                  const uint8_t* payload,
+                  size_t payload_size);
+
+bool RemoveSidecar(const std::string& source_path);
+
+// Serialization helpers exposed for tests.
+std::vector<uint8_t> EncodeSidecar(std::string_view engine_tag,
+                                   std::string_view source_utf8,
+                                   uint64_t filename_hash,
+                                   const uint8_t* payload,
+                                   size_t payload_size);
+bool DecodeSidecar(const uint8_t* data,
+                   size_t size,
+                   std::string_view engine_tag,
+                   std::string_view source_utf8,
+                   uint64_t expected_filename_hash,
+                   std::vector<uint8_t>* payload_out);
+
+}  // namespace edge_bytecode_cache
+
+#endif  // EDGE_BYTECODE_CACHE_H_

--- a/src/edge_bytecode_cache.h
+++ b/src/edge_bytecode_cache.h
@@ -95,32 +95,6 @@ bool DecodeSidecar(const uint8_t* data,
                    size_t* payload_offset_out,
                    size_t* payload_size_out);
 
-// vm cachedData wrapper. Engine payloads self-validate integrity (V8
-// CachedData; QuickJS via the provider's QJSB header) but QuickJS cannot
-// detect bytecode compiled from different SOURCE. User-facing vm buffers
-// (vm.Script/compileFunction/SourceTextModule cachedData) on QuickJS
-// therefore carry an Edge-owned 12-byte prefix [QJSC + XXH3(source)] that is
-// validated and stripped before the bytes reach the engine. On V8 both
-// helpers are pass-throughs (offset 0), keeping byte-parity with Node's
-// CachedData. Sidecar/builtins payloads carry no Edge prefix — their
-// containers already record the source hash.
-bool VmCachedDataNeedsWrapper();
-
-// Prefix + payload as a fresh buffer (pass-through copy on V8).
-std::vector<uint8_t> WrapVmCachedData(uint64_t source_hash,
-                                      const uint8_t* payload,
-                                      size_t payload_size);
-
-// Validates the prefix against the expected source hash and returns the raw
-// payload span. False means wrong/missing prefix or wrong source — callers
-// report cachedData as rejected without touching the engine. On V8 always
-// true with the identity span.
-bool UnwrapVmCachedData(uint64_t expected_source_hash,
-                        const uint8_t* data,
-                        size_t size,
-                        size_t* payload_offset_out,
-                        size_t* payload_size_out);
-
 }  // namespace edge_bytecode_cache
 
 #endif  // EDGE_BYTECODE_CACHE_H_

--- a/src/edge_bytecode_io.h
+++ b/src/edge_bytecode_io.h
@@ -1,0 +1,116 @@
+#ifndef EDGE_BYTECODE_IO_H_
+#define EDGE_BYTECODE_IO_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+// Little-endian integer codecs and whole-file read / atomic write shared by the
+// bytecode container modules (edge_bytecode_cache, edge_builtin_bytecode).
+namespace edge_bytecode_cache::io {
+
+inline void WriteU16(std::vector<uint8_t>* out, size_t offset, uint16_t value) {
+  (*out)[offset + 0] = static_cast<uint8_t>(value);
+  (*out)[offset + 1] = static_cast<uint8_t>(value >> 8);
+}
+
+inline void WriteU32(std::vector<uint8_t>* out, size_t offset, uint32_t value) {
+  for (int i = 0; i < 4; ++i) (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
+}
+
+inline void WriteU64(std::vector<uint8_t>* out, size_t offset, uint64_t value) {
+  for (int i = 0; i < 8; ++i) (*out)[offset + i] = static_cast<uint8_t>(value >> (8 * i));
+}
+
+inline uint16_t ReadU16(const uint8_t* data, size_t offset) {
+  return static_cast<uint16_t>(static_cast<uint16_t>(data[offset]) |
+                               (static_cast<uint16_t>(data[offset + 1]) << 8));
+}
+
+inline uint32_t ReadU32(const uint8_t* data, size_t offset) {
+  uint32_t value = 0;
+  for (int i = 0; i < 4; ++i) value |= static_cast<uint32_t>(data[offset + i]) << (8 * i);
+  return value;
+}
+
+inline uint64_t ReadU64(const uint8_t* data, size_t offset) {
+  uint64_t value = 0;
+  for (int i = 0; i < 8; ++i) value |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
+  return value;
+}
+
+// Reads the whole file into `out` (resized to the exact size) in one sized
+// read, so the caller can validate in place. False (and empty `out`) on any
+// error; never throws. The caller owns tracing.
+inline bool ReadFileFully(const std::string& path, std::vector<uint8_t>* out) {
+  out->clear();
+  std::FILE* in = std::fopen(path.c_str(), "rb");
+  if (in == nullptr) return false;
+  if (std::fseek(in, 0, SEEK_END) != 0) {
+    std::fclose(in);
+    return false;
+  }
+  const long file_size = std::ftell(in);
+  if (file_size <= 0 || std::fseek(in, 0, SEEK_SET) != 0) {
+    std::fclose(in);
+    return false;
+  }
+  out->resize(static_cast<size_t>(file_size));
+  const size_t read = std::fread(out->data(), 1, out->size(), in);
+  std::fclose(in);
+  if (read != out->size()) {
+    out->clear();
+    return false;
+  }
+  return true;
+}
+
+// Atomically replaces `path` with `data` via a pid-tagged temp file + rename.
+// False on any error (read-only filesystem, permissions, ...); never throws.
+inline bool AtomicWriteFile(const std::string& path, const uint8_t* data, size_t size) {
+#if defined(_WIN32)
+  const int pid = _getpid();
+#else
+  const int pid = static_cast<int>(getpid());
+#endif
+  const std::string tmp_path = path + "." + std::to_string(pid) + ".tmp";
+
+  std::error_code ec;
+  {
+    std::FILE* out = std::fopen(tmp_path.c_str(), "wb");
+    if (out == nullptr) return false;
+    const size_t written = (size > 0 && data != nullptr) ? std::fwrite(data, 1, size, out) : 0;
+    const bool ok = written == size && std::fflush(out) == 0;
+    std::fclose(out);
+    if (!ok) {
+      std::filesystem::remove(tmp_path, ec);
+      return false;
+    }
+  }
+
+  std::filesystem::rename(tmp_path, path, ec);
+  if (ec) {
+    // Windows rename does not replace an existing destination.
+    std::filesystem::remove(path, ec);
+    std::filesystem::rename(tmp_path, path, ec);
+    if (ec) {
+      std::filesystem::remove(tmp_path, ec);
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace edge_bytecode_cache::io
+
+#endif  // EDGE_BYTECODE_IO_H_

--- a/src/edge_cli.cc
+++ b/src/edge_cli.cc
@@ -71,7 +71,8 @@ constexpr const char kNativeHelpText[] =
     "  --watch                     run in watch mode\n"
     "  --test                      run tests\n"
     "  --precompile <path>...      compile .js/.cjs files to bytecode sidecars\n"
-    "  --no-bytecode-cache         do not read or write bytecode sidecar files\n"
+    "  --bytecode-cache            enable per-file bytecode sidecars (off by default)\n"
+    "  --no-bytecode-cache         disable all bytecode caching (incl. builtins)\n"
     "  --completion-bash           print source-able bash completion script\n"
     "  -v, --version               print Edge.js / Node.js version\n"
     "  -h, --help                  print this help\n";
@@ -369,18 +370,18 @@ bool IsBooleanOptionEnabled(const std::vector<std::string>& tokens, const char* 
   return false;
 }
 
-// Default-on boolean: disabled only when the last occurrence among
-// --bytecode-cache / --no-bytecode-cache is the negation.
-bool BytecodeCacheDisabledByTokens(const std::vector<std::string>& tokens) {
-  bool disabled = false;
+// --bytecode-cache / --no-bytecode-cache, last occurrence wins. Returns
+// -1 (disable everything), +1 (opt user sidecars in), or 0 (neither given).
+int BytecodeCacheCliOverride(const std::vector<std::string>& tokens) {
+  int override_state = 0;
   for (const auto& token : tokens) {
     if (token == "--no-bytecode-cache") {
-      disabled = true;
+      override_state = -1;
     } else if (token == "--bytecode-cache") {
-      disabled = false;
+      override_state = 1;
     }
   }
-  return disabled;
+  return override_state;
 }
 
 bool TokenHasInlineValue(const std::string& token) {
@@ -1604,12 +1605,17 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
   ApplySupportedV8Flags(raw_exec_argv);
   EDGE_STARTUP_TRACE(startup_trace, "cli.apply-v8-flags");
 
-  const bool bytecode_cache_disabled =
-      BytecodeCacheDisabledByTokens(effective_state.effective_tokens);
+  // Bytecode cache defaults: builtins ON, per-file user sidecars OFF.
+  //   --no-bytecode-cache / --check  -> kill switch (builtins + sidecars off)
+  //   --bytecode-cache / --precompile -> opt user sidecars in
   // --check must never touch sidecars: a syntax check should not write to the
   // checked tree.
-  if (bytecode_cache_disabled || mode == CliMode::kCheck) {
-    edge_bytecode_cache::SetEnabledFromCli(false);
+  const int bytecode_cache_override =
+      BytecodeCacheCliOverride(effective_state.effective_tokens);
+  if (bytecode_cache_override == -1 || mode == CliMode::kCheck) {
+    edge_bytecode_cache::SetCacheDisabledFromCli();
+  } else if (bytecode_cache_override == 1 || saw_precompile) {
+    edge_bytecode_cache::SetSidecarsEnabledFromCli();
   }
   if (HasExactOptionToken(effective_state.effective_tokens, "--completion-bash")) {
     EDGE_STARTUP_TRACE(startup_trace, "cli.dispatch.completion-bash");
@@ -1677,7 +1683,7 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
       conflicting = "--watch";
     } else if (!run_target.empty()) {
       conflicting = "--run";
-    } else if (bytecode_cache_disabled) {
+    } else if (bytecode_cache_override == -1) {
       conflicting = "--no-bytecode-cache";
     }
     if (conflicting != nullptr) {

--- a/src/edge_cli.cc
+++ b/src/edge_cli.cc
@@ -39,6 +39,8 @@
 #include "edge_stream_base.h"
 #include "edge_timers_host.h"
 #include "edge_runtime_platform.h"
+#include "edge_bytecode_cache.h"
+#include "edge_precompile.h"
 #include "edge_runtime.h"
 #include "edge_worker_control.h"
 #include "edge_worker_env.h"
@@ -67,6 +69,8 @@ constexpr const char kNativeHelpText[] =
     "  --run <command>             run a package script command\n"
     "  --watch                     run in watch mode\n"
     "  --test                      run tests\n"
+    "  --precompile <path>...      compile .js/.cjs files to bytecode sidecars\n"
+    "  --no-bytecode-cache         do not read or write bytecode sidecar files\n"
     "  --completion-bash           print source-able bash completion script\n"
     "  -v, --version               print Edge.js / Node.js version\n"
     "  -h, --help                  print this help\n";
@@ -363,6 +367,20 @@ bool IsBooleanOptionEnabled(const std::vector<std::string>& tokens, const char* 
   return false;
 }
 
+// Default-on boolean: disabled only when the last occurrence among
+// --bytecode-cache / --no-bytecode-cache is the negation.
+bool BytecodeCacheDisabledByTokens(const std::vector<std::string>& tokens) {
+  bool disabled = false;
+  for (const auto& token : tokens) {
+    if (token == "--no-bytecode-cache") {
+      disabled = true;
+    } else if (token == "--bytecode-cache") {
+      disabled = false;
+    }
+  }
+  return disabled;
+}
+
 bool TokenHasInlineValue(const std::string& token) {
   return token.find('=') != std::string::npos;
 }
@@ -470,6 +488,7 @@ bool IsBooleanOptionForNegation(const std::string& option) {
       "--allow-wasi",
       "--allow-worker",
       "--async-context-frame",
+      "--bytecode-cache",
       "--check",
       "--enable-source-maps",
       "--entry-url",
@@ -514,6 +533,7 @@ bool IsBooleanOptionForNegation(const std::string& option) {
       "--openssl-shared-config",
       "--pending-deprecation",
       "--permission",
+      "--precompile",
       "--preserve-symlinks",
       "--preserve-symlinks-main",
       "--print",
@@ -614,6 +634,7 @@ bool HasDisallowedNodeOption(const std::string& token) {
       "--expose_internals",
       "--help",
       "--interactive",
+      "--precompile",
       "--print",
       "--test",
       "--v8-options",
@@ -1380,6 +1401,7 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
     kPrint,
     kCheck,
     kRun,
+    kPrecompile,
   };
 
   CliMode mode = CliMode::kNone;
@@ -1390,6 +1412,7 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
   int script_index = argc;
   std::string run_target;
   bool saw_check = false;
+  bool saw_precompile = false;
   bool print_flag = false;
   bool has_eval_string = false;
   bool force_repl = false;
@@ -1475,6 +1498,12 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
       raw_exec_argv.push_back(token);
       saw_check = true;
       mode = CliMode::kCheck;
+      continue;
+    }
+    if (token == "--precompile") {
+      raw_exec_argv.push_back(token);
+      saw_precompile = true;
+      mode = CliMode::kPrecompile;
       continue;
     }
     if (token == "-i" || token == "--interactive") {
@@ -1572,6 +1601,14 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
   EdgeSetExecArgv(raw_exec_argv);
   ApplySupportedV8Flags(raw_exec_argv);
   EDGE_STARTUP_TRACE(startup_trace, "cli.apply-v8-flags");
+
+  const bool bytecode_cache_disabled =
+      BytecodeCacheDisabledByTokens(effective_state.effective_tokens);
+  // --check must never touch sidecars: a syntax check should not write to the
+  // checked tree.
+  if (bytecode_cache_disabled || mode == CliMode::kCheck) {
+    edge_bytecode_cache::SetEnabledFromCli(false);
+  }
   if (HasExactOptionToken(effective_state.effective_tokens, "--completion-bash")) {
     EDGE_STARTUP_TRACE(startup_trace, "cli.dispatch.completion-bash");
     std::cout << GetBashCompletion();
@@ -1619,6 +1656,32 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
     if (HasOptionTokenWithInlineValue(effective_state.effective_tokens, "--watch-path")) {
       if (error_out != nullptr) {
         *error_out = FormatCliError("--watch-path cannot be used in combination with --test");
+      }
+      return 9;
+    }
+  }
+
+  if (saw_precompile) {
+    const char* conflicting = nullptr;
+    if (saw_check) {
+      conflicting = "--check";
+    } else if (has_eval_string) {
+      conflicting = "--eval";
+    } else if (force_repl) {
+      conflicting = "--interactive";
+    } else if (requested_test_flag) {
+      conflicting = "--test";
+    } else if (use_watch_mode) {
+      conflicting = "--watch";
+    } else if (!run_target.empty()) {
+      conflicting = "--run";
+    } else if (bytecode_cache_disabled) {
+      conflicting = "--no-bytecode-cache";
+    }
+    if (conflicting != nullptr) {
+      if (error_out != nullptr) {
+        *error_out = FormatCliError(std::string("either --precompile or ") + conflicting +
+                                    " can be used, not both");
       }
       return 9;
     }
@@ -1739,6 +1802,32 @@ int EdgeRunCli(int argc, const char* const* argv, std::string* error_out) {
     EdgeSetScriptArgv(script_argv);
     EDGE_STARTUP_TRACE(startup_trace, "cli.dispatch.watch");
     return RunCliBuiltin(";", "internal/main/watch_mode", nullptr, error_out, init_options);
+  }
+
+  if (mode == CliMode::kPrecompile) {
+    int path_index = script_index;
+    if (path_index < argc && argv[path_index] != nullptr && std::strcmp(argv[path_index], "--") == 0) {
+      path_index++;
+    }
+    std::vector<std::string> precompile_paths;
+    precompile_paths.reserve(static_cast<size_t>(argc - path_index));
+    for (int argi = path_index; argi < argc; ++argi) {
+      if (argv[argi] != nullptr) precompile_paths.emplace_back(argv[argi]);
+    }
+    if (precompile_paths.empty()) {
+      if (error_out != nullptr) {
+        *error_out = FormatCliError("--precompile requires at least one file or directory");
+      }
+      return 9;
+    }
+    EdgeSetScriptArgv(precompile_paths);
+    EDGE_STARTUP_TRACE(startup_trace, "cli.dispatch.precompile");
+    return RunWithFreshEnv(
+        [&](napi_env env) {
+          return edge_precompile::RunPrecompile(env, precompile_paths, error_out);
+        },
+        error_out,
+        init_options);
   }
 
   const bool use_stdin_entry =

--- a/src/edge_cli.cc
+++ b/src/edge_cli.cc
@@ -39,6 +39,7 @@
 #include "edge_stream_base.h"
 #include "edge_timers_host.h"
 #include "edge_runtime_platform.h"
+#include "edge_builtin_bytecode.h"
 #include "edge_bytecode_cache.h"
 #include "edge_precompile.h"
 #include "edge_runtime.h"
@@ -271,6 +272,7 @@ int RunWithFreshEnv(const std::function<int(napi_env)>& runner,
   }
   EdgeEnvironmentRunCleanup(env);
   EdgeEnvironmentRunAtExitCallbacks(env);
+  edge_builtin_bytecode::FlushIfDirty();
   EDGE_STARTUP_TRACE(startup_trace, "cli.env.cleanup");
   const napi_status release_status = unofficial_napi_release_env(env_scope);
   if (release_status != napi_ok) {

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -1204,13 +1204,12 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
     }
   }
   napi_value compile_result = nullptr;
+  const unofficial_napi_js_source compile_source{code, nullptr};
   if (unofficial_napi_contextify_compile_function(env,
-                                                  code,
+                                                  &compile_source,
                                                   filename,
                                                   0,
                                                   0,
-                                                  undefined,
-                                                  false,
                                                   undefined,
                                                   undefined,
                                                   params,
@@ -1634,14 +1633,13 @@ static bool ExecuteBuiltinFromNative(napi_env env, ModuleLoaderState* state, con
   }
 
   napi_value compile_result = nullptr;
+  const unofficial_napi_js_source compile_source{code, nullptr};
   const napi_status compile_status =
       unofficial_napi_contextify_compile_function(env,
-                                                  code,
+                                                  &compile_source,
                                                   filename,
                                                   0,
                                                   0,
-                                                  undefined,
-                                                  false,
                                                   undefined,
                                                   undefined,
                                                   params,
@@ -3071,6 +3069,123 @@ static napi_value CreateContextifyCjsLoaderResult(napi_env env,
   return out;
 }
 
+// Extracts the bytes of any ArrayBufferView (typed array or DataView) —
+// Node's vm cachedData accepts every view flavor over the same buffer.
+static bool GetTypedArrayBytes(napi_env env, napi_value value, const uint8_t** data_out, size_t* len_out) {
+  *data_out = nullptr;
+  *len_out = 0;
+  if (value == nullptr) return false;
+
+  bool is_typedarray = false;
+  if (napi_is_typedarray(env, value, &is_typedarray) == napi_ok && is_typedarray) {
+    napi_typedarray_type type = napi_uint8_array;
+    size_t length = 0;
+    void* data = nullptr;
+    if (napi_get_typedarray_info(env, value, &type, &length, &data, nullptr, nullptr) != napi_ok ||
+        data == nullptr) {
+      return false;
+    }
+    size_t element_size = 1;
+    switch (type) {
+      case napi_int8_array:
+      case napi_uint8_array:
+      case napi_uint8_clamped_array:
+        element_size = 1;
+        break;
+      case napi_int16_array:
+      case napi_uint16_array:
+      case napi_float16_array:
+        element_size = 2;
+        break;
+      case napi_int32_array:
+      case napi_uint32_array:
+      case napi_float32_array:
+        element_size = 4;
+        break;
+      case napi_float64_array:
+      case napi_bigint64_array:
+      case napi_biguint64_array:
+        element_size = 8;
+        break;
+      default:
+        return false;
+    }
+    *data_out = static_cast<const uint8_t*>(data);
+    *len_out = length * element_size;
+    return true;
+  }
+
+  bool is_dataview = false;
+  if (napi_is_dataview(env, value, &is_dataview) == napi_ok && is_dataview) {
+    size_t byte_length = 0;
+    void* data = nullptr;
+    if (napi_get_dataview_info(env, value, &byte_length, &data, nullptr, nullptr) != napi_ok ||
+        data == nullptr) {
+      return false;
+    }
+    *data_out = static_cast<const uint8_t*>(data);
+    *len_out = byte_length;
+    return true;
+  }
+  return false;
+}
+
+// vm APIs promise node Buffers for cachedData; bytecode_serialize guarantees
+// only a Uint8Array (engine-dependent). Wrap via Buffer.from when needed.
+static napi_value EnsureNodeBuffer(napi_env env, napi_value view) {
+  if (view == nullptr) return nullptr;
+  napi_value global = nullptr;
+  napi_value buffer_ctor = nullptr;
+  if (napi_get_global(env, &global) != napi_ok || global == nullptr ||
+      napi_get_named_property(env, global, "Buffer", &buffer_ctor) != napi_ok ||
+      buffer_ctor == nullptr) {
+    return view;
+  }
+  bool is_buffer = false;
+  if (napi_instanceof(env, view, buffer_ctor, &is_buffer) == napi_ok && is_buffer) {
+    return view;
+  }
+  napi_value from_fn = nullptr;
+  napi_value wrapped = nullptr;
+  if (napi_get_named_property(env, buffer_ctor, "from", &from_fn) != napi_ok || from_fn == nullptr ||
+      napi_call_function(env, buffer_ctor, from_fn, 1, &view, &wrapped) != napi_ok ||
+      wrapped == nullptr) {
+    return view;
+  }
+  return wrapped;
+}
+
+// Compiles script text and returns its serialized code cache (replaces the
+// removed unofficial_napi_contextify_create_cached_data). Leaves the compile
+// exception pending on syntax errors.
+static bool CreateScriptCachedDataBuffer(napi_env env,
+                                         napi_value code,
+                                         napi_value filename,
+                                         int32_t line_offset,
+                                         int32_t column_offset,
+                                         napi_value* buffer_out) {
+  *buffer_out = nullptr;
+  void* bytecode = nullptr;
+  if (unofficial_napi_bytecode_compile(env,
+                                       code,
+                                       filename,
+                                       unofficial_napi_bytecode_shape_script,
+                                       nullptr,
+                                       nullptr,
+                                       line_offset,
+                                       column_offset,
+                                       &bytecode,
+                                       nullptr) != napi_ok ||
+      bytecode == nullptr) {
+    return false;
+  }
+  const napi_status status = unofficial_napi_bytecode_serialize(env, bytecode, buffer_out);
+  (void)unofficial_napi_bytecode_release(env, bytecode);
+  if (status != napi_ok || *buffer_out == nullptr) return false;
+  *buffer_out = EnsureNodeBuffer(env, *buffer_out);
+  return *buffer_out != nullptr;
+}
+
 static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callback_info info) {
   size_t argc = 8;
   napi_value argv[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
@@ -3117,42 +3232,79 @@ static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callbac
     SetHostDefinedOptionSymbol(env, this_arg, host_defined_option_id);
   }
 
-  // Match Node's constructor-time syntax validation behavior.
-  napi_value precompiled_cache = nullptr;
-  if (unofficial_napi_contextify_create_cached_data(env,
-                                                    code,
-                                                    filename,
-                                                    line_offset,
-                                                    column_offset,
-                                                    host_defined_option_id,
-                                                    &precompiled_cache) != napi_ok) {
-    return nullptr;
-  }
-
   const bool has_cached_data_arg =
       argc >= 5 && argv[4] != nullptr && !IsUndefinedValue(env, argv[4]);
-  if (has_cached_data_arg) {
-    napi_value rejected = nullptr;
-    napi_get_boolean(env, false, &rejected);
-    if (rejected != nullptr) {
-      napi_set_named_property(env, this_arg, "cachedDataRejected", rejected);
-    }
-  }
-
   bool produce_cached_data = false;
   if (argc >= 6 && argv[5] != nullptr) {
     napi_get_value_bool(env, argv[5], &produce_cached_data);
   }
+
+  // Validate user cachedData (and report rejection honestly), then compile —
+  // which doubles as Node's constructor-time syntax validation.
+  bool cached_data_rejected = false;
+  void* script_bytecode = nullptr;
+  if (has_cached_data_arg) {
+    const uint8_t* bytes = nullptr;
+    size_t length = 0;
+    if (GetTypedArrayBytes(env, argv[4], &bytes, &length) && length > 0) {
+      bool rejected = false;
+      if (unofficial_napi_bytecode_deserialize(env,
+                                               bytes,
+                                               length,
+                                               code,
+                                               filename,
+                                               unofficial_napi_bytecode_shape_script,
+                                               nullptr,
+                                               host_defined_option_id,
+                                               &script_bytecode,
+                                               &rejected) == napi_ok) {
+        cached_data_rejected = rejected;
+      } else {
+        cached_data_rejected = true;
+      }
+    } else {
+      cached_data_rejected = true;
+    }
+  }
+  if (script_bytecode == nullptr) {
+    if (unofficial_napi_bytecode_compile(env,
+                                         code,
+                                         filename,
+                                         unofficial_napi_bytecode_shape_script,
+                                         nullptr,
+                                         host_defined_option_id,
+                                         line_offset,
+                                         column_offset,
+                                         &script_bytecode,
+                                         nullptr) != napi_ok ||
+        script_bytecode == nullptr) {
+      return nullptr;  // Preserve the syntax error.
+    }
+  }
+
+  if (has_cached_data_arg) {
+    napi_value rejected = nullptr;
+    napi_get_boolean(env, cached_data_rejected, &rejected);
+    if (rejected != nullptr) {
+      napi_set_named_property(env, this_arg, "cachedDataRejected", rejected);
+    }
+  }
   if (produce_cached_data) {
+    napi_value cache_buffer = nullptr;
+    const bool produced_ok =
+        unofficial_napi_bytecode_serialize(env, script_bytecode, &cache_buffer) == napi_ok &&
+        cache_buffer != nullptr;
+    if (produced_ok) cache_buffer = EnsureNodeBuffer(env, cache_buffer);
     napi_value produced = nullptr;
-    napi_get_boolean(env, true, &produced);
+    napi_get_boolean(env, produced_ok, &produced);
     if (produced != nullptr) {
       napi_set_named_property(env, this_arg, "cachedDataProduced", produced);
     }
-    if (precompiled_cache != nullptr) {
-      napi_set_named_property(env, this_arg, "cachedData", precompiled_cache);
+    if (produced_ok) {
+      napi_set_named_property(env, this_arg, "cachedData", cache_buffer);
     }
   }
+  (void)unofficial_napi_bytecode_release(env, script_bytecode);
   return this_arg;
 }
 
@@ -3208,9 +3360,10 @@ static napi_value ContextifyScriptRunInContextCallback(napi_env env, napi_callba
   }
 
   napi_value result = nullptr;
+  const unofficial_napi_js_source run_source{code_value, nullptr};
   const napi_status st = unofficial_napi_contextify_run_script(env,
                                                                sandbox,
-                                                               code_value,
+                                                               &run_source,
                                                                filename_value,
                                                                line_offset,
                                                                column_offset,
@@ -3293,15 +3446,9 @@ static napi_value ContextifyScriptCreateCachedDataCallback(napi_env env, napi_ca
     napi_get_value_int32(env, column_offset_value, &column_offset);
   }
 
+  (void)host_defined_option_id;
   napi_value out = nullptr;
-  if (unofficial_napi_contextify_create_cached_data(env,
-                                                    code_value,
-                                                    filename_value,
-                                                    line_offset,
-                                                    column_offset,
-                                                    host_defined_option_id,
-                                                    &out) != napi_ok ||
-      out == nullptr) {
+  if (!CreateScriptCachedDataBuffer(env, code_value, filename_value, line_offset, column_offset, &out)) {
     return nullptr;
   }
   return out;
@@ -3524,22 +3671,91 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
     napi_get_undefined(env, &host_defined_option_id);
   }
 
+  // vm.compileFunction cache handling now lives here: user cachedData is
+  // validated via bytecode_deserialize (honest rejected flag), production via
+  // an up-front eager bytecode_compile whose artifact the compile consumes.
+  const bool has_cached_data = cached_data != nullptr && !IsUndefinedValue(env, cached_data);
+  void* fn_bytecode = nullptr;
+  bool cached_data_rejected = false;
+  if (has_cached_data) {
+    const uint8_t* bytes = nullptr;
+    size_t length = 0;
+    if (GetTypedArrayBytes(env, cached_data, &bytes, &length) && length > 0) {
+      bool rejected = false;
+      if (unofficial_napi_bytecode_deserialize(env,
+                                               bytes,
+                                               length,
+                                               code,
+                                               filename,
+                                               unofficial_napi_bytecode_shape_cjs_function,
+                                               params,
+                                               host_defined_option_id,
+                                               &fn_bytecode,
+                                               &rejected) == napi_ok) {
+        cached_data_rejected = rejected;
+      } else {
+        cached_data_rejected = true;
+      }
+    } else {
+      cached_data_rejected = true;
+    }
+  } else if (produce_cached_data) {
+    if (unofficial_napi_bytecode_compile(env,
+                                         code,
+                                         filename,
+                                         unofficial_napi_bytecode_shape_cjs_function,
+                                         params,
+                                         host_defined_option_id,
+                                         line_offset,
+                                         column_offset,
+                                         &fn_bytecode,
+                                         nullptr) != napi_ok ||
+        fn_bytecode == nullptr) {
+      return nullptr;  // Preserve the compile error.
+    }
+  }
+
+  const unofficial_napi_js_source compile_source{fn_bytecode != nullptr ? nullptr : code, fn_bytecode};
   napi_value out = nullptr;
-  if (unofficial_napi_contextify_compile_function(env,
-                                                  code,
+  const napi_status compile_status =
+      unofficial_napi_contextify_compile_function(env,
+                                                  &compile_source,
                                                   filename,
                                                   line_offset,
                                                   column_offset,
-                                                  cached_data,
-                                                  produce_cached_data,
                                                   parsing_context,
                                                   context_extensions,
                                                   params,
                                                   host_defined_option_id,
-                                                  &out) != napi_ok ||
-      out == nullptr) {
+                                                  &out);
+  if (compile_status != napi_ok || out == nullptr) {
+    if (fn_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, fn_bytecode);
     return nullptr;
   }
+
+  if (has_cached_data) {
+    napi_value rejected = nullptr;
+    napi_get_boolean(env, cached_data_rejected, &rejected);
+    if (rejected != nullptr) {
+      napi_set_named_property(env, out, "cachedDataRejected", rejected);
+    }
+  }
+  if (produce_cached_data && fn_bytecode != nullptr) {
+    napi_value cache_buffer = nullptr;
+    const bool produced_ok =
+        unofficial_napi_bytecode_serialize(env, fn_bytecode, &cache_buffer) == napi_ok &&
+        cache_buffer != nullptr;
+    if (produced_ok) cache_buffer = EnsureNodeBuffer(env, cache_buffer);
+    napi_value produced = nullptr;
+    napi_get_boolean(env, produced_ok, &produced);
+    if (produced != nullptr) {
+      napi_set_named_property(env, out, "cachedDataProduced", produced);
+    }
+    if (produced_ok) {
+      napi_set_named_property(env, out, "cachedData", cache_buffer);
+    }
+  }
+  if (fn_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, fn_bytecode);
   return out;
 }
 
@@ -3576,83 +3792,102 @@ static napi_value ContextifyCompileFunctionForCJSLoaderCallback(napi_env env, na
   napi_value host_defined_option_id = GetPerIsolateSymbolByName(env, "vm_dynamic_import_default_internal");
   if (host_defined_option_id == nullptr) host_defined_option_id = undefined;
 
-  // Bytecode sidecar cache: consume <filename>.v8b/.qjsb when it matches the
-  // exact source about to be compiled, otherwise produce it after compiling
-  // (write-on-first-run). Only real files participate; [eval]/[stdin]/REPL
-  // sources have no sidecar identity.
-  napi_value cached_data_value = undefined;
-  bool consumed_sidecar = false;
-  bool produce_sidecar = false;
+  // Bytecode sidecar cache: deserialize <filename>.v8b/.qjsb when it matches
+  // the exact source about to be compiled, otherwise compile to a fresh
+  // bytecode handle and write the sidecar (write-on-first-run). Only real
+  // files participate; [eval]/[stdin]/REPL sources have no sidecar identity.
+  void* cjs_bytecode = nullptr;
   std::string sidecar_source_path;
   std::string sidecar_source_utf8;
+  bool sidecar_eligible = false;
   if (edge_bytecode_cache::Enabled()) {
     std::string filename_utf8 = ValueToUtf8(env, filename);
     fs::path filename_path(filename_utf8);
     if (filename_path.is_absolute() && PathExistsRegularFile(filename_path)) {
+      sidecar_eligible = true;
       sidecar_source_path = std::move(filename_utf8);
       sidecar_source_utf8 = ValueToUtf8(env, code);
       std::vector<uint8_t> payload;
-      if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8, &payload)) {
-        napi_value arraybuffer = nullptr;
-        void* arraybuffer_data = nullptr;
-        if (napi_create_arraybuffer(env, payload.size(), &arraybuffer_data, &arraybuffer) == napi_ok &&
-            arraybuffer_data != nullptr) {
-          std::memcpy(arraybuffer_data, payload.data(), payload.size());
-          napi_value payload_view = nullptr;
-          if (napi_create_typedarray(env, napi_uint8_array, payload.size(), arraybuffer, 0, &payload_view) ==
-                  napi_ok &&
-              payload_view != nullptr) {
-            cached_data_value = payload_view;
-            consumed_sidecar = true;
+      if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8,
+                                           edge_bytecode_cache::kFlagCjsFunctionV1, &payload)) {
+        bool rejected = false;
+        if (unofficial_napi_bytecode_deserialize(env,
+                                                 payload.data(),
+                                                 payload.size(),
+                                                 code,
+                                                 filename,
+                                                 unofficial_napi_bytecode_shape_cjs_function,
+                                                 params,
+                                                 host_defined_option_id,
+                                                 &cjs_bytecode,
+                                                 &rejected) != napi_ok ||
+            rejected || cjs_bytecode == nullptr) {
+          // Engine refused bytecode our header considered valid (e.g. engine
+          // flag drift); drop it so the next run rewrites instead of
+          // re-rejecting forever.
+          edge_bytecode_cache::RemoveSidecar(sidecar_source_path);
+          cjs_bytecode = nullptr;
+        }
+      }
+      if (cjs_bytecode == nullptr) {
+        // No valid sidecar: compile once (eagerly) and persist the bytes; the
+        // compile below consumes the same handle, so the source is parsed
+        // exactly once.
+        bool can_parse_as_module = false;
+        const napi_status produce_status =
+            unofficial_napi_bytecode_compile(env,
+                                             code,
+                                             filename,
+                                             unofficial_napi_bytecode_shape_cjs_function,
+                                             params,
+                                             host_defined_option_id,
+                                             0,
+                                             0,
+                                             &cjs_bytecode,
+                                             &can_parse_as_module);
+        if (produce_status != napi_ok || cjs_bytecode == nullptr) {
+          if (produce_status == napi_pending_exception && should_detect_module && can_parse_as_module) {
+            bool has_pending = false;
+            napi_value ignored = nullptr;
+            if (napi_is_exception_pending(env, &has_pending) == napi_ok && has_pending) {
+              (void)napi_get_and_clear_last_exception(env, &ignored);
+            }
+            return CreateContextifyCjsLoaderResult(env, nullptr, true);
+          }
+          return nullptr;  // Preserve the compile error.
+        }
+        napi_value cache_buffer = nullptr;
+        if (unofficial_napi_bytecode_serialize(env, cjs_bytecode, &cache_buffer) == napi_ok &&
+            cache_buffer != nullptr) {
+          const uint8_t* bytes = nullptr;
+          size_t length = 0;
+          if (GetTypedArrayBytes(env, cache_buffer, &bytes, &length) && length > 0) {
+            edge_bytecode_cache::WriteSidecar(sidecar_source_path,
+                                              sidecar_source_utf8,
+                                              edge_bytecode_cache::kFlagCjsFunctionV1,
+                                              bytes,
+                                              length);
           }
         }
-      } else {
-        produce_sidecar = true;
       }
     }
   }
+  (void)sidecar_eligible;
 
+  const unofficial_napi_js_source compile_source{cjs_bytecode != nullptr ? nullptr : code, cjs_bytecode};
   napi_value compile_result = nullptr;
   napi_status status = unofficial_napi_contextify_compile_function(env,
-                                                                   code,
+                                                                   &compile_source,
                                                                    filename,
                                                                    0,
                                                                    0,
-                                                                   cached_data_value,
-                                                                   produce_sidecar,
                                                                    undefined,
                                                                    undefined,
                                                                    params,
                                                                    host_defined_option_id,
                                                                    &compile_result);
+  if (cjs_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, cjs_bytecode);
   if (status == napi_ok && compile_result != nullptr) {
-    if (consumed_sidecar) {
-      napi_value rejected_value = GetNamedPropertyOrUndefined(env, compile_result, "cachedDataRejected");
-      bool rejected = false;
-      if (rejected_value != nullptr && napi_get_value_bool(env, rejected_value, &rejected) == napi_ok &&
-          rejected) {
-        // Engine refused bytecode our header considered valid (e.g. engine
-        // flag drift); drop it so the next run rewrites instead of re-rejecting.
-        edge_bytecode_cache::RemoveSidecar(sidecar_source_path);
-      }
-    } else if (produce_sidecar) {
-      napi_value produced_value = GetNamedPropertyOrUndefined(env, compile_result, "cachedData");
-      bool is_typedarray = false;
-      if (produced_value != nullptr && napi_is_typedarray(env, produced_value, &is_typedarray) == napi_ok &&
-          is_typedarray) {
-        napi_typedarray_type type = napi_uint8_array;
-        size_t length = 0;
-        void* data = nullptr;
-        if (napi_get_typedarray_info(env, produced_value, &type, &length, &data, nullptr, nullptr) ==
-                napi_ok &&
-            type == napi_uint8_array && data != nullptr && length > 0) {
-          edge_bytecode_cache::WriteSidecar(sidecar_source_path,
-                                            sidecar_source_utf8,
-                                            static_cast<const uint8_t*>(data),
-                                            length);
-        }
-      }
-    }
     return CreateContextifyCjsLoaderResult(env, compile_result, false);
   }
   if (status != napi_pending_exception || !should_detect_module) {

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -3254,62 +3254,6 @@ static napi_value EnsureNodeBuffer(napi_env env, napi_value view) {
   return wrapped;
 }
 
-// Wraps raw bytecode_serialize output into a user-facing vm cachedData
-// Buffer: on QuickJS an Edge-owned source-hash prefix is prepended (the
-// engine cannot validate source identity itself); on V8 this is just
-// EnsureNodeBuffer (CachedData self-validates, bytes stay Node-parity raw).
-static napi_value WrapVmCachedDataBuffer(napi_env env, napi_value source_text, napi_value raw_buffer) {
-  if (raw_buffer == nullptr) return nullptr;
-  if (!edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
-    return EnsureNodeBuffer(env, raw_buffer);
-  }
-  const uint8_t* bytes = nullptr;
-  size_t length = 0;
-  if (!GetTypedArrayBytes(env, raw_buffer, &bytes, &length) || length == 0) {
-    return EnsureNodeBuffer(env, raw_buffer);
-  }
-  const std::string source_utf8 = ValueToUtf8(env, source_text);
-  const std::vector<uint8_t> wrapped = edge_bytecode_cache::WrapVmCachedData(
-      edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size()), bytes, length);
-  napi_value out = nullptr;
-  if (napi_create_buffer_copy(env, wrapped.size(), wrapped.data(), nullptr, &out) != napi_ok ||
-      out == nullptr) {
-    return nullptr;
-  }
-  return out;
-}
-
-// Validates and strips the vm cachedData wrapper from user-supplied bytes.
-// False means the bytes were not produced from this exact source (or carry no
-// valid wrapper) — callers report cachedDataRejected without touching the
-// engine. Pass-through on V8, where the engine validates.
-static bool UnwrapVmCachedDataBytes(napi_env env,
-                                    napi_value source_text,
-                                    const uint8_t* bytes,
-                                    size_t length,
-                                    const uint8_t** payload_out,
-                                    size_t* payload_size_out) {
-  *payload_out = nullptr;
-  *payload_size_out = 0;
-  if (bytes == nullptr || length == 0) return false;
-  if (!edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
-    *payload_out = bytes;
-    *payload_size_out = length;
-    return true;
-  }
-  const std::string source_utf8 = ValueToUtf8(env, source_text);
-  size_t offset = 0;
-  size_t size = 0;
-  if (!edge_bytecode_cache::UnwrapVmCachedData(
-          edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size()), bytes, length,
-          &offset, &size)) {
-    return false;
-  }
-  *payload_out = bytes + offset;
-  *payload_size_out = size;
-  return true;
-}
-
 // Compiles script text and returns its serialized code cache (replaces the
 // removed unofficial_napi_contextify_create_cached_data). Leaves the compile
 // exception pending on syntax errors.
@@ -3337,7 +3281,9 @@ static bool CreateScriptCachedDataBuffer(napi_env env,
   const napi_status status = unofficial_napi_bytecode_serialize(env, bytecode, buffer_out);
   (void)unofficial_napi_bytecode_release(env, bytecode);
   if (status != napi_ok || *buffer_out == nullptr) return false;
-  *buffer_out = WrapVmCachedDataBuffer(env, code, *buffer_out);
+  // The provider's serialized bytes self-validate (V8 CachedData / QuickJS
+  // QJSB header); just hand back a Node Buffer.
+  *buffer_out = EnsureNodeBuffer(env, *buffer_out);
   return *buffer_out != nullptr;
 }
 
@@ -3401,14 +3347,13 @@ static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callbac
   if (has_cached_data_arg) {
     const uint8_t* bytes = nullptr;
     size_t length = 0;
-    const uint8_t* payload = nullptr;
-    size_t payload_size = 0;
-    if (GetTypedArrayBytes(env, argv[4], &bytes, &length) && length > 0 &&
-        UnwrapVmCachedDataBytes(env, code, bytes, length, &payload, &payload_size)) {
+    // The provider validates source/shape/integrity itself (V8 CachedData /
+    // QuickJS QJSB header) and reports a mismatch via rejected_out.
+    if (GetTypedArrayBytes(env, argv[4], &bytes, &length) && length > 0) {
       bool rejected = false;
       if (unofficial_napi_bytecode_deserialize(env,
-                                               payload,
-                                               payload_size,
+                                               bytes,
+                                               length,
                                                code,
                                                filename,
                                                unofficial_napi_bytecode_shape_script,
@@ -3449,11 +3394,17 @@ static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callbac
   }
   if (produce_cached_data) {
     napi_value cache_buffer = nullptr;
+    const uint8_t* produced_bytes = nullptr;
+    size_t produced_len = 0;
+    // Only report cachedDataProduced when the engine actually emitted bytes
+    // (an empty buffer round-trips as "rejected", so reporting it as produced
+    // would be misleading).
     bool produced_ok =
         unofficial_napi_bytecode_serialize(env, script_bytecode, &cache_buffer) == napi_ok &&
-        cache_buffer != nullptr;
+        cache_buffer != nullptr &&
+        GetTypedArrayBytes(env, cache_buffer, &produced_bytes, &produced_len) && produced_len > 0;
     if (produced_ok) {
-      cache_buffer = WrapVmCachedDataBuffer(env, code, cache_buffer);
+      cache_buffer = EnsureNodeBuffer(env, cache_buffer);
       produced_ok = cache_buffer != nullptr;
     }
     napi_value produced = nullptr;
@@ -3841,14 +3792,13 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
   if (has_cached_data) {
     const uint8_t* bytes = nullptr;
     size_t length = 0;
-    const uint8_t* payload = nullptr;
-    size_t payload_size = 0;
-    if (GetTypedArrayBytes(env, cached_data, &bytes, &length) && length > 0 &&
-        UnwrapVmCachedDataBytes(env, code, bytes, length, &payload, &payload_size)) {
+    // The provider validates source/shape/params/integrity itself (V8
+    // CachedData / QuickJS QJSB header) and reports a mismatch via rejected_out.
+    if (GetTypedArrayBytes(env, cached_data, &bytes, &length) && length > 0) {
       bool rejected = false;
       if (unofficial_napi_bytecode_deserialize(env,
-                                               payload,
-                                               payload_size,
+                                               bytes,
+                                               length,
                                                code,
                                                filename,
                                                unofficial_napi_bytecode_shape_cjs_function,
@@ -3863,7 +3813,11 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
     } else {
       cached_data_rejected = true;
     }
-  } else if (produce_cached_data) {
+  }
+  // Produce a fresh cache when asked — including after a rejected cachedData,
+  // so a caller refreshing a stale cache (cachedData + produceCachedData) gets
+  // a new buffer instead of silently nothing.
+  if (fn_bytecode == nullptr && produce_cached_data) {
     if (unofficial_napi_bytecode_compile(env,
                                          code,
                                          filename,
@@ -3906,11 +3860,14 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
   }
   if (produce_cached_data && fn_bytecode != nullptr) {
     napi_value cache_buffer = nullptr;
+    const uint8_t* produced_bytes = nullptr;
+    size_t produced_len = 0;
     bool produced_ok =
         unofficial_napi_bytecode_serialize(env, fn_bytecode, &cache_buffer) == napi_ok &&
-        cache_buffer != nullptr;
+        cache_buffer != nullptr &&
+        GetTypedArrayBytes(env, cache_buffer, &produced_bytes, &produced_len) && produced_len > 0;
     if (produced_ok) {
-      cache_buffer = WrapVmCachedDataBuffer(env, code, cache_buffer);
+      cache_buffer = EnsureNodeBuffer(env, cache_buffer);
       produced_ok = cache_buffer != nullptr;
     }
     napi_value produced = nullptr;

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -3254,6 +3254,62 @@ static napi_value EnsureNodeBuffer(napi_env env, napi_value view) {
   return wrapped;
 }
 
+// Wraps raw bytecode_serialize output into a user-facing vm cachedData
+// Buffer: on QuickJS an Edge-owned source-hash prefix is prepended (the
+// engine cannot validate source identity itself); on V8 this is just
+// EnsureNodeBuffer (CachedData self-validates, bytes stay Node-parity raw).
+static napi_value WrapVmCachedDataBuffer(napi_env env, napi_value source_text, napi_value raw_buffer) {
+  if (raw_buffer == nullptr) return nullptr;
+  if (!edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
+    return EnsureNodeBuffer(env, raw_buffer);
+  }
+  const uint8_t* bytes = nullptr;
+  size_t length = 0;
+  if (!GetTypedArrayBytes(env, raw_buffer, &bytes, &length) || length == 0) {
+    return EnsureNodeBuffer(env, raw_buffer);
+  }
+  const std::string source_utf8 = ValueToUtf8(env, source_text);
+  const std::vector<uint8_t> wrapped = edge_bytecode_cache::WrapVmCachedData(
+      edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size()), bytes, length);
+  napi_value out = nullptr;
+  if (napi_create_buffer_copy(env, wrapped.size(), wrapped.data(), nullptr, &out) != napi_ok ||
+      out == nullptr) {
+    return nullptr;
+  }
+  return out;
+}
+
+// Validates and strips the vm cachedData wrapper from user-supplied bytes.
+// False means the bytes were not produced from this exact source (or carry no
+// valid wrapper) — callers report cachedDataRejected without touching the
+// engine. Pass-through on V8, where the engine validates.
+static bool UnwrapVmCachedDataBytes(napi_env env,
+                                    napi_value source_text,
+                                    const uint8_t* bytes,
+                                    size_t length,
+                                    const uint8_t** payload_out,
+                                    size_t* payload_size_out) {
+  *payload_out = nullptr;
+  *payload_size_out = 0;
+  if (bytes == nullptr || length == 0) return false;
+  if (!edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
+    *payload_out = bytes;
+    *payload_size_out = length;
+    return true;
+  }
+  const std::string source_utf8 = ValueToUtf8(env, source_text);
+  size_t offset = 0;
+  size_t size = 0;
+  if (!edge_bytecode_cache::UnwrapVmCachedData(
+          edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size()), bytes, length,
+          &offset, &size)) {
+    return false;
+  }
+  *payload_out = bytes + offset;
+  *payload_size_out = size;
+  return true;
+}
+
 // Compiles script text and returns its serialized code cache (replaces the
 // removed unofficial_napi_contextify_create_cached_data). Leaves the compile
 // exception pending on syntax errors.
@@ -3281,7 +3337,7 @@ static bool CreateScriptCachedDataBuffer(napi_env env,
   const napi_status status = unofficial_napi_bytecode_serialize(env, bytecode, buffer_out);
   (void)unofficial_napi_bytecode_release(env, bytecode);
   if (status != napi_ok || *buffer_out == nullptr) return false;
-  *buffer_out = EnsureNodeBuffer(env, *buffer_out);
+  *buffer_out = WrapVmCachedDataBuffer(env, code, *buffer_out);
   return *buffer_out != nullptr;
 }
 
@@ -3345,11 +3401,14 @@ static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callbac
   if (has_cached_data_arg) {
     const uint8_t* bytes = nullptr;
     size_t length = 0;
-    if (GetTypedArrayBytes(env, argv[4], &bytes, &length) && length > 0) {
+    const uint8_t* payload = nullptr;
+    size_t payload_size = 0;
+    if (GetTypedArrayBytes(env, argv[4], &bytes, &length) && length > 0 &&
+        UnwrapVmCachedDataBytes(env, code, bytes, length, &payload, &payload_size)) {
       bool rejected = false;
       if (unofficial_napi_bytecode_deserialize(env,
-                                               bytes,
-                                               length,
+                                               payload,
+                                               payload_size,
                                                code,
                                                filename,
                                                unofficial_napi_bytecode_shape_script,
@@ -3390,10 +3449,13 @@ static napi_value ContextifyScriptConstructorCallback(napi_env env, napi_callbac
   }
   if (produce_cached_data) {
     napi_value cache_buffer = nullptr;
-    const bool produced_ok =
+    bool produced_ok =
         unofficial_napi_bytecode_serialize(env, script_bytecode, &cache_buffer) == napi_ok &&
         cache_buffer != nullptr;
-    if (produced_ok) cache_buffer = EnsureNodeBuffer(env, cache_buffer);
+    if (produced_ok) {
+      cache_buffer = WrapVmCachedDataBuffer(env, code, cache_buffer);
+      produced_ok = cache_buffer != nullptr;
+    }
     napi_value produced = nullptr;
     napi_get_boolean(env, produced_ok, &produced);
     if (produced != nullptr) {
@@ -3779,11 +3841,14 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
   if (has_cached_data) {
     const uint8_t* bytes = nullptr;
     size_t length = 0;
-    if (GetTypedArrayBytes(env, cached_data, &bytes, &length) && length > 0) {
+    const uint8_t* payload = nullptr;
+    size_t payload_size = 0;
+    if (GetTypedArrayBytes(env, cached_data, &bytes, &length) && length > 0 &&
+        UnwrapVmCachedDataBytes(env, code, bytes, length, &payload, &payload_size)) {
       bool rejected = false;
       if (unofficial_napi_bytecode_deserialize(env,
-                                               bytes,
-                                               length,
+                                               payload,
+                                               payload_size,
                                                code,
                                                filename,
                                                unofficial_napi_bytecode_shape_cjs_function,
@@ -3841,10 +3906,13 @@ static napi_value ContextifyCompileFunctionCallback(napi_env env, napi_callback_
   }
   if (produce_cached_data && fn_bytecode != nullptr) {
     napi_value cache_buffer = nullptr;
-    const bool produced_ok =
+    bool produced_ok =
         unofficial_napi_bytecode_serialize(env, fn_bytecode, &cache_buffer) == napi_ok &&
         cache_buffer != nullptr;
-    if (produced_ok) cache_buffer = EnsureNodeBuffer(env, cache_buffer);
+    if (produced_ok) {
+      cache_buffer = WrapVmCachedDataBuffer(env, code, cache_buffer);
+      produced_ok = cache_buffer != nullptr;
+    }
     napi_value produced = nullptr;
     napi_get_boolean(env, produced_ok, &produced);
     if (produced != nullptr) {

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -1,5 +1,6 @@
 #include "edge_module_loader.h"
 #include "edge_buffer.h"
+#include "edge_builtin_bytecode.h"
 #include "edge_bytecode_cache.h"
 #include "edge_cares_wrap.h"
 #include "edge_crypto.h"
@@ -1034,6 +1035,76 @@ static NativeBuiltinExecutionKind GetNativeBuiltinExecutionKind(const std::strin
   return NativeBuiltinExecutionKind::kUnsupported;
 }
 
+static bool GetTypedArrayBytes(napi_env env, napi_value value, const uint8_t** data_out, size_t* len_out);
+
+// Builtins consolidated bytecode cache: returns a bytecode handle for the
+// builtin either deserialized from the per-binary cache file or compiled
+// eagerly and recorded for the teardown flush. nullptr on any failure with no
+// pending exception, so callers fall back to the plain-text compile path and
+// its exact error shaping.
+static void* AcquireBuiltinBytecode(napi_env env,
+                                    edge_builtin_bytecode::Kind kind,
+                                    const std::string& id,
+                                    const std::string& source,
+                                    napi_value code,
+                                    napi_value filename,
+                                    int32_t shape,
+                                    napi_value params_or_undefined,
+                                    napi_value host_defined_option_id) {
+  if (!edge_bytecode_cache::Enabled()) return nullptr;
+
+  edge_builtin_bytecode::PayloadView view;
+  if (edge_builtin_bytecode::TryGet(kind, id, source, &view)) {
+    void* handle = nullptr;
+    bool rejected = false;
+    if (unofficial_napi_bytecode_deserialize(env,
+                                             view.data,
+                                             view.size,
+                                             code,
+                                             filename,
+                                             shape,
+                                             params_or_undefined,
+                                             host_defined_option_id,
+                                             &handle,
+                                             &rejected) == napi_ok &&
+        !rejected && handle != nullptr) {
+      return handle;
+    }
+    if (handle != nullptr) (void)unofficial_napi_bytecode_release(env, handle);
+    // Engine refused bytes our header considered valid (e.g. engine flag
+    // drift); recompile below so the flush rewrites the entry.
+  }
+
+  void* handle = nullptr;
+  if (unofficial_napi_bytecode_compile(env,
+                                       code,
+                                       filename,
+                                       shape,
+                                       params_or_undefined,
+                                       host_defined_option_id,
+                                       0,
+                                       0,
+                                       &handle,
+                                       nullptr) != napi_ok ||
+      handle == nullptr) {
+    bool has_pending = false;
+    napi_value ignored = nullptr;
+    if (napi_is_exception_pending(env, &has_pending) == napi_ok && has_pending) {
+      (void)napi_get_and_clear_last_exception(env, &ignored);
+    }
+    return nullptr;
+  }
+  napi_value buffer = nullptr;
+  if (unofficial_napi_bytecode_serialize(env, handle, &buffer) == napi_ok && buffer != nullptr) {
+    const uint8_t* bytes = nullptr;
+    size_t length = 0;
+    if (GetTypedArrayBytes(env, buffer, &bytes, &length) && length > 0) {
+      edge_builtin_bytecode::Record(kind, id, source, bytes, length);
+    }
+  }
+  return handle;
+}
+
 static const std::vector<std::string>& CollectRuntimeBuiltinIds() {
   static const std::vector<std::string> ids = []() {
     std::vector<std::string> out = builtin_catalog::AllBuiltinIds();
@@ -1172,7 +1243,9 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
            param != nullptr &&
            napi_set_element(env, params, index, param) == napi_ok;
   };
+  edge_builtin_bytecode::Kind bytecode_kind;
   if (id == "internal/bootstrap/realm") {
+    bytecode_kind = edge_builtin_bytecode::Kind::kFnBootstrapRealm;
     if (!set_param(0, "process") ||
         !set_param(1, "getLinkedBinding") ||
         !set_param(2, "getInternalBinding") ||
@@ -1180,6 +1253,7 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
       return nullptr;
     }
   } else if (IsPerContextBuiltinId(id)) {
+    bytecode_kind = edge_builtin_bytecode::Kind::kFnPerContext;
     if (!set_param(0, "exports") ||
         !set_param(1, "primordials") ||
         !set_param(2, "privateSymbols") ||
@@ -1187,6 +1261,7 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
       return nullptr;
     }
   } else if (id.rfind("internal/main/", 0) == 0 || id.rfind("internal/bootstrap/", 0) == 0) {
+    bytecode_kind = edge_builtin_bytecode::Kind::kFnBootstrapMain;
     if (!set_param(0, "process") ||
         !set_param(1, "require") ||
         !set_param(2, "internalBinding") ||
@@ -1194,6 +1269,7 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
       return nullptr;
     }
   } else {
+    bytecode_kind = edge_builtin_bytecode::Kind::kFnLazyBuiltin;
     if (!set_param(0, "exports") ||
         !set_param(1, "require") ||
         !set_param(2, "module") ||
@@ -1203,19 +1279,24 @@ static napi_value BuiltinsCompileFunctionCallback(napi_env env, napi_callback_in
       return nullptr;
     }
   }
+  void* builtin_bytecode =
+      AcquireBuiltinBytecode(env, bytecode_kind, id, source, code, filename,
+                             unofficial_napi_bytecode_shape_cjs_function, params, undefined);
   napi_value compile_result = nullptr;
-  const unofficial_napi_js_source compile_source{code, nullptr};
-  if (unofficial_napi_contextify_compile_function(env,
-                                                  &compile_source,
-                                                  filename,
-                                                  0,
-                                                  0,
-                                                  undefined,
-                                                  undefined,
-                                                  params,
-                                                  undefined,
-                                                  &compile_result) != napi_ok ||
-      compile_result == nullptr) {
+  const unofficial_napi_js_source compile_source{builtin_bytecode != nullptr ? nullptr : code,
+                                                 builtin_bytecode};
+  const napi_status compile_status = unofficial_napi_contextify_compile_function(env,
+                                                                                 &compile_source,
+                                                                                 filename,
+                                                                                 0,
+                                                                                 0,
+                                                                                 undefined,
+                                                                                 undefined,
+                                                                                 params,
+                                                                                 undefined,
+                                                                                 &compile_result);
+  if (builtin_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, builtin_bytecode);
+  if (compile_status != napi_ok || compile_result == nullptr) {
     return nullptr;
   }
   napi_value compiled = nullptr;
@@ -1632,8 +1713,25 @@ static bool ExecuteBuiltinFromNative(napi_env env, ModuleLoaderState* state, con
     return ThrowNativeBuiltinExecutionError(env, id, "failed to create compile inputs");
   }
 
+  edge_builtin_bytecode::Kind bytecode_kind = edge_builtin_bytecode::Kind::kFnBootstrapMain;
+  switch (GetNativeBuiltinExecutionKind(id)) {
+    case NativeBuiltinExecutionKind::kPerContext:
+      bytecode_kind = edge_builtin_bytecode::Kind::kFnPerContext;
+      break;
+    case NativeBuiltinExecutionKind::kBootstrapRealm:
+      bytecode_kind = edge_builtin_bytecode::Kind::kFnBootstrapRealm;
+      break;
+    case NativeBuiltinExecutionKind::kBootstrapOrMain:
+    case NativeBuiltinExecutionKind::kUnsupported:
+      bytecode_kind = edge_builtin_bytecode::Kind::kFnBootstrapMain;
+      break;
+  }
+  void* builtin_bytecode =
+      AcquireBuiltinBytecode(env, bytecode_kind, id, source, code, filename,
+                             unofficial_napi_bytecode_shape_cjs_function, params, undefined);
   napi_value compile_result = nullptr;
-  const unofficial_napi_js_source compile_source{code, nullptr};
+  const unofficial_napi_js_source compile_source{builtin_bytecode != nullptr ? nullptr : code,
+                                                 builtin_bytecode};
   const napi_status compile_status =
       unofficial_napi_contextify_compile_function(env,
                                                   &compile_source,
@@ -1645,6 +1743,7 @@ static bool ExecuteBuiltinFromNative(napi_env env, ModuleLoaderState* state, con
                                                   params,
                                                   undefined,
                                                   &compile_result);
+  if (builtin_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, builtin_bytecode);
   if (compile_status != napi_ok ||
       compile_result == nullptr) {
     std::string message = "contextify compile failed";
@@ -3807,13 +3906,13 @@ static napi_value ContextifyCompileFunctionForCJSLoaderCallback(napi_env env, na
       sidecar_eligible = true;
       sidecar_source_path = std::move(filename_utf8);
       sidecar_source_utf8 = ValueToUtf8(env, code);
-      std::vector<uint8_t> payload;
+      edge_bytecode_cache::SidecarPayload payload;
       if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8,
                                            edge_bytecode_cache::kFlagCjsFunctionV1, &payload)) {
         bool rejected = false;
         if (unofficial_napi_bytecode_deserialize(env,
                                                  payload.data(),
-                                                 payload.size(),
+                                                 payload.payload_size,
                                                  code,
                                                  filename,
                                                  unofficial_napi_bytecode_shape_cjs_function,
@@ -5007,8 +5106,8 @@ bool EvaluateJsModule(napi_env env,
   // Node-aligned: compile the wrapper as a function, then call it from C++ with (internalBinding, primordials)
   // as arguments (realm->primordials() in Node). No JS expression like globalThis.primordials at call time.
   std::string builtin_id;
-  const bool is_per_context =
-      TryGetBuiltinIdFromResolvedPath(resolved_path, &builtin_id) && IsPerContextBuiltinId(builtin_id);
+  const bool is_builtin = TryGetBuiltinIdFromResolvedPath(resolved_path, &builtin_id);
+  const bool is_per_context = is_builtin && IsPerContextBuiltinId(builtin_id);
   const std::string wrapped_source = is_per_context
                                          ? "(function(primordials, privateSymbols, perIsolateSymbols) {"
                                            "return function(exports, require, module, __filename, __dirname) {\n" +
@@ -5024,8 +5123,53 @@ bool EvaluateJsModule(napi_env env,
     return ThrowLoaderError(env, "Failed to create wrapped module source");
   }
 
+  // Builtins consolidated bytecode cache (keyed by the full wrapped IIFE text,
+  // so wrapper drift self-invalidates). Non-builtin files keep the plain
+  // napi_run_script path untouched.
   napi_value outer_fn = nullptr;
-  if (napi_run_script(env, script_source, &outer_fn) != napi_ok || outer_fn == nullptr) {
+  if (is_builtin) {
+    napi_value undefined = nullptr;
+    napi_get_undefined(env, &undefined);
+    napi_value source_url_value = nullptr;
+    if (napi_create_string_utf8(env, source_url.c_str(), NAPI_AUTO_LENGTH, &source_url_value) == napi_ok &&
+        source_url_value != nullptr) {
+      const edge_builtin_bytecode::Kind bytecode_kind =
+          is_per_context ? edge_builtin_bytecode::Kind::kWrapperPerContext
+                         : edge_builtin_bytecode::Kind::kWrapperStandard;
+      void* wrapper_bytecode =
+          AcquireBuiltinBytecode(env, bytecode_kind, builtin_id, wrapped_source, script_source,
+                                 source_url_value, unofficial_napi_bytecode_shape_script,
+                                 undefined, undefined);
+      if (wrapper_bytecode != nullptr) {
+        const unofficial_napi_js_source js_source{nullptr, wrapper_bytecode};
+        const napi_status run_status =
+            unofficial_napi_contextify_run_script(env,
+                                                  nullptr,
+                                                  &js_source,
+                                                  source_url_value,
+                                                  0,
+                                                  0,
+                                                  -1,
+                                                  false,
+                                                  false,
+                                                  false,
+                                                  undefined,
+                                                  &outer_fn);
+        (void)unofficial_napi_bytecode_release(env, wrapper_bytecode);
+        if (run_status != napi_ok || outer_fn == nullptr) {
+          // Fall back to the plain path for exact error shaping.
+          outer_fn = nullptr;
+          bool has_pending = false;
+          napi_value ignored = nullptr;
+          if (napi_is_exception_pending(env, &has_pending) == napi_ok && has_pending) {
+            (void)napi_get_and_clear_last_exception(env, &ignored);
+          }
+        }
+      }
+    }
+  }
+  if (outer_fn == nullptr &&
+      (napi_run_script(env, script_source, &outer_fn) != napi_ok || outer_fn == nullptr)) {
     return false;  // Preserve JS exception.
   }
 

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -1,5 +1,6 @@
 #include "edge_module_loader.h"
 #include "edge_buffer.h"
+#include "edge_bytecode_cache.h"
 #include "edge_cares_wrap.h"
 #include "edge_crypto.h"
 #include "edge_env_loop.h"
@@ -3575,20 +3576,83 @@ static napi_value ContextifyCompileFunctionForCJSLoaderCallback(napi_env env, na
   napi_value host_defined_option_id = GetPerIsolateSymbolByName(env, "vm_dynamic_import_default_internal");
   if (host_defined_option_id == nullptr) host_defined_option_id = undefined;
 
+  // Bytecode sidecar cache: consume <filename>.v8b/.qjsb when it matches the
+  // exact source about to be compiled, otherwise produce it after compiling
+  // (write-on-first-run). Only real files participate; [eval]/[stdin]/REPL
+  // sources have no sidecar identity.
+  napi_value cached_data_value = undefined;
+  bool consumed_sidecar = false;
+  bool produce_sidecar = false;
+  std::string sidecar_source_path;
+  std::string sidecar_source_utf8;
+  if (edge_bytecode_cache::Enabled()) {
+    std::string filename_utf8 = ValueToUtf8(env, filename);
+    fs::path filename_path(filename_utf8);
+    if (filename_path.is_absolute() && PathExistsRegularFile(filename_path)) {
+      sidecar_source_path = std::move(filename_utf8);
+      sidecar_source_utf8 = ValueToUtf8(env, code);
+      std::vector<uint8_t> payload;
+      if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8, &payload)) {
+        napi_value arraybuffer = nullptr;
+        void* arraybuffer_data = nullptr;
+        if (napi_create_arraybuffer(env, payload.size(), &arraybuffer_data, &arraybuffer) == napi_ok &&
+            arraybuffer_data != nullptr) {
+          std::memcpy(arraybuffer_data, payload.data(), payload.size());
+          napi_value payload_view = nullptr;
+          if (napi_create_typedarray(env, napi_uint8_array, payload.size(), arraybuffer, 0, &payload_view) ==
+                  napi_ok &&
+              payload_view != nullptr) {
+            cached_data_value = payload_view;
+            consumed_sidecar = true;
+          }
+        }
+      } else {
+        produce_sidecar = true;
+      }
+    }
+  }
+
   napi_value compile_result = nullptr;
   napi_status status = unofficial_napi_contextify_compile_function(env,
                                                                    code,
                                                                    filename,
                                                                    0,
                                                                    0,
-                                                                   undefined,
-                                                                   false,
+                                                                   cached_data_value,
+                                                                   produce_sidecar,
                                                                    undefined,
                                                                    undefined,
                                                                    params,
                                                                    host_defined_option_id,
                                                                    &compile_result);
   if (status == napi_ok && compile_result != nullptr) {
+    if (consumed_sidecar) {
+      napi_value rejected_value = GetNamedPropertyOrUndefined(env, compile_result, "cachedDataRejected");
+      bool rejected = false;
+      if (rejected_value != nullptr && napi_get_value_bool(env, rejected_value, &rejected) == napi_ok &&
+          rejected) {
+        // Engine refused bytecode our header considered valid (e.g. engine
+        // flag drift); drop it so the next run rewrites instead of re-rejecting.
+        edge_bytecode_cache::RemoveSidecar(sidecar_source_path);
+      }
+    } else if (produce_sidecar) {
+      napi_value produced_value = GetNamedPropertyOrUndefined(env, compile_result, "cachedData");
+      bool is_typedarray = false;
+      if (produced_value != nullptr && napi_is_typedarray(env, produced_value, &is_typedarray) == napi_ok &&
+          is_typedarray) {
+        napi_typedarray_type type = napi_uint8_array;
+        size_t length = 0;
+        void* data = nullptr;
+        if (napi_get_typedarray_info(env, produced_value, &type, &length, &data, nullptr, nullptr) ==
+                napi_ok &&
+            type == napi_uint8_array && data != nullptr && length > 0) {
+          edge_bytecode_cache::WriteSidecar(sidecar_source_path,
+                                            sidecar_source_utf8,
+                                            static_cast<const uint8_t*>(data),
+                                            length);
+        }
+      }
+    }
     return CreateContextifyCjsLoaderResult(env, compile_result, false);
   }
   if (status != napi_pending_exception || !should_detect_module) {

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -1051,7 +1051,7 @@ static void* AcquireBuiltinBytecode(napi_env env,
                                     int32_t shape,
                                     napi_value params_or_undefined,
                                     napi_value host_defined_option_id) {
-  if (!edge_bytecode_cache::Enabled()) return nullptr;
+  if (!edge_bytecode_cache::BuiltinsCacheEnabled()) return nullptr;
 
   edge_builtin_bytecode::PayloadView view;
   if (edge_builtin_bytecode::TryGet(kind, id, source, &view)) {

--- a/src/edge_precompile.cc
+++ b/src/edge_precompile.cc
@@ -10,6 +10,7 @@
 #include <system_error>
 
 #include "edge_bytecode_cache.h"
+#include "edge_url.h"
 #include "simdjson/simdjson.h"
 #include "unofficial_napi.h"
 
@@ -122,7 +123,23 @@ enum class FileResult {
   kFailed,
 };
 
-FileResult PrecompileFile(napi_env env, const fs::path& file_path, std::string* detail_out) {
+enum class FileShape {
+  kCjs,
+  kEsm,
+};
+
+struct PrecompileEntry {
+  fs::path path;
+  FileShape shape = FileShape::kCjs;
+
+  bool operator<(const PrecompileEntry& other) const { return path < other.path; }
+  bool operator==(const PrecompileEntry& other) const { return path == other.path; }
+};
+
+FileResult PrecompileFile(napi_env env,
+                          const fs::path& file_path,
+                          FileShape shape,
+                          std::string* detail_out) {
   std::string source;
   if (!ReadFileUtf8(file_path, &source)) {
     *detail_out = "failed to read file";
@@ -140,85 +157,95 @@ FileResult PrecompileFile(napi_env env, const fs::path& file_path, std::string* 
     ~ScopeCloser() { napi_close_handle_scope(env, scope); }
   } scope_closer{env, scope};
 
-  const std::string filename_utf8 = file_path.string();
+  const std::string path_utf8 = file_path.string();
+  // ESM modules compile under their file:// URL — the exact name the runtime
+  // ModuleWrap hook compiles with (and that QuickJS bakes into the bytecode).
+  const std::string filename_utf8 =
+      shape == FileShape::kEsm ? edge_url::PathToFileURLString(path_utf8) : path_utf8;
+  if (filename_utf8.empty()) {
+    *detail_out = "failed to derive module URL";
+    return FileResult::kFailed;
+  }
+
   napi_value code = nullptr;
   napi_value filename = nullptr;
-  napi_value undefined = nullptr;
   if (napi_create_string_utf8(env, source.c_str(), source.size(), &code) != napi_ok ||
-      napi_create_string_utf8(env, filename_utf8.c_str(), filename_utf8.size(), &filename) != napi_ok ||
-      napi_get_undefined(env, &undefined) != napi_ok) {
+      napi_create_string_utf8(env, filename_utf8.c_str(), filename_utf8.size(), &filename) != napi_ok) {
     *detail_out = "failed to create compile arguments";
     return FileResult::kFailed;
   }
 
-  // Same parameter list the CJS loader compiles with; the sidecar must match
-  // the runtime compile shape exactly.
-  static constexpr const char* kParams[] = {"exports", "require", "module", "__filename", "__dirname"};
   napi_value params = nullptr;
-  if (napi_create_array_with_length(env, 5, &params) != napi_ok) {
-    *detail_out = "failed to create compile arguments";
-    return FileResult::kFailed;
-  }
-  for (uint32_t i = 0; i < 5; ++i) {
-    napi_value param = nullptr;
-    if (napi_create_string_utf8(env, kParams[i], NAPI_AUTO_LENGTH, &param) != napi_ok ||
-        napi_set_element(env, params, i, param) != napi_ok) {
+  if (shape == FileShape::kCjs) {
+    // Same parameter list the CJS loader compiles with; the sidecar must match
+    // the runtime compile shape exactly.
+    static constexpr const char* kParams[] = {"exports", "require", "module", "__filename", "__dirname"};
+    if (napi_create_array_with_length(env, 5, &params) != napi_ok) {
       *detail_out = "failed to create compile arguments";
       return FileResult::kFailed;
     }
+    for (uint32_t i = 0; i < 5; ++i) {
+      napi_value param = nullptr;
+      if (napi_create_string_utf8(env, kParams[i], NAPI_AUTO_LENGTH, &param) != napi_ok ||
+          napi_set_element(env, params, i, param) != napi_ok) {
+        *detail_out = "failed to create compile arguments";
+        return FileResult::kFailed;
+      }
+    }
   }
 
-  napi_value compile_result = nullptr;
-  const napi_status status = unofficial_napi_contextify_compile_function(env,
-                                                                         code,
-                                                                         filename,
-                                                                         0,
-                                                                         0,
-                                                                         undefined,
-                                                                         true,
-                                                                         undefined,
-                                                                         undefined,
-                                                                         params,
-                                                                         undefined,
-                                                                         &compile_result);
-  if (status != napi_ok || compile_result == nullptr) {
+  const int32_t bytecode_shape = shape == FileShape::kEsm
+                                     ? unofficial_napi_bytecode_shape_module
+                                     : unofficial_napi_bytecode_shape_cjs_function;
+  void* bytecode = nullptr;
+  bool can_parse_as_module = false;
+  const napi_status status = unofficial_napi_bytecode_compile(env,
+                                                              code,
+                                                              filename,
+                                                              bytecode_shape,
+                                                              params,
+                                                              nullptr,
+                                                              0,
+                                                              0,
+                                                              &bytecode,
+                                                              &can_parse_as_module);
+  if (status != napi_ok || bytecode == nullptr) {
     const std::string compile_error = DescribePendingException(env);
-    // A .js file with module syntax in a commonjs scope is loadable at
-    // runtime through ESM detection; that is not a precompile failure.
-    bool can_parse_as_esm = false;
-    if (unofficial_napi_contextify_contains_module_syntax(
-            env, code, filename, undefined, true, &can_parse_as_esm) == napi_ok &&
-        can_parse_as_esm) {
-      *detail_out = "ES module syntax (sidecars cover CommonJS only)";
-      return FileResult::kSkipped;
-    }
     bool pending = false;
     napi_value ignored = nullptr;
     if (napi_is_exception_pending(env, &pending) == napi_ok && pending) {
       (void)napi_get_and_clear_last_exception(env, &ignored);
     }
+    if (shape == FileShape::kCjs && can_parse_as_module) {
+      // A .js file with module syntax in a commonjs scope loads as ESM at
+      // runtime (detect-module); precompile it with the module shape instead.
+      return PrecompileFile(env, file_path, FileShape::kEsm, detail_out);
+    }
     *detail_out = compile_error;
     return FileResult::kFailed;
   }
 
-  napi_value produced = nullptr;
-  bool is_typedarray = false;
-  if (napi_get_named_property(env, compile_result, "cachedData", &produced) != napi_ok ||
-      produced == nullptr ||
-      napi_is_typedarray(env, produced, &is_typedarray) != napi_ok || !is_typedarray) {
+  napi_value cache_buffer = nullptr;
+  const bool serialized =
+      unofficial_napi_bytecode_serialize(env, bytecode, &cache_buffer) == napi_ok && cache_buffer != nullptr;
+  (void)unofficial_napi_bytecode_release(env, bytecode);
+  if (!serialized) {
     *detail_out = "engine produced no cached data";
     return FileResult::kFailed;
   }
+
   napi_typedarray_type type = napi_uint8_array;
   size_t length = 0;
   void* data = nullptr;
-  if (napi_get_typedarray_info(env, produced, &type, &length, &data, nullptr, nullptr) != napi_ok ||
+  if (napi_get_typedarray_info(env, cache_buffer, &type, &length, &data, nullptr, nullptr) != napi_ok ||
       type != napi_uint8_array || data == nullptr || length == 0) {
     *detail_out = "engine produced no cached data";
     return FileResult::kFailed;
   }
 
-  if (!edge_bytecode_cache::WriteSidecar(filename_utf8, source,
+  const uint32_t sidecar_flags = shape == FileShape::kEsm ? edge_bytecode_cache::kFlagEsmModuleV1
+                                                          : edge_bytecode_cache::kFlagCjsFunctionV1;
+  if (!edge_bytecode_cache::WriteSidecar(path_utf8, source, sidecar_flags,
                                          static_cast<const uint8_t*>(data), length)) {
     *detail_out = "failed to write sidecar (read-only or inaccessible location?)";
     return FileResult::kFailed;
@@ -228,8 +255,7 @@ FileResult PrecompileFile(napi_env env, const fs::path& file_path, std::string* 
 
 void CollectFromDirectory(const fs::path& dir,
                           PackageTypeResolver* resolver,
-                          std::vector<fs::path>* out,
-                          size_t* skipped) {
+                          std::vector<PrecompileEntry>* out) {
   std::error_code ec;
   fs::recursive_directory_iterator it(dir, fs::directory_options::skip_permission_denied, ec);
   if (ec) return;
@@ -239,13 +265,11 @@ void CollectFromDirectory(const fs::path& dir,
     const fs::path& path = entry.path();
     const std::string ext = path.extension().string();
     if (ext == ".cjs") {
-      out->push_back(path);
+      out->push_back({path, FileShape::kCjs});
+    } else if (ext == ".mjs") {
+      out->push_back({path, FileShape::kEsm});
     } else if (ext == ".js") {
-      if (resolver->IsModuleScope(path)) {
-        ++*skipped;
-      } else {
-        out->push_back(path);
-      }
+      out->push_back({path, resolver->IsModuleScope(path) ? FileShape::kEsm : FileShape::kCjs});
     }
   }
 }
@@ -262,21 +286,25 @@ int RunPrecompile(napi_env env, const std::vector<std::string>& paths, std::stri
   }
 
   PackageTypeResolver resolver;
-  std::vector<fs::path> files;
+  std::vector<PrecompileEntry> files;
   size_t skipped = 0;
   for (const auto& raw_path : paths) {
     const fs::path path(raw_path);
     std::error_code ec;
     if (fs::is_directory(path, ec) && !ec) {
-      CollectFromDirectory(path, &resolver, &files, &skipped);
+      CollectFromDirectory(path, &resolver, &files);
       continue;
     }
     if (fs::is_regular_file(path, ec) && !ec) {
       const std::string ext = path.extension().string();
-      if (ext == ".cjs" || (ext == ".js" && !resolver.IsModuleScope(path))) {
-        files.push_back(path);
+      if (ext == ".cjs") {
+        files.push_back({path, FileShape::kCjs});
+      } else if (ext == ".mjs") {
+        files.push_back({path, FileShape::kEsm});
+      } else if (ext == ".js") {
+        files.push_back({path, resolver.IsModuleScope(path) ? FileShape::kEsm : FileShape::kCjs});
       } else {
-        std::fprintf(stderr, "edge --precompile: skipping %s (not a CommonJS .js/.cjs file)\n",
+        std::fprintf(stderr, "edge --precompile: skipping %s (not a .js/.cjs/.mjs file)\n",
                      path.string().c_str());
         ++skipped;
       }
@@ -294,21 +322,21 @@ int RunPrecompile(napi_env env, const std::vector<std::string>& paths, std::stri
   size_t failed = 0;
   for (const auto& file : files) {
     std::error_code abs_ec;
-    fs::path absolute = fs::absolute(file, abs_ec);
-    if (abs_ec) absolute = file;
+    fs::path absolute = fs::absolute(file.path, abs_ec);
+    if (abs_ec) absolute = file.path;
     std::string detail;
-    switch (PrecompileFile(env, absolute.lexically_normal(), &detail)) {
+    switch (PrecompileFile(env, absolute.lexically_normal(), file.shape, &detail)) {
       case FileResult::kWritten:
         ++written;
         break;
       case FileResult::kSkipped:
         std::fprintf(stderr, "edge --precompile: skipping %s: %s\n",
-                     file.string().c_str(), detail.c_str());
+                     file.path.string().c_str(), detail.c_str());
         ++skipped;
         break;
       case FileResult::kFailed:
         std::fprintf(stderr, "edge --precompile: error in %s: %s\n",
-                     file.string().c_str(), detail.c_str());
+                     file.path.string().c_str(), detail.c_str());
         ++failed;
         break;
     }

--- a/src/edge_precompile.cc
+++ b/src/edge_precompile.cc
@@ -342,8 +342,10 @@ int RunPrecompile(napi_env env, const std::vector<std::string>& paths, std::stri
     }
   }
 
-  std::fprintf(stderr, "edge --precompile: wrote %zu sidecar(s) (*%s), skipped %zu, %zu error(s)\n",
-               written, edge_bytecode_cache::SidecarSuffix(), skipped, failed);
+  std::fprintf(stderr,
+               "edge --precompile: wrote %zu sidecar(s) (__edgecache__/*.jsc), skipped %zu, "
+               "%zu error(s)\n",
+               written, skipped, failed);
   return failed > 0 ? 1 : 0;
 }
 

--- a/src/edge_precompile.cc
+++ b/src/edge_precompile.cc
@@ -1,0 +1,322 @@
+#include "edge_precompile.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+
+#include "edge_bytecode_cache.h"
+#include "simdjson/simdjson.h"
+#include "unofficial_napi.h"
+
+namespace edge_precompile {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Nearest-package.json "type" lookup, mirroring the module loader's scope walk
+// (the scope ends at a node_modules boundary). Results are cached per
+// directory because directory trees compile many siblings.
+class PackageTypeResolver {
+ public:
+  bool IsModuleScope(const fs::path& file_path) {
+    return DirIsModuleScope(file_path.parent_path());
+  }
+
+ private:
+  bool DirIsModuleScope(const fs::path& dir) {
+    const std::string key = dir.string();
+    auto it = cache_.find(key);
+    if (it != cache_.end()) return it->second;
+
+    bool is_module = false;
+    if (dir.filename() != "node_modules" && !dir.empty()) {
+      const fs::path package_json = dir / "package.json";
+      std::string type;
+      if (ReadPackageType(package_json, &type)) {
+        is_module = type == "module";
+      } else {
+        const fs::path parent = dir.parent_path();
+        if (!parent.empty() && parent != dir) {
+          is_module = DirIsModuleScope(parent);
+        }
+      }
+    }
+    cache_.emplace(key, is_module);
+    return is_module;
+  }
+
+  static bool ReadPackageType(const fs::path& package_json, std::string* type_out) {
+    std::error_code ec;
+    if (!fs::is_regular_file(package_json, ec) || ec) return false;
+    std::ifstream in(package_json, std::ios::binary);
+    if (!in.is_open()) return false;
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    const std::string source = ss.str();
+
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string padded(source);
+    simdjson::ondemand::document document;
+    simdjson::ondemand::object main_object;
+    if (parser.iterate(padded).get(document) != simdjson::SUCCESS ||
+        document.get_object().get(main_object) != simdjson::SUCCESS) {
+      // Invalid package.json still establishes the scope; treat as commonjs.
+      type_out->clear();
+      return true;
+    }
+    std::string_view type_value;
+    if (main_object["type"].get_string().get(type_value) == simdjson::SUCCESS) {
+      *type_out = std::string(type_value);
+    } else {
+      type_out->clear();
+    }
+    return true;
+  }
+
+  std::map<std::string, bool> cache_;
+};
+
+bool ReadFileUtf8(const fs::path& path, std::string* out) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.is_open()) return false;
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  *out = ss.str();
+  return !in.bad();
+}
+
+std::string DescribePendingException(napi_env env) {
+  bool pending = false;
+  if (napi_is_exception_pending(env, &pending) != napi_ok || !pending) {
+    return "unknown compile error";
+  }
+  napi_value exception = nullptr;
+  if (napi_get_and_clear_last_exception(env, &exception) != napi_ok || exception == nullptr) {
+    return "unknown compile error";
+  }
+  napi_value as_string = nullptr;
+  if (napi_coerce_to_string(env, exception, &as_string) != napi_ok || as_string == nullptr) {
+    return "unknown compile error";
+  }
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, as_string, nullptr, 0, &length) != napi_ok) {
+    return "unknown compile error";
+  }
+  std::string message(length + 1, '\0');
+  size_t copied = 0;
+  if (napi_get_value_string_utf8(env, as_string, message.data(), message.size(), &copied) != napi_ok) {
+    return "unknown compile error";
+  }
+  message.resize(copied);
+  return message;
+}
+
+enum class FileResult {
+  kWritten,
+  kSkipped,
+  kFailed,
+};
+
+FileResult PrecompileFile(napi_env env, const fs::path& file_path, std::string* detail_out) {
+  std::string source;
+  if (!ReadFileUtf8(file_path, &source)) {
+    *detail_out = "failed to read file";
+    return FileResult::kFailed;
+  }
+
+  napi_handle_scope scope = nullptr;
+  if (napi_open_handle_scope(env, &scope) != napi_ok) {
+    *detail_out = "failed to open handle scope";
+    return FileResult::kFailed;
+  }
+  struct ScopeCloser {
+    napi_env env;
+    napi_handle_scope scope;
+    ~ScopeCloser() { napi_close_handle_scope(env, scope); }
+  } scope_closer{env, scope};
+
+  const std::string filename_utf8 = file_path.string();
+  napi_value code = nullptr;
+  napi_value filename = nullptr;
+  napi_value undefined = nullptr;
+  if (napi_create_string_utf8(env, source.c_str(), source.size(), &code) != napi_ok ||
+      napi_create_string_utf8(env, filename_utf8.c_str(), filename_utf8.size(), &filename) != napi_ok ||
+      napi_get_undefined(env, &undefined) != napi_ok) {
+    *detail_out = "failed to create compile arguments";
+    return FileResult::kFailed;
+  }
+
+  // Same parameter list the CJS loader compiles with; the sidecar must match
+  // the runtime compile shape exactly.
+  static constexpr const char* kParams[] = {"exports", "require", "module", "__filename", "__dirname"};
+  napi_value params = nullptr;
+  if (napi_create_array_with_length(env, 5, &params) != napi_ok) {
+    *detail_out = "failed to create compile arguments";
+    return FileResult::kFailed;
+  }
+  for (uint32_t i = 0; i < 5; ++i) {
+    napi_value param = nullptr;
+    if (napi_create_string_utf8(env, kParams[i], NAPI_AUTO_LENGTH, &param) != napi_ok ||
+        napi_set_element(env, params, i, param) != napi_ok) {
+      *detail_out = "failed to create compile arguments";
+      return FileResult::kFailed;
+    }
+  }
+
+  napi_value compile_result = nullptr;
+  const napi_status status = unofficial_napi_contextify_compile_function(env,
+                                                                         code,
+                                                                         filename,
+                                                                         0,
+                                                                         0,
+                                                                         undefined,
+                                                                         true,
+                                                                         undefined,
+                                                                         undefined,
+                                                                         params,
+                                                                         undefined,
+                                                                         &compile_result);
+  if (status != napi_ok || compile_result == nullptr) {
+    const std::string compile_error = DescribePendingException(env);
+    // A .js file with module syntax in a commonjs scope is loadable at
+    // runtime through ESM detection; that is not a precompile failure.
+    bool can_parse_as_esm = false;
+    if (unofficial_napi_contextify_contains_module_syntax(
+            env, code, filename, undefined, true, &can_parse_as_esm) == napi_ok &&
+        can_parse_as_esm) {
+      *detail_out = "ES module syntax (sidecars cover CommonJS only)";
+      return FileResult::kSkipped;
+    }
+    bool pending = false;
+    napi_value ignored = nullptr;
+    if (napi_is_exception_pending(env, &pending) == napi_ok && pending) {
+      (void)napi_get_and_clear_last_exception(env, &ignored);
+    }
+    *detail_out = compile_error;
+    return FileResult::kFailed;
+  }
+
+  napi_value produced = nullptr;
+  bool is_typedarray = false;
+  if (napi_get_named_property(env, compile_result, "cachedData", &produced) != napi_ok ||
+      produced == nullptr ||
+      napi_is_typedarray(env, produced, &is_typedarray) != napi_ok || !is_typedarray) {
+    *detail_out = "engine produced no cached data";
+    return FileResult::kFailed;
+  }
+  napi_typedarray_type type = napi_uint8_array;
+  size_t length = 0;
+  void* data = nullptr;
+  if (napi_get_typedarray_info(env, produced, &type, &length, &data, nullptr, nullptr) != napi_ok ||
+      type != napi_uint8_array || data == nullptr || length == 0) {
+    *detail_out = "engine produced no cached data";
+    return FileResult::kFailed;
+  }
+
+  if (!edge_bytecode_cache::WriteSidecar(filename_utf8, source,
+                                         static_cast<const uint8_t*>(data), length)) {
+    *detail_out = "failed to write sidecar (read-only or inaccessible location?)";
+    return FileResult::kFailed;
+  }
+  return FileResult::kWritten;
+}
+
+void CollectFromDirectory(const fs::path& dir,
+                          PackageTypeResolver* resolver,
+                          std::vector<fs::path>* out,
+                          size_t* skipped) {
+  std::error_code ec;
+  fs::recursive_directory_iterator it(dir, fs::directory_options::skip_permission_denied, ec);
+  if (ec) return;
+  for (const auto& entry : it) {
+    std::error_code entry_ec;
+    if (!entry.is_regular_file(entry_ec) || entry_ec) continue;
+    const fs::path& path = entry.path();
+    const std::string ext = path.extension().string();
+    if (ext == ".cjs") {
+      out->push_back(path);
+    } else if (ext == ".js") {
+      if (resolver->IsModuleScope(path)) {
+        ++*skipped;
+      } else {
+        out->push_back(path);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+int RunPrecompile(napi_env env, const std::vector<std::string>& paths, std::string* error_out) {
+  if (!edge_bytecode_cache::Enabled()) {
+    if (error_out != nullptr) {
+      *error_out = "bytecode cache is disabled (EDGE_BYTECODE_CACHE or unsupported engine); "
+                   "--precompile cannot proceed";
+    }
+    return 1;
+  }
+
+  PackageTypeResolver resolver;
+  std::vector<fs::path> files;
+  size_t skipped = 0;
+  for (const auto& raw_path : paths) {
+    const fs::path path(raw_path);
+    std::error_code ec;
+    if (fs::is_directory(path, ec) && !ec) {
+      CollectFromDirectory(path, &resolver, &files, &skipped);
+      continue;
+    }
+    if (fs::is_regular_file(path, ec) && !ec) {
+      const std::string ext = path.extension().string();
+      if (ext == ".cjs" || (ext == ".js" && !resolver.IsModuleScope(path))) {
+        files.push_back(path);
+      } else {
+        std::fprintf(stderr, "edge --precompile: skipping %s (not a CommonJS .js/.cjs file)\n",
+                     path.string().c_str());
+        ++skipped;
+      }
+      continue;
+    }
+    if (error_out != nullptr) {
+      *error_out = "no such file or directory: " + raw_path;
+    }
+    return 1;
+  }
+  std::sort(files.begin(), files.end());
+  files.erase(std::unique(files.begin(), files.end()), files.end());
+
+  size_t written = 0;
+  size_t failed = 0;
+  for (const auto& file : files) {
+    std::error_code abs_ec;
+    fs::path absolute = fs::absolute(file, abs_ec);
+    if (abs_ec) absolute = file;
+    std::string detail;
+    switch (PrecompileFile(env, absolute.lexically_normal(), &detail)) {
+      case FileResult::kWritten:
+        ++written;
+        break;
+      case FileResult::kSkipped:
+        std::fprintf(stderr, "edge --precompile: skipping %s: %s\n",
+                     file.string().c_str(), detail.c_str());
+        ++skipped;
+        break;
+      case FileResult::kFailed:
+        std::fprintf(stderr, "edge --precompile: error in %s: %s\n",
+                     file.string().c_str(), detail.c_str());
+        ++failed;
+        break;
+    }
+  }
+
+  std::fprintf(stderr, "edge --precompile: wrote %zu sidecar(s) (*%s), skipped %zu, %zu error(s)\n",
+               written, edge_bytecode_cache::SidecarSuffix(), skipped, failed);
+  return failed > 0 ? 1 : 0;
+}
+
+}  // namespace edge_precompile

--- a/src/edge_precompile.h
+++ b/src/edge_precompile.h
@@ -1,0 +1,22 @@
+#ifndef EDGE_PRECOMPILE_H_
+#define EDGE_PRECOMPILE_H_
+
+#include <string>
+#include <vector>
+
+#include "node_api.h"
+
+namespace edge_precompile {
+
+// Walks the given files/directories, compiles every eligible CommonJS source
+// (.cjs always; .js unless its nearest package.json declares type "module")
+// and writes bytecode sidecars next to the sources. Module bodies are never
+// executed. Returns the process exit code (0 = all eligible files written,
+// 1 = at least one failure).
+int RunPrecompile(napi_env env,
+                  const std::vector<std::string>& paths,
+                  std::string* error_out);
+
+}  // namespace edge_precompile
+
+#endif  // EDGE_PRECOMPILE_H_

--- a/src/edge_url.cc
+++ b/src/edge_url.cc
@@ -441,3 +441,18 @@ napi_value EdgeInstallUrlBinding(napi_env env) {
 
   return binding;
 }
+
+namespace edge_url {
+
+std::string PathToFileURLString(std::string_view absolute_path) {
+#if defined(_WIN32)
+  constexpr bool windows = true;
+#else
+  constexpr bool windows = false;
+#endif
+  auto out = ada::parse<ada::url_aggregator>(EncodePathChars(absolute_path, windows), nullptr);
+  if (!out) return std::string();
+  return std::string(out->get_href());
+}
+
+}  // namespace edge_url

--- a/src/edge_url.h
+++ b/src/edge_url.h
@@ -1,9 +1,21 @@
 #ifndef EDGE_URL_H_
 #define EDGE_URL_H_
 
+#include <string>
+#include <string_view>
+
 #include "node_api.h"
 
 napi_value EdgeInstallUrlBinding(napi_env env);
 napi_value EdgeInstallUrlPatternBinding(napi_env env);
+
+namespace edge_url {
+
+// pathToFileURL equivalent for absolute paths — byte-identical to the JS
+// loader's url.pathToFileURL() href (same percent-encoding via ada). Returns
+// an empty string when the input does not parse as a file URL.
+std::string PathToFileURLString(std::string_view absolute_path);
+
+}  // namespace edge_url
 
 #endif  // EDGE_URL_H_

--- a/src/internal_binding/binding_messaging.cc
+++ b/src/internal_binding/binding_messaging.cc
@@ -4686,9 +4686,10 @@ napi_value CreateMovedMessagePortWrapperInContext(napi_env env,
   }
 
   napi_value out = nullptr;
+  const unofficial_napi_js_source run_source{source, nullptr};
   const napi_status status = unofficial_napi_contextify_run_script(env,
                                                                    contextified_object,
-                                                                   source,
+                                                                   &run_source,
                                                                    filename,
                                                                    0,
                                                                    0,

--- a/src/internal_binding/binding_module_wrap.cc
+++ b/src/internal_binding/binding_module_wrap.cc
@@ -37,10 +37,6 @@ struct ModuleWrapInstance {
   napi_ref url_ref = nullptr;
   void* module_handle = nullptr;
   bool has_top_level_await = false;
-  // XXH3 of the source text; backs the Edge cachedData wrapper on engines
-  // whose deserializer cannot validate source identity (createCachedData /
-  // constructor cachedData). Unused (0) on V8.
-  uint64_t source_hash = 0;
 };
 
 struct ModuleWrapBindingState {
@@ -438,12 +434,6 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
       if (argc >= 4 && argv[3] != nullptr) (void)napi_get_value_int32(env, argv[3], &line_offset);
       if (argc >= 5 && argv[4] != nullptr) (void)napi_get_value_int32(env, argv[4], &column_offset);
 
-      if (edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
-        const std::string source_utf8 = ValueToUtf8(env, argv[2]);
-        instance->source_hash =
-            edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size());
-      }
-
       // arg5 is dual-purpose at the JS boundary: the ESM loader passes its
       // host-defined-option Symbol; vm.SourceTextModule passes user cachedData
       // (an ArrayBufferView).
@@ -453,21 +443,18 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
 
       void* module_bytecode = nullptr;
       if (arg5_is_cached_data) {
-        // vm.SourceTextModule cachedData: validate and consume. Node throws
-        // ERR_VM_MODULE_CACHED_DATA_REJECTED from the constructor when the
-        // bytes don't match this source.
+        // vm.SourceTextModule cachedData: validate and consume. The provider
+        // validates source/shape/integrity itself (V8 CachedData / QuickJS
+        // QJSB header) and reports a mismatch via rejected_out. Node throws
+        // ERR_VM_MODULE_CACHED_DATA_REJECTED from the constructor on reject.
         bool rejected = true;
         const uint8_t* data = nullptr;
         size_t length = 0;
-        size_t payload_offset = 0;
-        size_t payload_size = 0;
-        if (GetArrayBufferViewBytes(env, arg5, &data, &length) && length > 0 &&
-            edge_bytecode_cache::UnwrapVmCachedData(instance->source_hash, data, length,
-                                                    &payload_offset, &payload_size)) {
+        if (GetArrayBufferViewBytes(env, arg5, &data, &length) && length > 0) {
           bool deserialize_rejected = false;
           if (unofficial_napi_bytecode_deserialize(env,
-                                                   data + payload_offset,
-                                                   payload_size,
+                                                   data,
+                                                   length,
                                                    argv[2],
                                                    argc >= 1 ? argv[0] : nullptr,
                                                    unofficial_napi_bytecode_shape_module,
@@ -485,11 +472,16 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
           delete instance;
           return nullptr;
         }
-      } else if (edge_bytecode_cache::Enabled() && (argc < 2 || IsNullishValue(env, argv[1]))) {
+      } else if (edge_bytecode_cache::Enabled() && (argc < 2 || IsNullishValue(env, argv[1])) &&
+                 line_offset == 0 && column_offset == 0) {
         // Bytecode sidecar cache for file-backed modules loaded by the default
         // ESM loader (a vm context in argv[1] opts out). Deserialize
         // <path>.v8b/.qjsb when it matches the exact source, otherwise compile
-        // to a fresh handle and persist it (write-on-first-run).
+        // to a fresh handle and persist it (write-on-first-run). Non-zero
+        // line/column offsets are baked into the payload but absent from the
+        // sidecar key, so they are excluded here — otherwise a
+        // `new vm.SourceTextModule(src, {identifier:'file://…', lineOffset:N})`
+        // would poison the real loader's sidecar with shifted positions.
         const std::string url_utf8 = argc >= 1 && argv[0] != nullptr ? ValueToUtf8(env, argv[0]) : "";
         if (url_utf8.rfind("file://", 0) == 0) {
           const std::string sidecar_source_path = edge_path::NormalizeFileURLOrPath(url_utf8);
@@ -762,25 +754,10 @@ napi_value ModuleWrapCreateCachedData(napi_env env, napi_callback_info info) {
     napi_value out = nullptr;
     if (unofficial_napi_module_wrap_create_cached_data(env, instance->module_handle, &out) == napi_ok &&
         out != nullptr) {
-      if (edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
-        // QuickJS: prepend the Edge source-hash prefix so the constructor's
-        // cachedData path can validate source identity (the engine cannot).
-        const uint8_t* bytes = nullptr;
-        size_t length = 0;
-        if (GetArrayBufferViewBytes(env, out, &bytes, &length) && length > 0) {
-          const std::vector<uint8_t> wrapped_bytes =
-              edge_bytecode_cache::WrapVmCachedData(instance->source_hash, bytes, length);
-          napi_value buffer = nullptr;
-          if (napi_create_buffer_copy(env, wrapped_bytes.size(), wrapped_bytes.data(), nullptr,
-                                      &buffer) == napi_ok &&
-              buffer != nullptr) {
-            return buffer;
-          }
-        }
-        // Empty cache (evaluated module): fall through unwrapped.
-      }
-      // vm.SourceTextModule#createCachedData() promises a node Buffer; the
-      // QuickJS provider hands back a plain Uint8Array.
+      // The provider's bytes self-validate (V8 CachedData / QuickJS QJSB
+      // header, which now carries the module source hash); just hand back a
+      // node Buffer. vm.SourceTextModule#createCachedData() promises a Buffer;
+      // the QuickJS provider returns a plain Uint8Array.
       napi_value global = nullptr;
       napi_value buffer_ctor = nullptr;
       napi_value from_fn = nullptr;

--- a/src/internal_binding/binding_module_wrap.cc
+++ b/src/internal_binding/binding_module_wrap.cc
@@ -37,6 +37,10 @@ struct ModuleWrapInstance {
   napi_ref url_ref = nullptr;
   void* module_handle = nullptr;
   bool has_top_level_await = false;
+  // XXH3 of the source text; backs the Edge cachedData wrapper on engines
+  // whose deserializer cannot validate source identity (createCachedData /
+  // constructor cachedData). Unused (0) on V8.
+  uint64_t source_hash = 0;
 };
 
 struct ModuleWrapBindingState {
@@ -434,6 +438,12 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
       if (argc >= 4 && argv[3] != nullptr) (void)napi_get_value_int32(env, argv[3], &line_offset);
       if (argc >= 5 && argv[4] != nullptr) (void)napi_get_value_int32(env, argv[4], &column_offset);
 
+      if (edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
+        const std::string source_utf8 = ValueToUtf8(env, argv[2]);
+        instance->source_hash =
+            edge_bytecode_cache::Hash64(source_utf8.data(), source_utf8.size());
+      }
+
       // arg5 is dual-purpose at the JS boundary: the ESM loader passes its
       // host-defined-option Symbol; vm.SourceTextModule passes user cachedData
       // (an ArrayBufferView).
@@ -449,11 +459,15 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
         bool rejected = true;
         const uint8_t* data = nullptr;
         size_t length = 0;
-        if (GetArrayBufferViewBytes(env, arg5, &data, &length) && length > 0) {
+        size_t payload_offset = 0;
+        size_t payload_size = 0;
+        if (GetArrayBufferViewBytes(env, arg5, &data, &length) && length > 0 &&
+            edge_bytecode_cache::UnwrapVmCachedData(instance->source_hash, data, length,
+                                                    &payload_offset, &payload_size)) {
           bool deserialize_rejected = false;
           if (unofficial_napi_bytecode_deserialize(env,
-                                                   data,
-                                                   length,
+                                                   data + payload_offset,
+                                                   payload_size,
                                                    argv[2],
                                                    argc >= 1 ? argv[0] : nullptr,
                                                    unofficial_napi_bytecode_shape_module,
@@ -748,6 +762,23 @@ napi_value ModuleWrapCreateCachedData(napi_env env, napi_callback_info info) {
     napi_value out = nullptr;
     if (unofficial_napi_module_wrap_create_cached_data(env, instance->module_handle, &out) == napi_ok &&
         out != nullptr) {
+      if (edge_bytecode_cache::VmCachedDataNeedsWrapper()) {
+        // QuickJS: prepend the Edge source-hash prefix so the constructor's
+        // cachedData path can validate source identity (the engine cannot).
+        const uint8_t* bytes = nullptr;
+        size_t length = 0;
+        if (GetArrayBufferViewBytes(env, out, &bytes, &length) && length > 0) {
+          const std::vector<uint8_t> wrapped_bytes =
+              edge_bytecode_cache::WrapVmCachedData(instance->source_hash, bytes, length);
+          napi_value buffer = nullptr;
+          if (napi_create_buffer_copy(env, wrapped_bytes.size(), wrapped_bytes.data(), nullptr,
+                                      &buffer) == napi_ok &&
+              buffer != nullptr) {
+            return buffer;
+          }
+        }
+        // Empty cache (evaluated module): fall through unwrapped.
+      }
       // vm.SourceTextModule#createCachedData() promises a node Buffer; the
       // QuickJS provider hands back a plain Uint8Array.
       napi_value global = nullptr;

--- a/src/internal_binding/binding_module_wrap.cc
+++ b/src/internal_binding/binding_module_wrap.cc
@@ -483,13 +483,13 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
           if (!sidecar_source_path.empty() &&
               std::filesystem::is_regular_file(std::filesystem::path(sidecar_source_path), ec) && !ec) {
             const std::string sidecar_source_utf8 = ValueToUtf8(env, argv[2]);
-            std::vector<uint8_t> payload;
+            edge_bytecode_cache::SidecarPayload payload;
             if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8,
                                                  edge_bytecode_cache::kFlagEsmModuleV1, &payload)) {
               bool rejected = false;
               if (unofficial_napi_bytecode_deserialize(env,
                                                        payload.data(),
-                                                       payload.size(),
+                                                       payload.payload_size,
                                                        argv[2],
                                                        argv[0],
                                                        unofficial_napi_bytecode_shape_module,

--- a/src/internal_binding/binding_module_wrap.cc
+++ b/src/internal_binding/binding_module_wrap.cc
@@ -1,6 +1,8 @@
 #include "internal_binding/binding_initializers.h"
 
+#include <filesystem>
 #include <string>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -8,7 +10,9 @@
 #include "edge_environment.h"
 #include "internal_binding/helpers.h"
 #include "unofficial_napi.h"
+#include "../edge_bytecode_cache.h"
 #include "../edge_module_loader.h"
+#include "../edge_path.h"
 
 namespace internal_binding {
 
@@ -304,6 +308,82 @@ bool ThrowCodeError(napi_env env, const char* code, const char* message) {
   return napi_throw(env, error_value) == napi_ok;
 }
 
+bool IsNullishValue(napi_env env, napi_value value) {
+  if (value == nullptr) return true;
+  napi_valuetype type = napi_undefined;
+  if (napi_typeof(env, value, &type) != napi_ok) return true;
+  return type == napi_undefined || type == napi_null;
+}
+
+// Extracts the bytes of any ArrayBufferView (typed array or DataView) —
+// Node's vm cachedData accepts every view flavor over the same buffer.
+bool GetArrayBufferViewBytes(napi_env env, napi_value value, const uint8_t** data_out, size_t* len_out) {
+  *data_out = nullptr;
+  *len_out = 0;
+  if (value == nullptr) return false;
+
+  bool is_typedarray = false;
+  if (napi_is_typedarray(env, value, &is_typedarray) == napi_ok && is_typedarray) {
+    napi_typedarray_type type = napi_uint8_array;
+    size_t length = 0;
+    void* data = nullptr;
+    if (napi_get_typedarray_info(env, value, &type, &length, &data, nullptr, nullptr) != napi_ok ||
+        data == nullptr) {
+      return false;
+    }
+    size_t element_size = 1;
+    switch (type) {
+      case napi_int8_array:
+      case napi_uint8_array:
+      case napi_uint8_clamped_array:
+        element_size = 1;
+        break;
+      case napi_int16_array:
+      case napi_uint16_array:
+      case napi_float16_array:
+        element_size = 2;
+        break;
+      case napi_int32_array:
+      case napi_uint32_array:
+      case napi_float32_array:
+        element_size = 4;
+        break;
+      case napi_float64_array:
+      case napi_bigint64_array:
+      case napi_biguint64_array:
+        element_size = 8;
+        break;
+      default:
+        return false;
+    }
+    *data_out = static_cast<const uint8_t*>(data);
+    *len_out = length * element_size;
+    return true;
+  }
+
+  bool is_dataview = false;
+  if (napi_is_dataview(env, value, &is_dataview) == napi_ok && is_dataview) {
+    size_t byte_length = 0;
+    void* data = nullptr;
+    if (napi_get_dataview_info(env, value, &byte_length, &data, nullptr, nullptr) != napi_ok ||
+        data == nullptr) {
+      return false;
+    }
+    *data_out = static_cast<const uint8_t*>(data);
+    *len_out = byte_length;
+    return true;
+  }
+  return false;
+}
+
+bool IsArrayBufferViewValue(napi_env env, napi_value value) {
+  if (value == nullptr) return false;
+  bool is_typedarray = false;
+  if (napi_is_typedarray(env, value, &is_typedarray) == napi_ok && is_typedarray) return true;
+  bool is_dataview = false;
+  return napi_is_dataview(env, value, &is_dataview) == napi_ok && is_dataview;
+}
+
 napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
   size_t argc = 6;
   napi_value argv[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
@@ -353,16 +433,131 @@ napi_value ModuleWrapCtor(napi_env env, napi_callback_info info) {
       int32_t column_offset = 0;
       if (argc >= 4 && argv[3] != nullptr) (void)napi_get_value_int32(env, argv[3], &line_offset);
       if (argc >= 5 && argv[4] != nullptr) (void)napi_get_value_int32(env, argv[4], &column_offset);
+
+      // arg5 is dual-purpose at the JS boundary: the ESM loader passes its
+      // host-defined-option Symbol; vm.SourceTextModule passes user cachedData
+      // (an ArrayBufferView).
+      napi_value arg5 = argc >= 6 ? argv[5] : nullptr;
+      const bool arg5_is_cached_data = IsArrayBufferViewValue(env, arg5);
+      napi_value host_defined_option = arg5_is_cached_data ? nullptr : arg5;
+
+      void* module_bytecode = nullptr;
+      if (arg5_is_cached_data) {
+        // vm.SourceTextModule cachedData: validate and consume. Node throws
+        // ERR_VM_MODULE_CACHED_DATA_REJECTED from the constructor when the
+        // bytes don't match this source.
+        bool rejected = true;
+        const uint8_t* data = nullptr;
+        size_t length = 0;
+        if (GetArrayBufferViewBytes(env, arg5, &data, &length) && length > 0) {
+          bool deserialize_rejected = false;
+          if (unofficial_napi_bytecode_deserialize(env,
+                                                   data,
+                                                   length,
+                                                   argv[2],
+                                                   argc >= 1 ? argv[0] : nullptr,
+                                                   unofficial_napi_bytecode_shape_module,
+                                                   nullptr,
+                                                   nullptr,
+                                                   &module_bytecode,
+                                                   &deserialize_rejected) == napi_ok) {
+            rejected = deserialize_rejected || module_bytecode == nullptr;
+          }
+        }
+        SetNamedBool(env, this_arg, "cachedDataRejected", rejected);
+        if (rejected) {
+          ThrowCodeError(env, "ERR_VM_MODULE_CACHED_DATA_REJECTED",
+                         "cachedData buffer was rejected");
+          delete instance;
+          return nullptr;
+        }
+      } else if (edge_bytecode_cache::Enabled() && (argc < 2 || IsNullishValue(env, argv[1]))) {
+        // Bytecode sidecar cache for file-backed modules loaded by the default
+        // ESM loader (a vm context in argv[1] opts out). Deserialize
+        // <path>.v8b/.qjsb when it matches the exact source, otherwise compile
+        // to a fresh handle and persist it (write-on-first-run).
+        const std::string url_utf8 = argc >= 1 && argv[0] != nullptr ? ValueToUtf8(env, argv[0]) : "";
+        if (url_utf8.rfind("file://", 0) == 0) {
+          const std::string sidecar_source_path = edge_path::NormalizeFileURLOrPath(url_utf8);
+          std::error_code ec;
+          if (!sidecar_source_path.empty() &&
+              std::filesystem::is_regular_file(std::filesystem::path(sidecar_source_path), ec) && !ec) {
+            const std::string sidecar_source_utf8 = ValueToUtf8(env, argv[2]);
+            std::vector<uint8_t> payload;
+            if (edge_bytecode_cache::ReadSidecar(sidecar_source_path, sidecar_source_utf8,
+                                                 edge_bytecode_cache::kFlagEsmModuleV1, &payload)) {
+              bool rejected = false;
+              if (unofficial_napi_bytecode_deserialize(env,
+                                                       payload.data(),
+                                                       payload.size(),
+                                                       argv[2],
+                                                       argv[0],
+                                                       unofficial_napi_bytecode_shape_module,
+                                                       nullptr,
+                                                       host_defined_option,
+                                                       &module_bytecode,
+                                                       &rejected) != napi_ok ||
+                  rejected || module_bytecode == nullptr) {
+                edge_bytecode_cache::RemoveSidecar(sidecar_source_path);
+                module_bytecode = nullptr;
+              }
+            }
+            if (module_bytecode == nullptr) {
+              if (unofficial_napi_bytecode_compile(env,
+                                                   argv[2],
+                                                   argv[0],
+                                                   unofficial_napi_bytecode_shape_module,
+                                                   nullptr,
+                                                   host_defined_option,
+                                                   line_offset,
+                                                   column_offset,
+                                                   &module_bytecode,
+                                                   nullptr) == napi_ok &&
+                  module_bytecode != nullptr) {
+                napi_value cache_buffer = nullptr;
+                if (unofficial_napi_bytecode_serialize(env, module_bytecode, &cache_buffer) == napi_ok &&
+                    cache_buffer != nullptr) {
+                  napi_typedarray_type type = napi_uint8_array;
+                  size_t length = 0;
+                  void* data = nullptr;
+                  if (napi_get_typedarray_info(env, cache_buffer, &type, &length, &data, nullptr, nullptr) ==
+                          napi_ok &&
+                      type == napi_uint8_array && data != nullptr && length > 0) {
+                    edge_bytecode_cache::WriteSidecar(sidecar_source_path,
+                                                      sidecar_source_utf8,
+                                                      edge_bytecode_cache::kFlagEsmModuleV1,
+                                                      static_cast<const uint8_t*>(data),
+                                                      length);
+                  }
+                }
+              } else {
+                // Compile failed (syntax error): clear it and let the text
+                // path below regenerate it with the existing error decoration.
+                bool has_pending = false;
+                napi_value ignored = nullptr;
+                if (napi_is_exception_pending(env, &has_pending) == napi_ok && has_pending) {
+                  (void)napi_get_and_clear_last_exception(env, &ignored);
+                }
+                module_bytecode = nullptr;
+              }
+            }
+          }
+        }
+      }
+
+      const unofficial_napi_js_source module_source{module_bytecode != nullptr ? nullptr : argv[2],
+                                                    module_bytecode};
       const napi_status create_status =
           unofficial_napi_module_wrap_create_source_text(env,
                                                          this_arg,
                                                          argc >= 1 ? argv[0] : nullptr,
                                                          argc >= 2 ? argv[1] : nullptr,
-                                                         argv[2],
+                                                         &module_source,
                                                          line_offset,
                                                          column_offset,
-                                                         argc >= 6 ? argv[5] : nullptr,
+                                                         host_defined_option,
                                                          &instance->module_handle);
+      if (module_bytecode != nullptr) (void)unofficial_napi_bytecode_release(env, module_bytecode);
       if (create_status != napi_ok || instance->module_handle == nullptr) {
         napi_value err = nullptr;
         if (napi_get_and_clear_last_exception(env, &err) == napi_ok && err != nullptr) {
@@ -553,6 +748,23 @@ napi_value ModuleWrapCreateCachedData(napi_env env, napi_callback_info info) {
     napi_value out = nullptr;
     if (unofficial_napi_module_wrap_create_cached_data(env, instance->module_handle, &out) == napi_ok &&
         out != nullptr) {
+      // vm.SourceTextModule#createCachedData() promises a node Buffer; the
+      // QuickJS provider hands back a plain Uint8Array.
+      napi_value global = nullptr;
+      napi_value buffer_ctor = nullptr;
+      napi_value from_fn = nullptr;
+      napi_value wrapped = nullptr;
+      bool is_buffer = false;
+      if (napi_get_global(env, &global) == napi_ok && global != nullptr &&
+          napi_get_named_property(env, global, "Buffer", &buffer_ctor) == napi_ok &&
+          buffer_ctor != nullptr &&
+          napi_instanceof(env, out, buffer_ctor, &is_buffer) == napi_ok && !is_buffer &&
+          napi_get_named_property(env, buffer_ctor, "from", &from_fn) == napi_ok &&
+          from_fn != nullptr &&
+          napi_call_function(env, buffer_ctor, from_fn, 1, &out, &wrapped) == napi_ok &&
+          wrapped != nullptr) {
+        return wrapped;
+      }
       return out;
     }
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,9 @@ if(TARGET napi_v8 AND NAPI_V8_LIBRARY)
   add_edge_node_api_test(edge_test_6_binding_registry_phase04
     "${EDGE_ROOT}/tests/runners/test_6_binding_registry_phase04.cc"
   )
+  add_edge_node_api_test(edge_test_7_bytecode_cache_phase05
+    "${EDGE_ROOT}/tests/runners/test_7_bytecode_cache_phase05.cc"
+  )
 else()
   message(STATUS "Skipping edge node-api tests: napi_v8 runtime target/linkage is unavailable")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,9 @@ if(TARGET napi_v8 AND NAPI_V8_LIBRARY)
   add_edge_node_api_test(edge_test_7_bytecode_cache_phase05
     "${EDGE_ROOT}/tests/runners/test_7_bytecode_cache_phase05.cc"
   )
+  add_edge_node_api_test(edge_test_8_builtin_bytecode
+    "${EDGE_ROOT}/tests/runners/test_8_builtin_bytecode.cc"
+  )
 else()
   message(STATUS "Skipping edge node-api tests: napi_v8 runtime target/linkage is unavailable")
 endif()

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -132,84 +132,111 @@ TEST_F(Test7BytecodeCachePhase05, Hash64MatchesKnownVectors) {
   EXPECT_NE(edge_bytecode_cache::Hash64("abc", 3), edge_bytecode_cache::Hash64("abd", 3));
 }
 
+TEST_F(Test7BytecodeCachePhase05, VmCachedDataWrapperRoundTrip) {
+  const auto payload = SamplePayload();
+  const uint64_t source_hash = edge_bytecode_cache::Hash64(kSource, sizeof(kSource) - 1);
+  const auto wrapped =
+      edge_bytecode_cache::WrapVmCachedData(source_hash, payload.data(), payload.size());
+
+  size_t offset = 0;
+  size_t size = 0;
+  ASSERT_TRUE(edge_bytecode_cache::UnwrapVmCachedData(source_hash, wrapped.data(), wrapped.size(),
+                                                      &offset, &size));
+  ASSERT_EQ(size, payload.size());
+  EXPECT_EQ(std::vector<uint8_t>(wrapped.begin() + offset, wrapped.begin() + offset + size),
+            payload);
+
+#if defined(EDGE_NAPI_QUICKJS)
+  // QuickJS buffers carry the 12-byte source-hash prefix; a different source
+  // must be rejected before the bytes ever reach the engine.
+  EXPECT_EQ(wrapped.size(), payload.size() + 12);
+  EXPECT_FALSE(edge_bytecode_cache::UnwrapVmCachedData(source_hash + 1, wrapped.data(),
+                                                       wrapped.size(), &offset, &size));
+  auto corrupted = wrapped;
+  corrupted[0] ^= 0xff;  // magic
+  EXPECT_FALSE(edge_bytecode_cache::UnwrapVmCachedData(source_hash, corrupted.data(),
+                                                       corrupted.size(), &offset, &size));
+#else
+  // V8 cachedData stays raw engine bytes (CachedData self-validates);
+  // wrap/unwrap are pass-throughs and the hash is ignored.
+  EXPECT_EQ(wrapped, payload);
+  EXPECT_TRUE(edge_bytecode_cache::UnwrapVmCachedData(source_hash + 1, wrapped.data(),
+                                                      wrapped.size(), &offset, &size));
+#endif
+}
+
 TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
   const auto payload = SamplePayload();
   const auto encoded =
-      edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+      edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   size_t offset = 0;
   size_t size = 0;
   ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource,
-                                                 edge_bytecode_cache::kFlagCjsFunctionV1, 0, &offset, &size));
+                                                 edge_bytecode_cache::kFlagCjsFunctionV1, &offset, &size));
   ASSERT_EQ(size, payload.size());
   EXPECT_EQ(std::vector<uint8_t>(encoded.begin() + offset, encoded.begin() + offset + size), payload);
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadMagic) {
   const auto payload = SamplePayload();
-  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   encoded[0] ^= 0xff;
   size_t off = 0;
   size_t len = 0;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadFormatVersion) {
   const auto payload = SamplePayload();
-  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   encoded[8] ^= 0xff;
   size_t off = 0;
   size_t len = 0;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsWrongEngineTag) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   size_t off = 0;
   size_t len = 0;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                                   &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsSourceMismatch) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   size_t off = 0;
   size_t len = 0;
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag,
                                                   "module.exports = 43;\n",
-                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsTruncatedAndCorruptedPayload) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                          payload.data(), payload.size());
   size_t off = 0;
   size_t len = 0;
 
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
   EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
 
   auto corrupted = encoded;
   corrupted.back() ^= 0x01;
-#if defined(EDGE_NAPI_QUICKJS)
-  // QuickJS keeps a container-level payload hash (its reader is not hardened).
-  EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
-#else
-  // On V8 the engine self-validates payloads (CachedData::rejected), so the
-  // container accepts the flipped byte; end-to-end fallback is covered by the
-  // CorruptedAndStaleSidecarsFallBack spawn test.
+  // The container only pins structure (payload_len); payload integrity is the
+  // engine's job (V8 CachedData / the QuickJS provider's QJSB header), so a
+  // flipped payload byte passes container validation on both engines.
   EXPECT_TRUE(
-      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
-#endif
+      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, ShapeFlagsCrossRejected) {
@@ -218,35 +245,20 @@ TEST_F(Test7BytecodeCachePhase05, ShapeFlagsCrossRejected) {
   size_t len = 0;
 
   const auto cjs = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
-                                                      0, payload.data(), payload.size());
+                                                      payload.data(), payload.size());
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(cjs.data(), cjs.size(), kTag, kSource,
-                                                  edge_bytecode_cache::kFlagEsmModuleV1, 0, &off, &len));
+                                                  edge_bytecode_cache::kFlagEsmModuleV1, &off, &len));
 
   const auto esm = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagEsmModuleV1,
-                                                      0, payload.data(), payload.size());
+                                                      payload.data(), payload.size());
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
-                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
   EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
-                                                 edge_bytecode_cache::kFlagEsmModuleV1, 0, &off, &len));
+                                                 edge_bytecode_cache::kFlagEsmModuleV1, &off, &len));
   ASSERT_EQ(len, payload.size());
   EXPECT_EQ(std::vector<uint8_t>(esm.begin() + off, esm.begin() + off + len), payload);
 }
 
-TEST_F(Test7BytecodeCachePhase05, FilenameHashEnforcedOnlyWhenNonZero) {
-  const auto payload = SamplePayload();
-  size_t off = 0;
-  size_t len = 0;
-
-  const auto keyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234,
-                                         payload.data(), payload.size());
-  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234, &off, &len));
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &off, &len));
-
-  const auto unkeyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
-                                         payload.data(), payload.size());
-  EXPECT_TRUE(
-      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &off, &len));
-}
 
 TEST_F(Test7BytecodeCachePhase05, SidecarSuffixMatchesProvider) {
 #if defined(EDGE_BUNDLED_NAPI_V8)

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -1,0 +1,347 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <sys/wait.h>
+#endif
+
+#include "test_env.h"
+#include "edge_bytecode_cache.h"
+
+class Test7BytecodeCachePhase05 : public FixtureTestBase {};
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char kTag[] = "v8-test-tag";
+constexpr const char kSource[] = "module.exports = 42;\n";
+
+std::vector<uint8_t> SamplePayload() {
+  return {0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03};
+}
+
+std::filesystem::path ResolveBuiltEdgeBinary() {
+  const fs::path cwd = fs::current_path();
+  const std::vector<fs::path> candidates = {
+      cwd / "edge",
+      cwd / "build-edge" / "edge",
+      cwd / "build" / "edge",
+      cwd.parent_path() / "edge",
+      cwd.parent_path() / "build-edge" / "edge",
+      cwd.parent_path() / "build" / "edge",
+  };
+  for (const auto& candidate : candidates) {
+    std::error_code ec;
+    if (!fs::exists(candidate, ec) || ec) continue;
+    if (fs::is_directory(candidate, ec) || ec) continue;
+    return fs::absolute(candidate).lexically_normal();
+  }
+  return {};
+}
+
+std::string ShellSingleQuoted(const std::string& input) {
+  std::string out;
+  out.reserve(input.size() + 2);
+  out.push_back('\'');
+  for (char c : input) {
+    if (c == '\'') {
+      out += "'\\''";
+    } else {
+      out.push_back(c);
+    }
+  }
+  out.push_back('\'');
+  return out;
+}
+
+struct CommandResult {
+  int exit_code = -1;
+  std::string stdout_output;
+  std::string stderr_output;
+};
+
+CommandResult RunEdge(const fs::path& binary,
+                      const std::vector<std::string>& args,
+                      const fs::path& temp_root,
+                      const std::string& env_prefix = "") {
+  const fs::path stdout_path = temp_root / "cmd_stdout.txt";
+  const fs::path stderr_path = temp_root / "cmd_stderr.txt";
+
+  std::string cmd = env_prefix;
+  if (!cmd.empty()) cmd.push_back(' ');
+  cmd += ShellSingleQuoted(binary.string());
+  for (const auto& arg : args) {
+    cmd.push_back(' ');
+    cmd += ShellSingleQuoted(arg);
+  }
+  cmd += " >" + ShellSingleQuoted(stdout_path.string()) + " 2>" + ShellSingleQuoted(stderr_path.string());
+
+  CommandResult result;
+  const int status = std::system(cmd.c_str());
+#if !defined(_WIN32)
+  if (status != -1 && WIFEXITED(status)) result.exit_code = WEXITSTATUS(status);
+#else
+  result.exit_code = status;
+#endif
+  std::ifstream stdout_in(stdout_path);
+  result.stdout_output.assign(std::istreambuf_iterator<char>(stdout_in), std::istreambuf_iterator<char>());
+  std::ifstream stderr_in(stderr_path);
+  result.stderr_output.assign(std::istreambuf_iterator<char>(stderr_in), std::istreambuf_iterator<char>());
+  return result;
+}
+
+class TempProjectDir {
+ public:
+  explicit TempProjectDir(const std::string& stem) {
+    root_ = fs::temp_directory_path() / (stem + "_" + std::to_string(static_cast<unsigned long long>(
+                                                          std::hash<std::string>{}(stem))));
+    std::error_code ec;
+    fs::remove_all(root_, ec);
+    fs::create_directories(root_, ec);
+  }
+  ~TempProjectDir() {
+    std::error_code ec;
+    fs::remove_all(root_, ec);
+  }
+  const fs::path& root() const { return root_; }
+  fs::path Write(const std::string& relative, const std::string& contents) const {
+    const fs::path path = root_ / relative;
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    std::ofstream out(path, std::ios::binary);
+    out << contents;
+    return path;
+  }
+
+ private:
+  fs::path root_;
+};
+
+}  // namespace
+
+TEST_F(Test7BytecodeCachePhase05, Fnv1a64MatchesKnownVectors) {
+  EXPECT_EQ(edge_bytecode_cache::Fnv1a64("", 0), 0xcbf29ce484222325ull);
+  EXPECT_EQ(edge_bytecode_cache::Fnv1a64("a", 1), 0xaf63dc4c8601ec8cull);
+}
+
+TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
+  const auto payload = SamplePayload();
+  const auto encoded =
+      edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  std::vector<uint8_t> decoded;
+  ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+  EXPECT_EQ(decoded, payload);
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadMagic) {
+  const auto payload = SamplePayload();
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  encoded[0] ^= 0xff;
+  std::vector<uint8_t> decoded;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadFormatVersion) {
+  const auto payload = SamplePayload();
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  encoded[8] ^= 0xff;
+  std::vector<uint8_t> decoded;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsWrongEngineTag) {
+  const auto payload = SamplePayload();
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  std::vector<uint8_t> decoded;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, 0,
+                                                  &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsSourceMismatch) {
+  const auto payload = SamplePayload();
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  std::vector<uint8_t> decoded;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag,
+                                                  "module.exports = 43;\n", 0, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsTruncatedAndCorruptedPayload) {
+  const auto payload = SamplePayload();
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  std::vector<uint8_t> decoded;
+
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, 0, &decoded));
+  EXPECT_FALSE(
+      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, 0, &decoded));
+
+  auto corrupted = encoded;
+  corrupted.back() ^= 0x01;
+  EXPECT_FALSE(
+      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, 0, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, FilenameHashEnforcedOnlyWhenNonZero) {
+  const auto payload = SamplePayload();
+  std::vector<uint8_t> decoded;
+
+  const auto keyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 1234, payload.data(), payload.size());
+  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, 1234, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, 5678, &decoded));
+
+  const auto unkeyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  EXPECT_TRUE(
+      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, 5678, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, SidecarSuffixMatchesProvider) {
+#if defined(EDGE_BUNDLED_NAPI_V8)
+  EXPECT_STREQ(edge_bytecode_cache::SidecarSuffix(), ".v8b");
+#elif defined(EDGE_NAPI_QUICKJS)
+  EXPECT_STREQ(edge_bytecode_cache::SidecarSuffix(), ".qjsb");
+#else
+  GTEST_SKIP() << "no bundled engine";
+#endif
+}
+
+#if !defined(_WIN32)
+
+TEST_F(Test7BytecodeCachePhase05, WriteOnFirstRunThenConsume) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_first_run");
+  project.Write("lib.js", "module.exports = { value: 21 };\n");
+  const fs::path main_path =
+      project.Write("main.js", "const lib = require('./lib.js');\nconsole.log(lib.value * 2);\n");
+  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+
+  auto disabled = RunEdge(edge_path, {"--no-bytecode-cache", main_path.string()}, project.root());
+  EXPECT_EQ(disabled.exit_code, 0) << disabled.stderr_output;
+  EXPECT_EQ(disabled.stdout_output, "42\n");
+  EXPECT_FALSE(fs::exists(sidecar)) << "--no-bytecode-cache must not write sidecars";
+
+  auto first = RunEdge(edge_path, {main_path.string()}, project.root(),
+                       "EDGE_BYTECODE_CACHE_TRACE=1");
+  EXPECT_EQ(first.exit_code, 0) << first.stderr_output;
+  EXPECT_EQ(first.stdout_output, "42\n");
+  EXPECT_TRUE(fs::exists(sidecar)) << "first run should write a sidecar; stderr=" << first.stderr_output;
+  EXPECT_NE(first.stderr_output.find("write"), std::string::npos) << first.stderr_output;
+
+  auto second = RunEdge(edge_path, {main_path.string()}, project.root(),
+                        "EDGE_BYTECODE_CACHE_TRACE=1");
+  EXPECT_EQ(second.exit_code, 0) << second.stderr_output;
+  EXPECT_EQ(second.stdout_output, "42\n");
+  EXPECT_NE(second.stderr_output.find("hit"), std::string::npos)
+      << "second run should consume the sidecar; stderr=" << second.stderr_output;
+}
+
+TEST_F(Test7BytecodeCachePhase05, PrecompileWritesSidecarsWithoutExecuting) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_precompile");
+  project.Write("side_effect.js", "process.exitCode = 3; console.log('EXECUTED');\n");
+  const fs::path main_path = project.Write("main.js", "console.log('ok');\n");
+
+  auto precompiled = RunEdge(edge_path, {"--precompile", project.root().string()}, project.root());
+  EXPECT_EQ(precompiled.exit_code, 0) << precompiled.stderr_output;
+  EXPECT_EQ(precompiled.stdout_output.find("EXECUTED"), std::string::npos)
+      << "--precompile must not execute module bodies";
+
+  const std::string suffix = edge_bytecode_cache::SidecarSuffix();
+  EXPECT_TRUE(fs::exists(fs::path(main_path.string() + suffix)));
+  EXPECT_TRUE(fs::exists(project.root() / ("side_effect.js" + suffix)));
+
+  auto run = RunEdge(edge_path, {main_path.string()}, project.root(), "EDGE_BYTECODE_CACHE_TRACE=1");
+  EXPECT_EQ(run.exit_code, 0) << run.stderr_output;
+  EXPECT_EQ(run.stdout_output, "ok\n");
+  EXPECT_NE(run.stderr_output.find("hit"), std::string::npos) << run.stderr_output;
+}
+
+TEST_F(Test7BytecodeCachePhase05, CorruptedAndStaleSidecarsFallBack) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_corrupt");
+  const fs::path main_path = project.Write("main.js", "console.log('first');\n");
+  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+
+  auto first = RunEdge(edge_path, {main_path.string()}, project.root());
+  ASSERT_EQ(first.exit_code, 0) << first.stderr_output;
+  ASSERT_TRUE(fs::exists(sidecar));
+
+  // Corrupt the payload: flip the last byte.
+  {
+    std::fstream f(sidecar, std::ios::binary | std::ios::in | std::ios::out);
+    f.seekg(0, std::ios::end);
+    const auto size = static_cast<long long>(f.tellg());
+    ASSERT_GT(size, 0);
+    f.seekg(size - 1);
+    char last = 0;
+    f.read(&last, 1);
+    last = static_cast<char>(last ^ 0x01);
+    f.seekp(size - 1);
+    f.write(&last, 1);
+  }
+  auto corrupted = RunEdge(edge_path, {main_path.string()}, project.root());
+  EXPECT_EQ(corrupted.exit_code, 0) << corrupted.stderr_output;
+  EXPECT_EQ(corrupted.stdout_output, "first\n") << "corrupted sidecar must fall back to source";
+
+  // Stale: edit the source, leave the (now mismatched) sidecar in place.
+  project.Write("main.js", "console.log('second');\n");
+  auto stale = RunEdge(edge_path, {main_path.string()}, project.root());
+  EXPECT_EQ(stale.exit_code, 0) << stale.stderr_output;
+  EXPECT_EQ(stale.stdout_output, "second\n") << "stale sidecar must fall back to the new source";
+}
+
+TEST_F(Test7BytecodeCachePhase05, CheckModeWritesNoSidecars) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_check");
+  const fs::path main_path = project.Write("main.js", "console.log('never');\n");
+  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+
+  auto checked = RunEdge(edge_path, {"--check", main_path.string()}, project.root());
+  EXPECT_EQ(checked.exit_code, 0) << checked.stderr_output;
+  EXPECT_FALSE(fs::exists(sidecar)) << "--check must not write sidecars";
+}
+
+TEST_F(Test7BytecodeCachePhase05, PrecompileConflictsAndValidation) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_conflicts");
+
+  auto no_paths = RunEdge(edge_path, {"--precompile"}, project.root());
+  EXPECT_EQ(no_paths.exit_code, 9) << no_paths.stderr_output;
+
+  auto with_check = RunEdge(edge_path, {"--precompile", "--check", "x.js"}, project.root());
+  EXPECT_EQ(with_check.exit_code, 9) << with_check.stderr_output;
+
+  auto with_disable =
+      RunEdge(edge_path, {"--precompile", "--no-bytecode-cache", project.root().string()}, project.root());
+  EXPECT_EQ(with_disable.exit_code, 9) << with_disable.stderr_output;
+}
+
+TEST_F(Test7BytecodeCachePhase05, EsmSyntaxFilesAreSkippedNotFailed) {
+  const auto edge_path = ResolveBuiltEdgeBinary();
+  ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
+
+  TempProjectDir project("edge_bytecode_cache_esm");
+  project.Write("esm.js", "export const x = 1;\n");
+  project.Write("ok.js", "module.exports = 1;\n");
+
+  auto result = RunEdge(edge_path, {"--precompile", project.root().string()}, project.root());
+  EXPECT_EQ(result.exit_code, 0) << result.stderr_output;
+  const std::string suffix = edge_bytecode_cache::SidecarSuffix();
+  EXPECT_TRUE(fs::exists(project.root() / ("ok.js" + suffix)));
+  EXPECT_FALSE(fs::exists(project.root() / ("esm.js" + suffix)));
+}
+
+#endif  // !defined(_WIN32)

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -124,9 +124,12 @@ class TempProjectDir {
 
 }  // namespace
 
-TEST_F(Test7BytecodeCachePhase05, Fnv1a64MatchesKnownVectors) {
-  EXPECT_EQ(edge_bytecode_cache::Fnv1a64("", 0), 0xcbf29ce484222325ull);
-  EXPECT_EQ(edge_bytecode_cache::Fnv1a64("a", 1), 0xaf63dc4c8601ec8cull);
+TEST_F(Test7BytecodeCachePhase05, Hash64MatchesKnownVectors) {
+  // XXH3-64 reference vectors.
+  EXPECT_EQ(edge_bytecode_cache::Hash64("", 0), 0x2D06800538D394C2ull);
+  // Determinism + sensitivity.
+  EXPECT_EQ(edge_bytecode_cache::Hash64("abc", 3), edge_bytecode_cache::Hash64("abc", 3));
+  EXPECT_NE(edge_bytecode_cache::Hash64("abc", 3), edge_bytecode_cache::Hash64("abd", 3));
 }
 
 TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
@@ -134,9 +137,12 @@ TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
   const auto encoded =
       edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
-  std::vector<uint8_t> decoded;
-  ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
-  EXPECT_EQ(decoded, payload);
+  size_t offset = 0;
+  size_t size = 0;
+  ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource,
+                                                 edge_bytecode_cache::kFlagCjsFunctionV1, 0, &offset, &size));
+  ASSERT_EQ(size, payload.size());
+  EXPECT_EQ(std::vector<uint8_t>(encoded.begin() + offset, encoded.begin() + offset + size), payload);
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadMagic) {
@@ -144,8 +150,9 @@ TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadMagic) {
   auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
   encoded[0] ^= 0xff;
-  std::vector<uint8_t> decoded;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+  size_t off = 0;
+  size_t len = 0;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadFormatVersion) {
@@ -153,76 +160,92 @@ TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadFormatVersion) {
   auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
   encoded[8] ^= 0xff;
-  std::vector<uint8_t> decoded;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+  size_t off = 0;
+  size_t len = 0;
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsWrongEngineTag) {
   const auto payload = SamplePayload();
   const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
-  std::vector<uint8_t> decoded;
+  size_t off = 0;
+  size_t len = 0;
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
-                                                  &decoded));
+                                                  &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsSourceMismatch) {
   const auto payload = SamplePayload();
   const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
-  std::vector<uint8_t> decoded;
+  size_t off = 0;
+  size_t len = 0;
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag,
                                                   "module.exports = 43;\n",
-                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsTruncatedAndCorruptedPayload) {
   const auto payload = SamplePayload();
   const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
-  std::vector<uint8_t> decoded;
+  size_t off = 0;
+  size_t len = 0;
 
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
   EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
 
   auto corrupted = encoded;
   corrupted.back() ^= 0x01;
+#if defined(EDGE_NAPI_QUICKJS)
+  // QuickJS keeps a container-level payload hash (its reader is not hardened).
   EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+#else
+  // On V8 the engine self-validates payloads (CachedData::rejected), so the
+  // container accepts the flipped byte; end-to-end fallback is covered by the
+  // CorruptedAndStaleSidecarsFallBack spawn test.
+  EXPECT_TRUE(
+      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
+#endif
 }
 
 TEST_F(Test7BytecodeCachePhase05, ShapeFlagsCrossRejected) {
   const auto payload = SamplePayload();
-  std::vector<uint8_t> decoded;
+  size_t off = 0;
+  size_t len = 0;
 
   const auto cjs = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
                                                       0, payload.data(), payload.size());
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(cjs.data(), cjs.size(), kTag, kSource,
-                                                  edge_bytecode_cache::kFlagEsmModuleV1, 0, &decoded));
+                                                  edge_bytecode_cache::kFlagEsmModuleV1, 0, &off, &len));
 
   const auto esm = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagEsmModuleV1,
                                                       0, payload.data(), payload.size());
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
-                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &off, &len));
   EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
-                                                 edge_bytecode_cache::kFlagEsmModuleV1, 0, &decoded));
-  EXPECT_EQ(decoded, payload);
+                                                 edge_bytecode_cache::kFlagEsmModuleV1, 0, &off, &len));
+  ASSERT_EQ(len, payload.size());
+  EXPECT_EQ(std::vector<uint8_t>(esm.begin() + off, esm.begin() + off + len), payload);
 }
 
 TEST_F(Test7BytecodeCachePhase05, FilenameHashEnforcedOnlyWhenNonZero) {
   const auto payload = SamplePayload();
-  std::vector<uint8_t> decoded;
+  size_t off = 0;
+  size_t len = 0;
 
   const auto keyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234,
                                          payload.data(), payload.size());
-  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234, &decoded));
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &decoded));
+  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234, &off, &len));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &off, &len));
 
   const auto unkeyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                          payload.data(), payload.size());
   EXPECT_TRUE(
-      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &decoded));
+      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, SidecarSuffixMatchesProvider) {

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -132,70 +132,97 @@ TEST_F(Test7BytecodeCachePhase05, Fnv1a64MatchesKnownVectors) {
 TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
   const auto payload = SamplePayload();
   const auto encoded =
-      edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+      edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   std::vector<uint8_t> decoded;
-  ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+  ASSERT_TRUE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
   EXPECT_EQ(decoded, payload);
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadMagic) {
   const auto payload = SamplePayload();
-  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   encoded[0] ^= 0xff;
   std::vector<uint8_t> decoded;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsBadFormatVersion) {
   const auto payload = SamplePayload();
-  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   encoded[8] ^= 0xff;
   std::vector<uint8_t> decoded;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, 0, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsWrongEngineTag) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   std::vector<uint8_t> decoded;
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, 0,
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), "v8-other-tag", kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
                                                   &decoded));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsSourceMismatch) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   std::vector<uint8_t> decoded;
   EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size(), kTag,
-                                                  "module.exports = 43;\n", 0, &decoded));
+                                                  "module.exports = 43;\n",
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
 }
 
 TEST_F(Test7BytecodeCachePhase05, DecodeRejectsTruncatedAndCorruptedPayload) {
   const auto payload = SamplePayload();
-  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  const auto encoded = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   std::vector<uint8_t> decoded;
 
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, 0, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(encoded.data(), 16, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
   EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, 0, &decoded));
+      edge_bytecode_cache::DecodeSidecar(encoded.data(), encoded.size() - 1, kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
 
   auto corrupted = encoded;
   corrupted.back() ^= 0x01;
   EXPECT_FALSE(
-      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, 0, &decoded));
+      edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+}
+
+TEST_F(Test7BytecodeCachePhase05, ShapeFlagsCrossRejected) {
+  const auto payload = SamplePayload();
+  std::vector<uint8_t> decoded;
+
+  const auto cjs = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
+                                                      0, payload.data(), payload.size());
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(cjs.data(), cjs.size(), kTag, kSource,
+                                                  edge_bytecode_cache::kFlagEsmModuleV1, 0, &decoded));
+
+  const auto esm = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagEsmModuleV1,
+                                                      0, payload.data(), payload.size());
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, 0, &decoded));
+  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(esm.data(), esm.size(), kTag, kSource,
+                                                 edge_bytecode_cache::kFlagEsmModuleV1, 0, &decoded));
+  EXPECT_EQ(decoded, payload);
 }
 
 TEST_F(Test7BytecodeCachePhase05, FilenameHashEnforcedOnlyWhenNonZero) {
   const auto payload = SamplePayload();
   std::vector<uint8_t> decoded;
 
-  const auto keyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 1234, payload.data(), payload.size());
-  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, 1234, &decoded));
-  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, 5678, &decoded));
+  const auto keyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234,
+                                         payload.data(), payload.size());
+  EXPECT_TRUE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 1234, &decoded));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(keyed.data(), keyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &decoded));
 
-  const auto unkeyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, 0, payload.data(), payload.size());
+  const auto unkeyed = edge_bytecode_cache::EncodeSidecar(kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 0,
+                                         payload.data(), payload.size());
   EXPECT_TRUE(
-      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, 5678, &decoded));
+      edge_bytecode_cache::DecodeSidecar(unkeyed.data(), unkeyed.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, 5678, &decoded));
 }
 
 TEST_F(Test7BytecodeCachePhase05, SidecarSuffixMatchesProvider) {
@@ -329,19 +356,22 @@ TEST_F(Test7BytecodeCachePhase05, PrecompileConflictsAndValidation) {
   EXPECT_EQ(with_disable.exit_code, 9) << with_disable.stderr_output;
 }
 
-TEST_F(Test7BytecodeCachePhase05, EsmSyntaxFilesAreSkippedNotFailed) {
+TEST_F(Test7BytecodeCachePhase05, EsmSyntaxFilesGetModuleShapeSidecars) {
   const auto edge_path = ResolveBuiltEdgeBinary();
   ASSERT_FALSE(edge_path.empty()) << "Failed to resolve built edge binary";
 
   TempProjectDir project("edge_bytecode_cache_esm");
   project.Write("esm.js", "export const x = 1;\n");
   project.Write("ok.js", "module.exports = 1;\n");
+  project.Write("mod.mjs", "export const y = 2;\n");
 
   auto result = RunEdge(edge_path, {"--precompile", project.root().string()}, project.root());
   EXPECT_EQ(result.exit_code, 0) << result.stderr_output;
   const std::string suffix = edge_bytecode_cache::SidecarSuffix();
   EXPECT_TRUE(fs::exists(project.root() / ("ok.js" + suffix)));
-  EXPECT_FALSE(fs::exists(project.root() / ("esm.js" + suffix)));
+  EXPECT_TRUE(fs::exists(project.root() / ("esm.js" + suffix)))
+      << "ESM-syntax .js should be precompiled with the module shape";
+  EXPECT_TRUE(fs::exists(project.root() / ("mod.mjs" + suffix)));
 }
 
 #endif  // !defined(_WIN32)

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -270,6 +270,39 @@ TEST_F(Test7BytecodeCachePhase05, SidecarSuffixMatchesProvider) {
 #endif
 }
 
+TEST_F(Test7BytecodeCachePhase05, SidecarPathUsesEdgecacheSubdirKeepingFullFilename) {
+  const std::string& tag = edge_bytecode_cache::EngineFileTag();
+  if (tag.empty()) GTEST_SKIP() << "no bundled engine";
+
+  // The short file tag is "<engine>-<major>-<minor>" — no dots, so it stays a
+  // single clean filename component (e.g. v8-13-6 / qjs-0-14).
+  EXPECT_EQ(tag.find('.'), std::string::npos) << tag;
+#if defined(EDGE_BUNDLED_NAPI_V8)
+  EXPECT_EQ(tag.rfind("v8-", 0), 0u) << tag;
+#elif defined(EDGE_NAPI_QUICKJS)
+  EXPECT_EQ(tag.rfind("qjs-", 0), 0u) << tag;
+#endif
+
+  const std::string path = edge_bytecode_cache::SidecarPathForSource("/foo/bar/app.js");
+  // Caches go in a per-directory __edgecache__ subdir, keyed by the full source
+  // filename (extension included) + the short engine tag.
+  EXPECT_NE(path.find("/foo/bar/__edgecache__/"), std::string::npos) << path;
+  EXPECT_EQ(path, "/foo/bar/__edgecache__/app.js." + tag + ".jsc");
+
+  // The full filename keys the entry, so ".js"/".mjs" siblings never collide.
+  EXPECT_NE(edge_bytecode_cache::SidecarPathForSource("/x/app.js"),
+            edge_bytecode_cache::SidecarPathForSource("/x/app.mjs"));
+  EXPECT_EQ(edge_bytecode_cache::SidecarPathForSource("/x/app.mjs"),
+            "/x/__edgecache__/app.mjs." + tag + ".jsc");
+
+  // A relative/bare source keeps the cache next to it (empty parent dir).
+  EXPECT_EQ(edge_bytecode_cache::SidecarPathForSource("main.mjs"),
+            "__edgecache__/main.mjs." + tag + ".jsc");
+  // Compound names keep every component.
+  EXPECT_EQ(edge_bytecode_cache::SidecarPathForSource("/x/a.test.js"),
+            "/x/__edgecache__/a.test.js." + tag + ".jsc");
+}
+
 #if !defined(_WIN32)
 
 TEST_F(Test7BytecodeCachePhase05, WriteOnFirstRunThenConsume) {
@@ -280,21 +313,21 @@ TEST_F(Test7BytecodeCachePhase05, WriteOnFirstRunThenConsume) {
   project.Write("lib.js", "module.exports = { value: 21 };\n");
   const fs::path main_path =
       project.Write("main.js", "const lib = require('./lib.js');\nconsole.log(lib.value * 2);\n");
-  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+  const fs::path sidecar = edge_bytecode_cache::SidecarPathForSource(main_path.string());
 
   auto disabled = RunEdge(edge_path, {"--no-bytecode-cache", main_path.string()}, project.root());
   EXPECT_EQ(disabled.exit_code, 0) << disabled.stderr_output;
   EXPECT_EQ(disabled.stdout_output, "42\n");
   EXPECT_FALSE(fs::exists(sidecar)) << "--no-bytecode-cache must not write sidecars";
 
-  auto first = RunEdge(edge_path, {main_path.string()}, project.root(),
+  auto first = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root(),
                        "EDGE_BYTECODE_CACHE_TRACE=1");
   EXPECT_EQ(first.exit_code, 0) << first.stderr_output;
   EXPECT_EQ(first.stdout_output, "42\n");
   EXPECT_TRUE(fs::exists(sidecar)) << "first run should write a sidecar; stderr=" << first.stderr_output;
   EXPECT_NE(first.stderr_output.find("write"), std::string::npos) << first.stderr_output;
 
-  auto second = RunEdge(edge_path, {main_path.string()}, project.root(),
+  auto second = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root(),
                         "EDGE_BYTECODE_CACHE_TRACE=1");
   EXPECT_EQ(second.exit_code, 0) << second.stderr_output;
   EXPECT_EQ(second.stdout_output, "42\n");
@@ -315,11 +348,11 @@ TEST_F(Test7BytecodeCachePhase05, PrecompileWritesSidecarsWithoutExecuting) {
   EXPECT_EQ(precompiled.stdout_output.find("EXECUTED"), std::string::npos)
       << "--precompile must not execute module bodies";
 
-  const std::string suffix = edge_bytecode_cache::SidecarSuffix();
-  EXPECT_TRUE(fs::exists(fs::path(main_path.string() + suffix)));
-  EXPECT_TRUE(fs::exists(project.root() / ("side_effect.js" + suffix)));
+  EXPECT_TRUE(fs::exists(edge_bytecode_cache::SidecarPathForSource(main_path.string())));
+  EXPECT_TRUE(fs::exists(edge_bytecode_cache::SidecarPathForSource(
+      (project.root() / "side_effect.js").string())));
 
-  auto run = RunEdge(edge_path, {main_path.string()}, project.root(), "EDGE_BYTECODE_CACHE_TRACE=1");
+  auto run = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root(), "EDGE_BYTECODE_CACHE_TRACE=1");
   EXPECT_EQ(run.exit_code, 0) << run.stderr_output;
   EXPECT_EQ(run.stdout_output, "ok\n");
   EXPECT_NE(run.stderr_output.find("hit"), std::string::npos) << run.stderr_output;
@@ -331,9 +364,9 @@ TEST_F(Test7BytecodeCachePhase05, CorruptedAndStaleSidecarsFallBack) {
 
   TempProjectDir project("edge_bytecode_cache_corrupt");
   const fs::path main_path = project.Write("main.js", "console.log('first');\n");
-  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+  const fs::path sidecar = edge_bytecode_cache::SidecarPathForSource(main_path.string());
 
-  auto first = RunEdge(edge_path, {main_path.string()}, project.root());
+  auto first = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root());
   ASSERT_EQ(first.exit_code, 0) << first.stderr_output;
   ASSERT_TRUE(fs::exists(sidecar));
 
@@ -350,13 +383,13 @@ TEST_F(Test7BytecodeCachePhase05, CorruptedAndStaleSidecarsFallBack) {
     f.seekp(size - 1);
     f.write(&last, 1);
   }
-  auto corrupted = RunEdge(edge_path, {main_path.string()}, project.root());
+  auto corrupted = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root());
   EXPECT_EQ(corrupted.exit_code, 0) << corrupted.stderr_output;
   EXPECT_EQ(corrupted.stdout_output, "first\n") << "corrupted sidecar must fall back to source";
 
   // Stale: edit the source, leave the (now mismatched) sidecar in place.
   project.Write("main.js", "console.log('second');\n");
-  auto stale = RunEdge(edge_path, {main_path.string()}, project.root());
+  auto stale = RunEdge(edge_path, {"--bytecode-cache", main_path.string()}, project.root());
   EXPECT_EQ(stale.exit_code, 0) << stale.stderr_output;
   EXPECT_EQ(stale.stdout_output, "second\n") << "stale sidecar must fall back to the new source";
 }
@@ -367,7 +400,7 @@ TEST_F(Test7BytecodeCachePhase05, CheckModeWritesNoSidecars) {
 
   TempProjectDir project("edge_bytecode_cache_check");
   const fs::path main_path = project.Write("main.js", "console.log('never');\n");
-  const fs::path sidecar = fs::path(main_path.string() + edge_bytecode_cache::SidecarSuffix());
+  const fs::path sidecar = edge_bytecode_cache::SidecarPathForSource(main_path.string());
 
   auto checked = RunEdge(edge_path, {"--check", main_path.string()}, project.root());
   EXPECT_EQ(checked.exit_code, 0) << checked.stderr_output;
@@ -402,11 +435,13 @@ TEST_F(Test7BytecodeCachePhase05, EsmSyntaxFilesGetModuleShapeSidecars) {
 
   auto result = RunEdge(edge_path, {"--precompile", project.root().string()}, project.root());
   EXPECT_EQ(result.exit_code, 0) << result.stderr_output;
-  const std::string suffix = edge_bytecode_cache::SidecarSuffix();
-  EXPECT_TRUE(fs::exists(project.root() / ("ok.js" + suffix)));
-  EXPECT_TRUE(fs::exists(project.root() / ("esm.js" + suffix)))
+  EXPECT_TRUE(fs::exists(
+      edge_bytecode_cache::SidecarPathForSource((project.root() / "ok.js").string())));
+  EXPECT_TRUE(fs::exists(
+      edge_bytecode_cache::SidecarPathForSource((project.root() / "esm.js").string())))
       << "ESM-syntax .js should be precompiled with the module shape";
-  EXPECT_TRUE(fs::exists(project.root() / ("mod.mjs" + suffix)));
+  EXPECT_TRUE(fs::exists(
+      edge_bytecode_cache::SidecarPathForSource((project.root() / "mod.mjs").string())));
 }
 
 #endif  // !defined(_WIN32)

--- a/tests/runners/test_7_bytecode_cache_phase05.cc
+++ b/tests/runners/test_7_bytecode_cache_phase05.cc
@@ -132,39 +132,6 @@ TEST_F(Test7BytecodeCachePhase05, Hash64MatchesKnownVectors) {
   EXPECT_NE(edge_bytecode_cache::Hash64("abc", 3), edge_bytecode_cache::Hash64("abd", 3));
 }
 
-TEST_F(Test7BytecodeCachePhase05, VmCachedDataWrapperRoundTrip) {
-  const auto payload = SamplePayload();
-  const uint64_t source_hash = edge_bytecode_cache::Hash64(kSource, sizeof(kSource) - 1);
-  const auto wrapped =
-      edge_bytecode_cache::WrapVmCachedData(source_hash, payload.data(), payload.size());
-
-  size_t offset = 0;
-  size_t size = 0;
-  ASSERT_TRUE(edge_bytecode_cache::UnwrapVmCachedData(source_hash, wrapped.data(), wrapped.size(),
-                                                      &offset, &size));
-  ASSERT_EQ(size, payload.size());
-  EXPECT_EQ(std::vector<uint8_t>(wrapped.begin() + offset, wrapped.begin() + offset + size),
-            payload);
-
-#if defined(EDGE_NAPI_QUICKJS)
-  // QuickJS buffers carry the 12-byte source-hash prefix; a different source
-  // must be rejected before the bytes ever reach the engine.
-  EXPECT_EQ(wrapped.size(), payload.size() + 12);
-  EXPECT_FALSE(edge_bytecode_cache::UnwrapVmCachedData(source_hash + 1, wrapped.data(),
-                                                       wrapped.size(), &offset, &size));
-  auto corrupted = wrapped;
-  corrupted[0] ^= 0xff;  // magic
-  EXPECT_FALSE(edge_bytecode_cache::UnwrapVmCachedData(source_hash, corrupted.data(),
-                                                       corrupted.size(), &offset, &size));
-#else
-  // V8 cachedData stays raw engine bytes (CachedData self-validates);
-  // wrap/unwrap are pass-throughs and the hash is ignored.
-  EXPECT_EQ(wrapped, payload);
-  EXPECT_TRUE(edge_bytecode_cache::UnwrapVmCachedData(source_hash + 1, wrapped.data(),
-                                                      wrapped.size(), &offset, &size));
-#endif
-}
-
 TEST_F(Test7BytecodeCachePhase05, EncodeDecodeRoundTrip) {
   const auto payload = SamplePayload();
   const auto encoded =
@@ -237,6 +204,39 @@ TEST_F(Test7BytecodeCachePhase05, DecodeRejectsTruncatedAndCorruptedPayload) {
   // flipped payload byte passes container validation on both engines.
   EXPECT_TRUE(
       edge_bytecode_cache::DecodeSidecar(corrupted.data(), corrupted.size(), kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
+}
+
+TEST_F(Test7BytecodeCachePhase05, DecodeRejectsLengthFieldOverflow) {
+  // A crafted header whose payload_len/tag_len fields would overflow the
+  // additive structural check must be rejected without reading out of bounds.
+  const auto payload = SamplePayload();
+  const auto base = edge_bytecode_cache::EncodeSidecar(
+      kTag, kSource, edge_bytecode_cache::kFlagCjsFunctionV1, payload.data(), payload.size());
+  size_t off = 0;
+  size_t len = 0;
+
+  auto put_u64 = [](std::vector<uint8_t>* buf, size_t pos, uint64_t value) {
+    for (int i = 0; i < 8; ++i) (*buf)[pos + i] = static_cast<uint8_t>(value >> (8 * i));
+  };
+  auto put_u32 = [](std::vector<uint8_t>* buf, size_t pos, uint32_t value) {
+    for (int i = 0; i < 4; ++i) (*buf)[pos + i] = static_cast<uint8_t>(value >> (8 * i));
+  };
+
+  // payload_len (offset 32) set so kHeaderSize + tag_len + payload_len wraps
+  // back to the real size; the additive check must still reject it.
+  auto bad_payload_len = base;
+  put_u64(&bad_payload_len, 32, ~static_cast<uint64_t>(0));
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(bad_payload_len.data(), bad_payload_len.size(),
+                                                  kTag, kSource,
+                                                  edge_bytecode_cache::kFlagCjsFunctionV1, &off, &len));
+
+  // tag_len (offset 40) larger than the buffer must reject before the tag
+  // memcmp reads out of bounds.
+  auto bad_tag_len = base;
+  put_u32(&bad_tag_len, 40, 0xFFFFFFFFu);
+  EXPECT_FALSE(edge_bytecode_cache::DecodeSidecar(bad_tag_len.data(), bad_tag_len.size(), kTag,
+                                                  kSource, edge_bytecode_cache::kFlagCjsFunctionV1,
+                                                  &off, &len));
 }
 
 TEST_F(Test7BytecodeCachePhase05, ShapeFlagsCrossRejected) {

--- a/tests/runners/test_8_builtin_bytecode.cc
+++ b/tests/runners/test_8_builtin_bytecode.cc
@@ -1,0 +1,138 @@
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "edge_builtin_bytecode.h"
+#include "edge_bytecode_cache.h"
+
+class Test8BuiltinBytecode : public FixtureTestBase {};
+
+namespace {
+
+constexpr const char kTag[] = "v8-test-tag";
+
+std::vector<edge_builtin_bytecode::FileEntry> SampleEntries() {
+  std::vector<edge_builtin_bytecode::FileEntry> entries;
+  {
+    edge_builtin_bytecode::FileEntry entry;
+    entry.kind = edge_builtin_bytecode::Kind::kFnLazyBuiltin;
+    entry.id = "fs";
+    entry.source_hash = 0x1111111111111111ull;
+    entry.payload = {0x01, 0x02, 0x03, 0x04};
+    entries.push_back(entry);
+  }
+  {
+    edge_builtin_bytecode::FileEntry entry;
+    entry.kind = edge_builtin_bytecode::Kind::kFnBootstrapRealm;
+    entry.id = "internal/bootstrap/realm";
+    entry.source_hash = 0x2222222222222222ull;
+    entry.payload = {0xaa};
+    entries.push_back(entry);
+  }
+  {
+    edge_builtin_bytecode::FileEntry entry;
+    entry.kind = edge_builtin_bytecode::Kind::kWrapperStandard;
+    entry.id = "internal/util";
+    entry.source_hash = 0x3333333333333333ull;
+    entry.payload = {0xde, 0xad, 0xbe, 0xef, 0x00, 0xff};
+    entries.push_back(entry);
+  }
+  return entries;
+}
+
+void ExpectEntriesEqual(const std::vector<edge_builtin_bytecode::FileEntry>& actual,
+                        const std::vector<edge_builtin_bytecode::FileEntry>& expected) {
+  ASSERT_EQ(actual.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(actual[i].kind, expected[i].kind) << "entry " << i;
+    EXPECT_EQ(actual[i].id, expected[i].id) << "entry " << i;
+    EXPECT_EQ(actual[i].source_hash, expected[i].source_hash) << "entry " << i;
+    EXPECT_EQ(actual[i].payload, expected[i].payload) << "entry " << i;
+  }
+}
+
+}  // namespace
+
+TEST_F(Test8BuiltinBytecode, EncodeDecodeRoundTrip) {
+  const auto entries = SampleEntries();
+  const auto encoded = edge_builtin_bytecode::EncodeFile(kTag, entries);
+
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  ASSERT_TRUE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+  ExpectEntriesEqual(decoded, entries);
+}
+
+TEST_F(Test8BuiltinBytecode, EmptyFileRoundTrip) {
+  const auto encoded = edge_builtin_bytecode::EncodeFile(kTag, {});
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  ASSERT_TRUE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+  EXPECT_TRUE(decoded.empty());
+}
+
+TEST_F(Test8BuiltinBytecode, DecodeRejectsBadMagic) {
+  auto encoded = edge_builtin_bytecode::EncodeFile(kTag, SampleEntries());
+  encoded[0] ^= 0xff;
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  EXPECT_FALSE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+}
+
+TEST_F(Test8BuiltinBytecode, DecodeRejectsBadFormatVersion) {
+  auto encoded = edge_builtin_bytecode::EncodeFile(kTag, SampleEntries());
+  encoded[8] ^= 0xff;
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  EXPECT_FALSE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+}
+
+TEST_F(Test8BuiltinBytecode, DecodeRejectsWrongEngineTag) {
+  const auto encoded = edge_builtin_bytecode::EncodeFile(kTag, SampleEntries());
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  EXPECT_FALSE(
+      edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), "v8-other-tag", &decoded));
+}
+
+TEST_F(Test8BuiltinBytecode, DecodeRejectsTruncation) {
+  const auto encoded = edge_builtin_bytecode::EncodeFile(kTag, SampleEntries());
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+
+  // Header-only prefix.
+  EXPECT_FALSE(edge_builtin_bytecode::DecodeFile(encoded.data(), 16, kTag, &decoded));
+  // Last payload byte cut: the final entry overruns the buffer.
+  EXPECT_FALSE(
+      edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size() - 1, kTag, &decoded));
+}
+
+TEST_F(Test8BuiltinBytecode, DecodeRejectsTrailingGarbage) {
+  auto encoded = edge_builtin_bytecode::EncodeFile(kTag, SampleEntries());
+  encoded.push_back(0x00);
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  EXPECT_FALSE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+}
+
+TEST_F(Test8BuiltinBytecode, CorruptedPayloadEntryHandling) {
+  const auto entries = SampleEntries();
+  auto encoded = edge_builtin_bytecode::EncodeFile(kTag, entries);
+  // Flip the last byte: it belongs to the final entry's payload.
+  encoded.back() ^= 0x01;
+
+  std::vector<edge_builtin_bytecode::FileEntry> decoded;
+  ASSERT_TRUE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
+#if defined(EDGE_NAPI_QUICKJS)
+  // QuickJS entries carry a payload hash (its reader is not hardened): the
+  // corrupt entry is dropped, the rest survive.
+  ASSERT_EQ(decoded.size(), entries.size() - 1);
+#else
+  // V8 writes no payload hash (CachedData self-validates): the container
+  // keeps the entry and the engine rejects it at deserialize time.
+  ASSERT_EQ(decoded.size(), entries.size());
+#endif
+  EXPECT_EQ(decoded[0].id, "fs");
+  EXPECT_EQ(decoded[1].id, "internal/bootstrap/realm");
+}
+
+TEST_F(Test8BuiltinBytecode, CacheFilePathUsesExecPathAndEngineSuffix) {
+  const std::string path = edge_builtin_bytecode::BuiltinCacheFilePath();
+  const std::string expected_suffix =
+      std::string(".builtins") + edge_bytecode_cache::SidecarSuffix();
+  ASSERT_GT(path.size(), expected_suffix.size());
+  EXPECT_EQ(path.substr(path.size() - expected_suffix.size()), expected_suffix);
+}

--- a/tests/runners/test_8_builtin_bytecode.cc
+++ b/tests/runners/test_8_builtin_bytecode.cc
@@ -111,20 +111,16 @@ TEST_F(Test8BuiltinBytecode, DecodeRejectsTrailingGarbage) {
 TEST_F(Test8BuiltinBytecode, CorruptedPayloadEntryHandling) {
   const auto entries = SampleEntries();
   auto encoded = edge_builtin_bytecode::EncodeFile(kTag, entries);
-  // Flip the last byte: it belongs to the final entry's payload.
+  // Flip the last byte: it belongs to the final entry's payload. The
+  // container only pins structure; payload integrity is the engine's job
+  // (V8 CachedData / the QuickJS provider's QJSB payload header), so the
+  // entry survives container decoding on both engines and the engine
+  // rejects it at deserialize time.
   encoded.back() ^= 0x01;
 
   std::vector<edge_builtin_bytecode::FileEntry> decoded;
   ASSERT_TRUE(edge_builtin_bytecode::DecodeFile(encoded.data(), encoded.size(), kTag, &decoded));
-#if defined(EDGE_NAPI_QUICKJS)
-  // QuickJS entries carry a payload hash (its reader is not hardened): the
-  // corrupt entry is dropped, the rest survive.
-  ASSERT_EQ(decoded.size(), entries.size() - 1);
-#else
-  // V8 writes no payload hash (CachedData self-validates): the container
-  // keeps the entry and the engine rejects it at deserialize time.
   ASSERT_EQ(decoded.size(), entries.size());
-#endif
   EXPECT_EQ(decoded[0].id, "fs");
   EXPECT_EQ(decoded[1].id, "internal/bootstrap/realm");
 }


### PR DESCRIPTION
This PR adds a precompilation step to Edge.js.

Note: this PR depends on https://github.com/wasmerio/napi/pull/30 being merged first

# Measurements

All measurements collected on the current builds. Everything holds — the keystone, correctness fixes, and simplifications introduced **no performance regression** (numbers are within noise of the prior round, several slightly better).

## Synthetic startup lanes (hyperfine; cold = `--no-bytecode-cache`, warm = caches)

| engine / lane | cold | warm | speedup |
|---|---|---|---|
| V8 / CJS | 89.7 ms | **54.6 ms** | 1.64× |
| V8 / ESM | 93.9 ms | **63.5 ms** | 1.48× |
| V8 / empty startup | 39.3 ms | **29.5 ms** | 1.33× |
| QuickJS / CJS | 168.7 ms | **77.9 ms** | 2.17× |
| QuickJS / ESM | 185.0 ms | **98.2 ms** | 1.88× |
| QuickJS / empty startup | 55.8 ms | **30.8 ms** | 1.81× |

## Astro server — first HTTP response (8 runs each)

| config | to-listen | first request | total | saved |
|---|---|---|---|---|
| V8 disabled | 101.8 | 95.0 | 196.8 ms | — |
| V8 warm | 104.9 | 84.6 | **189.5 ms** | ~7 ms |
| QuickJS disabled | 185.2 | 312.0 | 497.1 ms | — |
| QuickJS warm | 133.5 | 241.7 | **375.2 ms** | **122 ms (24.5%)** |

## Sidecar read overhead (warm, 167 modules)

- **V8: 3.4 ms** for 3.82 MB of payloads · 107 builtin hits
- **QuickJS: 4.2 ms** for 9.57 MB · 107 builtin hits
