### PR TITLE
Fix two QuickJS GC use-after-frees (handle-wrap teardown + async-generator closures)

### DIFF
--- a/src/edge_handle_wrap.cc
+++ b/src/edge_handle_wrap.cc
@@ -5,6 +5,7 @@
 
 #include "binding_registry/binding_registry.h"
 #include "internal_binding/helpers.h"
+#include "edge_active_resource.h"
 #include "edge_environment.h"
 #include "edge_env_loop.h"
 #include "edge_handle_scope.h"
@@ -175,6 +176,7 @@ void EdgeHandleWrapInit(EdgeHandleWrap* wrap, napi_env env) {
   wrap->finalized = false;
   wrap->delete_on_close = false;
   wrap->wrapper_ref_held = false;
+  wrap->in_close_callback = false;
   wrap->state = kEdgeHandleUninitialized;
 }
 
@@ -339,6 +341,80 @@ bool EdgeHandleWrapHasRef(const EdgeHandleWrap* wrap, const uv_handle_t* handle)
 
 bool EdgeHandleWrapEnvCleanupStarted(napi_env env) {
   return EdgeEnvironmentCleanupStarted(env);
+}
+
+namespace {
+
+void UnregisterActiveHandleIfPresent(napi_env env, EdgeHandleWrap* wrap) {
+  if (wrap->active_handle_token == nullptr) return;
+  if (env != nullptr) EdgeUnregisterActiveHandle(env, wrap->active_handle_token);
+  wrap->active_handle_token = nullptr;
+}
+
+}  // namespace
+
+void EdgeHandleWrapCompleteClose(EdgeHandleWrap* wrap, void* native,
+                                 EdgeHandleWrapDeleteFn delete_native) {
+  if (wrap == nullptr || native == nullptr || delete_native == nullptr) return;
+
+  // Claim ownership of deletion for the entire teardown. Detaching, unregistering
+  // the active handle, and running the JS "onclose" callback can each re-enter
+  // the GC and run this wrap's finalizer; while in_close_callback is set the
+  // finalizer only records finalization and defers freeing to us, so the wrap is
+  // never freed while this teardown (or the onclose callback) is on the stack.
+  wrap->in_close_callback = true;
+
+  wrap->state = kEdgeHandleClosed;
+  EdgeHandleWrapDetach(wrap);
+  UnregisterActiveHandleIfPresent(wrap->env, wrap);
+  EdgeHandleWrapMaybeCallOnClose(wrap);
+
+  wrap->in_close_callback = false;
+
+  bool can_delete = wrap->finalized;
+  if (!can_delete && wrap->delete_on_close) {
+    can_delete = EdgeHandleWrapCancelFinalizer(wrap, native);
+  }
+  if (can_delete) {
+    EdgeHandleWrapDeleteRefIfPresent(wrap->env, &wrap->wrapper_ref);
+    delete_native(native);
+  } else {
+    // The handle is closed but the JS wrapper is still reachable; drop the
+    // strong pin so the wrapper becomes collectable. The finalizer will free
+    // the native object when the wrapper is eventually collected.
+    EdgeHandleWrapReleaseWrapperRef(wrap);
+  }
+}
+
+void EdgeHandleWrapFinalizeNative(napi_env env, EdgeHandleWrap* wrap, void* native,
+                                  EdgeHandleWrapDeleteFn delete_native) {
+  if (wrap == nullptr || native == nullptr || delete_native == nullptr) return;
+
+  wrap->finalized = true;
+  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->wrapper_ref);
+
+  // If a close callback is currently tearing this wrap down (this finalizer ran
+  // re-entrantly via the onclose callback), that close path owns the deletion.
+  if (wrap->in_close_callback) return;
+
+  if (wrap->state == kEdgeHandleInitialized) {
+    // The wrapper was collected while the handle is still open. Drop the pin and
+    // start closing it; OnClose (-> EdgeHandleWrapCompleteClose) frees the wrap.
+    wrap->delete_on_close = true;
+    EdgeHandleWrapReleaseWrapperRef(wrap);
+    if (wrap->close_callback != nullptr) wrap->close_callback(wrap->close_data);
+    return;
+  }
+  if (wrap->state == kEdgeHandleClosing) {
+    // A close is already in flight; let its OnClose free the wrap.
+    wrap->delete_on_close = true;
+    return;
+  }
+
+  // Uninitialized or already closed: free now.
+  EdgeHandleWrapDetach(wrap);
+  UnregisterActiveHandleIfPresent(env, wrap);
+  delete_native(native);
 }
 
 void EdgeHandleWrapRunEnvCleanup(napi_env env) {

--- a/src/edge_handle_wrap.h
+++ b/src/edge_handle_wrap.h
@@ -29,6 +29,11 @@ struct EdgeHandleWrap {
   bool finalized = false;
   bool delete_on_close = false;
   bool wrapper_ref_held = false;
+  // True while the uv close callback (OnClosed) is running its teardown, which
+  // includes invoking a JS "onclose" callback that can re-enter the GC and run
+  // this wrap's finalizer. While set, the finalizer must not free the wrap:
+  // OnClosed owns the deletion and performs it once it resumes.
+  bool in_close_callback = false;
   EdgeHandleState state = kEdgeHandleUninitialized;
 };
 
@@ -49,5 +54,25 @@ void EdgeHandleWrapMaybeCallOnClose(EdgeHandleWrap* wrap);
 bool EdgeHandleWrapHasRef(const EdgeHandleWrap* wrap, const uv_handle_t* handle);
 bool EdgeHandleWrapEnvCleanupStarted(napi_env env);
 void EdgeHandleWrapRunEnvCleanup(napi_env env);
+
+// Frees the native object that owns `wrap` (e.g. `delete static_cast<T*>(p)`).
+using EdgeHandleWrapDeleteFn = void (*)(void* native_object);
+
+// Shared, re-entrancy-safe teardown for the canonical handle-wrap lifetime
+// model (pin the JS wrapper strong while the uv handle is active; the finalizer
+// ultimately frees the native object once the handle is closed). Every handle
+// wrap should route its uv close callback and its napi finalizer through these
+// instead of hand-rolling the logic, so the subtle ordering — in particular not
+// freeing the wrap while its own onclose callback is on the stack — lives in
+// exactly one place and cannot be reintroduced by a new wrap.
+//
+// Call from a wrap's uv_close() callback. `native` is the owning object pointer.
+void EdgeHandleWrapCompleteClose(EdgeHandleWrap* wrap, void* native,
+                                 EdgeHandleWrapDeleteFn delete_native);
+
+// Call from a wrap's napi finalizer. Defers deletion to the close path when the
+// handle is still active/closing; deletes immediately only when it is safe.
+void EdgeHandleWrapFinalizeNative(napi_env env, EdgeHandleWrap* wrap, void* native,
+                                  EdgeHandleWrapDeleteFn delete_native);
 
 #endif  // EDGE_HANDLE_WRAP_H_

--- a/src/edge_process_wrap.cc
+++ b/src/edge_process_wrap.cc
@@ -179,6 +179,13 @@ void QueueDestroy(ProcessWrap* wrap) {
   EdgeAsyncWrapQueueDestroyId(wrap->handle_wrap.env, wrap->async_id);
 }
 
+void DeleteProcessWrap(void* data) {
+  auto* wrap = static_cast<ProcessWrap*>(data);
+  if (wrap == nullptr) return;
+  QueueDestroy(wrap);
+  delete wrap;
+}
+
 const char* SignalNameFromNumber(int sig) {
   switch (sig) {
     case 0:
@@ -383,30 +390,9 @@ bool ParseStdioOptions(napi_env env,
 void OnProcessClose(uv_handle_t* handle) {
   auto* wrap = static_cast<ProcessWrap*>(handle->data);
   if (wrap == nullptr) return;
-
-  wrap->handle_wrap.state = kEdgeHandleClosed;
   wrap->alive = false;
   UntrackLiveChildPid(wrap->pid);
-
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(wrap->handle_wrap.env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
-  QueueDestroy(wrap);
-
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    delete wrap;
-  } else {
-    EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
-  }
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteProcessWrap);
 }
 
 void CloseProcessWrapForCleanup(void* data) {
@@ -459,35 +445,14 @@ void OnProcessExit(uv_process_t* process, int64_t exit_status, int term_signal) 
 void ProcessFinalize(napi_env env, void* data, void* /*hint*/) {
   auto* wrap = static_cast<ProcessWrap*>(data);
   if (wrap == nullptr) return;
-
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-
-  if (wrap->handle_wrap.state == kEdgeHandleUninitialized || wrap->handle_wrap.state == kEdgeHandleClosed) {
-    EdgeHandleWrapDetach(&wrap->handle_wrap);
-    if (wrap->handle_wrap.active_handle_token != nullptr) {
-      EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-      wrap->handle_wrap.active_handle_token = nullptr;
-    }
-    QueueDestroy(wrap);
-    delete wrap;
-    return;
+  // If the wrapper is collected while the child is still tracked, stop tracking
+  // it; the shared finalizer initiates close (-> OnProcessClose) which also
+  // untracks, but doing it here keeps the live-child set tight.
+  if (wrap->handle_wrap.state == kEdgeHandleInitialized) {
+    wrap->alive = false;
+    UntrackLiveChildPid(wrap->pid);
   }
-
-  wrap->handle_wrap.delete_on_close = true;
-  wrap->alive = false;
-  UntrackLiveChildPid(wrap->pid);
-  CloseProcessWrapForCleanup(wrap);
-  if (wrap->handle_wrap.state == kEdgeHandleClosing) return;
-
-  if (wrap->handle_wrap.state != kEdgeHandleClosing) {
-    if (wrap->handle_wrap.active_handle_token != nullptr) {
-      EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-      wrap->handle_wrap.active_handle_token = nullptr;
-    }
-    QueueDestroy(wrap);
-    delete wrap;
-  }
+  EdgeHandleWrapFinalizeNative(env, &wrap->handle_wrap, wrap, DeleteProcessWrap);
 }
 
 napi_value ProcessCtor(napi_env env, napi_callback_info info) {
@@ -627,7 +592,10 @@ napi_value ProcessSpawn(napi_env env, napi_callback_info info) {
                       wrap,
                       reinterpret_cast<uv_handle_t*>(&wrap->process),
                       CloseProcessWrapForCleanup);
-  EdgeHandleWrapHoldWrapperRef(&wrap->handle_wrap);
+  // No explicit wrapper pin needed: EdgeRegisterActiveHandle already keeps the
+  // JS wrapper alive (a strong keepalive_ref) while the handle is active, and
+  // it is released on close/unregister. The shared close/finalize helpers
+  // handle the re-entrancy safety.
 
   if (rc != 0) {
     wrap->pid = 0;

--- a/src/edge_signal_wrap.cc
+++ b/src/edge_signal_wrap.cc
@@ -87,13 +87,11 @@ void QueueDestroy(SignalWrap* wrap) {
   // EdgeAsyncWrapQueueDestroy(wrap->env, static_cast<double>(wrap->async_id));
 }
 
-void UnregisterActiveHandleIfPresent(SignalWrap* wrap, napi_env env_override = nullptr) {
-  if (wrap == nullptr || wrap->handle_wrap.active_handle_token == nullptr) return;
-  napi_env env = env_override != nullptr ? env_override : wrap->handle_wrap.env;
-  if (env != nullptr) {
-    EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-  }
-  wrap->handle_wrap.active_handle_token = nullptr;
+void DeleteSignalWrap(void* data) {
+  auto* wrap = static_cast<SignalWrap*>(data);
+  if (wrap == nullptr) return;
+  QueueDestroy(wrap);
+  delete wrap;
 }
 
 void OnClosed(uv_handle_t* handle);
@@ -139,37 +137,11 @@ void CloseSignalWrapForCleanup(void* data) {
 void OnClosed(uv_handle_t* handle) {
   auto* wrap = static_cast<SignalWrap*>(handle->data);
   if (wrap == nullptr) return;
-  wrap->handle_wrap.state = kEdgeHandleClosed;
-  QueueDestroy(wrap);
-
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  UnregisterActiveHandleIfPresent(wrap);
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
-
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    delete wrap;
-  }
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteSignalWrap);
 }
 
 void SignalFinalize(napi_env env, void* data, void* /*hint*/) {
-  auto* wrap = static_cast<SignalWrap*>(data);
-  if (wrap == nullptr) return;
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleUninitialized || wrap->handle_wrap.state == kEdgeHandleClosed) {
-    EdgeHandleWrapDetach(&wrap->handle_wrap);
-    UnregisterActiveHandleIfPresent(wrap, env);
-    QueueDestroy(wrap);
-    delete wrap;
-    return;
-  }
-  wrap->handle_wrap.delete_on_close = true;
-  CloseSignalWrapHandle(wrap);
-  return;
+  EdgeHandleWrapFinalizeNative(env, &static_cast<SignalWrap*>(data)->handle_wrap, data, DeleteSignalWrap);
 }
 
 napi_value SignalCtor(napi_env env, napi_callback_info info) {

--- a/src/edge_udp_wrap.cc
+++ b/src/edge_udp_wrap.cc
@@ -760,6 +760,13 @@ void QueueUdpWrapDestroyIfNeeded(UdpWrap* wrap) {
   wrap->async_id = -1;
 }
 
+void DeleteUdpWrap(void* data) {
+  auto* wrap = static_cast<UdpWrap*>(data);
+  if (wrap == nullptr) return;
+  QueueUdpWrapDestroyIfNeeded(wrap);
+  delete wrap;
+}
+
 void SendWrapFinalize(napi_env env, void* data, void* hint) {
   (void)hint;
   auto* wrap = static_cast<SendWrap*>(data);
@@ -773,27 +780,7 @@ void SendWrapFinalize(napi_env env, void* data, void* hint) {
 
 void UdpFinalize(napi_env env, void* data, void* hint) {
   (void)hint;
-  auto* wrap = static_cast<UdpWrap*>(data);
-  if (wrap == nullptr) return;
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleInitialized) {
-    wrap->handle_wrap.delete_on_close = true;
-    EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
-    CloseUdpWrapForCleanup(wrap);
-    return;
-  }
-  if (wrap->handle_wrap.state == kEdgeHandleClosing) {
-    wrap->handle_wrap.delete_on_close = true;
-    return;
-  }
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-  QueueUdpWrapDestroyIfNeeded(wrap);
-  delete wrap;
+  EdgeHandleWrapFinalizeNative(env, &static_cast<UdpWrap*>(data)->handle_wrap, data, DeleteUdpWrap);
 }
 
 napi_value SendWrapCtor(napi_env env, napi_callback_info info) {
@@ -815,9 +802,8 @@ napi_value UdpCtor(napi_env env, napi_callback_info info) {
   napi_get_cb_info(env, info, &argc, nullptr, &self, nullptr);
   auto* wrap = new UdpWrap(env);
   napi_wrap(env, self, wrap, UdpFinalize, nullptr, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleInitialized) {
-    EdgeHandleWrapHoldWrapperRef(&wrap->handle_wrap);
-  }
+  // EdgeRegisterActiveHandle's keepalive_ref keeps the wrapper alive while the
+  // handle is active; no separate pin needed (see EdgeHandleWrapCompleteClose).
   wrap->handle_wrap.active_handle_token =
       EdgeRegisterActiveHandle(
           env, self, "UDPWRAP", UdpHandleHasRef, UdpGetActiveOwner, wrap, CloseUdpWrapForCleanup);
@@ -845,24 +831,7 @@ napi_value UdpCtor(napi_env env, napi_callback_info info) {
 void OnClosed(uv_handle_t* h) {
   auto* wrap = static_cast<UdpWrap*>(h->data);
   if (wrap == nullptr) return;
-  wrap->handle_wrap.state = kEdgeHandleClosed;
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(wrap->handle_wrap.env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
-  QueueUdpWrapDestroyIfNeeded(wrap);
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->handle_wrap.wrapper_ref);
-    delete wrap;
-  } else {
-    EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
-  }
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteUdpWrap);
 }
 
 void CloseUdpWrapForCleanup(void* data) {

--- a/src/internal_binding/binding_fs.cc
+++ b/src/internal_binding/binding_fs.cc
@@ -2538,26 +2538,14 @@ StatWatcherWrap* UnwrapStatWatcher(napi_env env, napi_value this_arg) {
   return static_cast<StatWatcherWrap*>(data);
 }
 
+void DeleteStatWatcherWrap(void* data) {
+  delete static_cast<StatWatcherWrap*>(data);
+}
+
 void OnStatWatcherClosed(uv_handle_t* handle) {
   auto* wrap = static_cast<StatWatcherWrap*>(handle != nullptr ? handle->data : nullptr);
   if (wrap == nullptr) return;
-  wrap->handle_wrap.state = kEdgeHandleClosed;
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(wrap->handle_wrap.env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->handle_wrap.wrapper_ref);
-    delete wrap;
-  } else {
-    EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
-  }
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteStatWatcherWrap);
 }
 
 void CloseStatWatcher(StatWatcherWrap* wrap) {
@@ -2601,21 +2589,7 @@ void OnStatWatcherChange(uv_fs_poll_t* handle, int status, const uv_stat_t* prev
 }
 
 void StatWatcherFinalize(napi_env env, void* data, void* /*hint*/) {
-  auto* wrap = static_cast<StatWatcherWrap*>(data);
-  if (wrap == nullptr) return;
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleUninitialized || wrap->handle_wrap.state == kEdgeHandleClosed) {
-    EdgeHandleWrapDetach(&wrap->handle_wrap);
-    if (wrap->handle_wrap.active_handle_token != nullptr) {
-      EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-      wrap->handle_wrap.active_handle_token = nullptr;
-    }
-    delete wrap;
-    return;
-  }
-  wrap->handle_wrap.delete_on_close = true;
-  CloseStatWatcher(wrap);
+  EdgeHandleWrapFinalizeNative(env, &static_cast<StatWatcherWrap*>(data)->handle_wrap, data, DeleteStatWatcherWrap);
 }
 
 napi_value StatWatcherCtor(napi_env env, napi_callback_info info) {
@@ -2671,7 +2645,7 @@ napi_value StatWatcherStart(napi_env env, napi_callback_info info) {
   }
 
   wrap->handle_wrap.state = kEdgeHandleInitialized;
-  EdgeHandleWrapHoldWrapperRef(&wrap->handle_wrap);
+  // Keep-alive comes from EdgeRegisterActiveHandle's strong keepalive_ref.
   if (wrap->handle_wrap.active_handle_token == nullptr) {
     wrap->handle_wrap.active_handle_token =
         EdgeRegisterActiveHandle(env,

--- a/src/internal_binding/binding_fs_event_wrap.cc
+++ b/src/internal_binding/binding_fs_event_wrap.cc
@@ -137,27 +137,17 @@ napi_value CreateFilenameValue(FsEventWrap* wrap, const char* filename) {
   return out;
 }
 
+void DeleteFsEventWrap(void* data) {
+  auto* wrap = static_cast<FsEventWrap*>(data);
+  if (wrap == nullptr) return;
+  EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->owner_ref);
+  delete wrap;
+}
+
 void OnClosed(uv_handle_t* handle) {
   auto* wrap = static_cast<FsEventWrap*>(handle != nullptr ? handle->data : nullptr);
   if (wrap == nullptr) return;
-  wrap->handle_wrap.state = kEdgeHandleClosed;
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(wrap->handle_wrap.env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->owner_ref);
-    EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->handle_wrap.wrapper_ref);
-    delete wrap;
-  } else {
-    EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
-  }
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteFsEventWrap);
 }
 
 void CloseFsEvent(FsEventWrap* wrap) {
@@ -171,22 +161,7 @@ void CloseFsEventForCleanup(void* data) {
 }
 
 void FsEventFinalize(napi_env env, void* data, void* /*hint*/) {
-  auto* wrap = static_cast<FsEventWrap*>(data);
-  if (wrap == nullptr) return;
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleUninitialized || wrap->handle_wrap.state == kEdgeHandleClosed) {
-    EdgeHandleWrapDetach(&wrap->handle_wrap);
-    if (wrap->handle_wrap.active_handle_token != nullptr) {
-      EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-      wrap->handle_wrap.active_handle_token = nullptr;
-    }
-    EdgeHandleWrapDeleteRefIfPresent(env, &wrap->owner_ref);
-    delete wrap;
-    return;
-  }
-  wrap->handle_wrap.delete_on_close = true;
-  CloseFsEvent(wrap);
+  EdgeHandleWrapFinalizeNative(env, &static_cast<FsEventWrap*>(data)->handle_wrap, data, DeleteFsEventWrap);
 }
 
 void OnEvent(uv_fs_event_t* handle, const char* filename, int events, int status) {
@@ -295,7 +270,7 @@ napi_value FsEventStart(napi_env env, napi_callback_info info) {
   }
 
   wrap->handle_wrap.state = kEdgeHandleInitialized;
-  EdgeHandleWrapHoldWrapperRef(&wrap->handle_wrap);
+  // Keep-alive comes from EdgeRegisterActiveHandle's strong keepalive_ref.
   if (wrap->handle_wrap.active_handle_token == nullptr) {
     wrap->handle_wrap.active_handle_token =
         EdgeRegisterActiveHandle(

--- a/src/internal_binding/binding_messaging.cc
+++ b/src/internal_binding/binding_messaging.cc
@@ -3544,45 +3544,32 @@ void ProcessQueuedMessages(MessagePortWrap* wrap, bool force, size_t processing_
   }
 }
 
+void DeleteMessagePortWrap(void* data) {
+  auto* wrap = static_cast<MessagePortWrap*>(data);
+  if (wrap == nullptr) return;
+  if (wrap->async_id > 0) {
+    EdgeAsyncWrapQueueDestroyId(wrap->handle_wrap.env, wrap->async_id);
+    wrap->async_id = 0;
+  }
+  DeleteQueuedMessages(wrap->handle_wrap.env, wrap);
+  delete wrap;
+}
+
 void OnMessagePortClosed(uv_handle_t* handle) {
   auto* wrap = static_cast<MessagePortWrap*>(handle != nullptr ? handle->data : nullptr);
   if (wrap == nullptr) return;
-  wrap->handle_wrap.state = kEdgeHandleClosed;
+  // MessagePort-specific teardown that must happen as the handle closes.
   if (EdgeHandleWrapEnvCleanupStarted(wrap->handle_wrap.env)) {
     wrap->handle_wrap.delete_on_close = true;
   }
   DisentanglePeer(wrap->handle_wrap.env, wrap, true);
-  EdgeHandleWrapDetach(&wrap->handle_wrap);
-  if (wrap->handle_wrap.active_handle_token != nullptr) {
-    EdgeUnregisterActiveHandle(wrap->handle_wrap.env, wrap->handle_wrap.active_handle_token);
-    wrap->handle_wrap.active_handle_token = nullptr;
-  }
-  EdgeHandleWrapMaybeCallOnClose(&wrap->handle_wrap);
   if (wrap->data) {
     std::lock_guard<std::mutex> lock(wrap->data->mutex);
     if (wrap->data->attached_port == wrap) {
       wrap->data->attached_port = nullptr;
     }
   }
-  bool can_delete = wrap->handle_wrap.finalized;
-  if (!can_delete && wrap->handle_wrap.delete_on_close) {
-    can_delete = EdgeHandleWrapCancelFinalizer(&wrap->handle_wrap, wrap);
-  }
-  if (can_delete) {
-    if (wrap->async_id > 0) {
-      EdgeAsyncWrapQueueDestroyId(wrap->handle_wrap.env, wrap->async_id);
-      wrap->async_id = 0;
-    }
-    DeleteQueuedMessages(wrap->handle_wrap.env, wrap);
-    EdgeHandleWrapDeleteRefIfPresent(wrap->handle_wrap.env, &wrap->handle_wrap.wrapper_ref);
-    delete wrap;
-    return;
-  }
-  if (wrap->async_id > 0) {
-    EdgeAsyncWrapQueueDestroyId(wrap->handle_wrap.env, wrap->async_id);
-    wrap->async_id = 0;
-  }
-  EdgeHandleWrapReleaseWrapperRef(&wrap->handle_wrap);
+  EdgeHandleWrapCompleteClose(&wrap->handle_wrap, wrap, DeleteMessagePortWrap);
 }
 
 void OnMessagePortAsync(uv_async_t* handle) {
@@ -3639,30 +3626,7 @@ void CloseMessagePortForCleanup(void* data) {
 }
 
 void MessagePortFinalize(napi_env env, void* data, void* /*hint*/) {
-  auto* wrap = static_cast<MessagePortWrap*>(data);
-  if (wrap == nullptr) return;
-  wrap->handle_wrap.finalized = true;
-  EdgeHandleWrapDeleteRefIfPresent(env, &wrap->handle_wrap.wrapper_ref);
-  if (wrap->handle_wrap.state == kEdgeHandleUninitialized || wrap->handle_wrap.state == kEdgeHandleClosed) {
-    EdgeHandleWrapDetach(&wrap->handle_wrap);
-    DeleteQueuedMessages(env, wrap);
-    if (wrap->async_id > 0) {
-      EdgeAsyncWrapQueueDestroyId(env, wrap->async_id);
-      wrap->async_id = 0;
-    }
-    if (wrap->handle_wrap.active_handle_token != nullptr) {
-      EdgeUnregisterActiveHandle(env, wrap->handle_wrap.active_handle_token);
-      wrap->handle_wrap.active_handle_token = nullptr;
-    }
-    delete wrap;
-    return;
-  }
-  wrap->handle_wrap.delete_on_close = true;
-  if (wrap->handle_wrap.state == kEdgeHandleInitialized &&
-      !uv_is_closing(reinterpret_cast<uv_handle_t*>(&wrap->async))) {
-    wrap->handle_wrap.state = kEdgeHandleClosing;
-    uv_close(reinterpret_cast<uv_handle_t*>(&wrap->async), OnMessagePortClosed);
-  }
+  EdgeHandleWrapFinalizeNative(env, &static_cast<MessagePortWrap*>(data)->handle_wrap, data, DeleteMessagePortWrap);
 }
 
 void InvokePortSymbolHook(napi_env env, napi_value port, napi_value symbol) {
@@ -3796,7 +3760,7 @@ napi_value MessagePortConstructorCallback(napi_env env, napi_callback_info info)
                         wrap,
                         reinterpret_cast<uv_handle_t*>(&wrap->async),
                         CloseMessagePortForCleanup);
-    EdgeHandleWrapHoldWrapperRef(&wrap->handle_wrap);
+    // Keep-alive comes from EdgeRegisterActiveHandle's strong keepalive_ref.
     wrap->async_id = EdgeAsyncWrapNextId(env);
     EdgeAsyncWrapEmitInit(
         env, wrap->async_id, kEdgeProviderMessagePort, EdgeAsyncWrapExecutionAsyncId(env), this_arg);


### PR DESCRIPTION
Two independent QuickJS cycle-GC use-after-free fixes found while bringing up async-heavy framework tests (Etherpad). No framework-test changes are included here.

## 1. Handle-wrap finalize/close re-entrancy (this repo, `src/`)
A napi external finalizer could run re-entrantly during a libuv close callback and free a handle wrap mid-teardown (originally seen as a signal-wrap double-free at shutdown). Fixed by routing **all** handle wraps through a single centralized close/finalize teardown with an `in_close_callback` guard, so finalize and close can't free out from under each other.

- `cafec1df` Fix signal-wrap GC use-after-free via centralized handle teardown
- `43767ecd` Route all handle wraps through the shared close/finalize teardown

## 2. Async function/generator closure cycle-GC UAF (submodule bump)
The cycle collector could free a Promise resolving function still referenced by a **suspended async generator's closure var_ref** → heap-use-after-free in `gc_decref_child` during a later GC. It surfaces in async-heavy apps iterating streams (Etherpad, undici) and reproduces deterministically with `for await (const x of socket)` under GC pressure.

Root cause: this is **CVE-2023-48184 / bellard/quickjs#156** ("incorrect GC of async functions with closures"), fixed in bellard via commit `7414e5f` (2024-01-13) but **never adopted by quickjs-ng** (the fork we vendor still ships the old `async_func_mark`/`JSAsyncFunctionData` design on `master`). The fix ports that restructuring to our quickjs-ng tree, adapted to quickjs-ng's array-based `sf->var_refs[]`.

**Follow-up (regression in the port):** the ported design stores a frame's `var_refs[]` array inside its `arg_buf` allocation, which opened a new cycle-teardown ordering hole — when an incomplete async generator is collected as part of a cycle, `async_func_free_frame()` frees `arg_buf` while open closure var_refs still point into it, so a later `free_var_ref()` writes into freed memory (heap-UAF, `corrupted size vs. prev_size`). This reproduced deterministically via `test-stream-iterator-helpers-test262-tests` (the CI failure on this PR) and is fixed by neutralizing still-open var_refs into detached/empty refs before the frame is freed. Verified: 1/1 crash → 30/30 pass + ASAN-clean.

- `5e33a307` Bump napi → wasmerio/napi#36 → wasmerio/quickjs#6 (async-closure cycle-GC fix + the follow-up ordering fix)

### ⚠️ Not final yet
The `napi` submodule pointer here references the **unmerged** quickjs fix via the PR branch. This PR is **not final until**:
1. **wasmerio/quickjs#6** merges, then
2. **wasmerio/napi#36** is updated to the merged quickjs commit and merges, then
3. the `napi` pointer in this PR is updated to that merged napi commit.

Dependency chain: wasmerio/quickjs#6 → wasmerio/napi#36 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

