### PR TITLE
ECO-380: fix heap-buffer-overflow in stream-base wrap accessors

### DIFF
--- a/src/edge_pipe_wrap.cc
+++ b/src/edge_pipe_wrap.cc
@@ -25,6 +25,15 @@ constexpr int kPipeSocket = 0;
 constexpr int kPipeServer = 1;
 constexpr int kPipeIPC = 2;
 
+// Unique N-API type tag used to safely identify PipeWrap-backed JS objects
+// before downcasting their unwrapped native pointer. Without this, napi_unwrap
+// returns the native pointer of *any* wrapped object (e.g. a JsStreamWrap),
+// and reading PipeWrap-specific fields off it is an out-of-bounds read.
+constexpr napi_type_tag kPipeWrapTypeTag = {
+    0xe1c4a2b3d5f60718ULL,
+    0x2938475665748392ULL,
+};
+
 struct PipeWrap;
 
 struct PipeConnectReqWrap {
@@ -310,6 +319,7 @@ napi_value PipeCtor(napi_env env, napi_callback_info info) {
     if (pipe_wrap == nullptr) return;
     EdgeStreamBaseFinalize(&pipe_wrap->base);
   }, nullptr, &wrap->base.wrapper_ref);
+  (void)napi_type_tag_object(env, self, &kPipeWrapTypeTag);
   EdgeStreamBaseSetWrapperRef(&wrap->base, wrap->base.wrapper_ref);
   EdgeStreamBaseSetInitialStreamProperties(&wrap->base, false, false);
   if (socket_type != kPipeIPC) {
@@ -784,6 +794,14 @@ EdgeStreamBase* EdgePipeWrapGetStreamBase(napi_env env, napi_value value) {
   napi_valuetype type = napi_undefined;
   if (napi_typeof(env, value, &type) != napi_ok ||
       (type != napi_object && type != napi_function && type != napi_external)) {
+    return nullptr;
+  }
+  // Confirm this JS object is genuinely a PipeWrap before downcasting the
+  // unwrapped pointer. napi_unwrap succeeds for any wrapped native object, so
+  // without this tag check we could read PipeWrap fields off a smaller wrap
+  // (e.g. JsStreamWrap) and overrun its allocation.
+  bool is_pipe = false;
+  if (napi_check_object_type_tag(env, value, &kPipeWrapTypeTag, &is_pipe) != napi_ok || !is_pipe) {
     return nullptr;
   }
   PipeWrap* wrap = nullptr;

--- a/src/edge_tcp_wrap.cc
+++ b/src/edge_tcp_wrap.cc
@@ -27,6 +27,13 @@ namespace {
 constexpr int kTcpSocket = 0;
 constexpr int kTcpServer = 1;
 
+// Unique N-API type tag used to safely identify TcpWrap-backed JS objects
+// before downcasting their unwrapped native pointer. See EdgePipeWrapGetStreamBase.
+constexpr napi_type_tag kTcpWrapTypeTag = {
+    0xa1b2c3d4e5f60789ULL,
+    0x1122334455667788ULL,
+};
+
 struct TcpWrap;
 
 struct ConnectReqWrap {
@@ -357,6 +364,7 @@ napi_value TcpCtor(napi_env env, napi_callback_info info) {
     if (tcp_wrap == nullptr) return;
     EdgeStreamBaseFinalize(&tcp_wrap->base);
   }, nullptr, &wrap->base.wrapper_ref);
+  (void)napi_type_tag_object(env, self, &kTcpWrapTypeTag);
   EdgeStreamBaseSetWrapperRef(&wrap->base, wrap->base.wrapper_ref);
   EdgeStreamBaseSetInitialStreamProperties(&wrap->base, true, true);
   return self;
@@ -926,6 +934,12 @@ EdgeStreamBase* EdgeTcpWrapGetStreamBase(napi_env env, napi_value value) {
   }
   if (type_status != napi_ok ||
       (type != napi_object && type != napi_function && type != napi_external)) {
+    return nullptr;
+  }
+  // See EdgePipeWrapGetStreamBase: verify the type tag before downcasting the
+  // unwrapped native pointer to avoid an out-of-bounds read on other wrap types.
+  bool is_tcp = false;
+  if (napi_check_object_type_tag(env, value, &kTcpWrapTypeTag, &is_tcp) != napi_ok || !is_tcp) {
     return nullptr;
   }
   TcpWrap* wrap = nullptr;

--- a/src/edge_tty_wrap.cc
+++ b/src/edge_tty_wrap.cc
@@ -18,6 +18,13 @@
 
 namespace {
 
+// Unique N-API type tag used to safely identify TtyWrap-backed JS objects
+// before downcasting their unwrapped native pointer. See EdgePipeWrapGetStreamBase.
+constexpr napi_type_tag kTtyWrapTypeTag = {
+    0xb7e15162f01d3c9aULL,
+    0x3f84a1b2c3d4e5f6ULL,
+};
+
 struct TtyWrap {
   napi_env env = nullptr;
   EdgeStreamBase base{};
@@ -183,6 +190,7 @@ napi_value TtyCtor(napi_env env, napi_callback_info info) {
             },
             nullptr,
             &wrap->base.wrapper_ref);
+  (void)napi_type_tag_object(env, self, &kTtyWrapTypeTag);
 
   if (wrap->initialized) {
     EdgeStreamBaseSetWrapperRef(&wrap->base, wrap->base.wrapper_ref);
@@ -494,6 +502,12 @@ EdgeStreamBase* EdgeTtyWrapGetStreamBase(napi_env env, napi_value value) {
   napi_valuetype type = napi_undefined;
   if (napi_typeof(env, value, &type) != napi_ok ||
       (type != napi_object && type != napi_function && type != napi_external)) {
+    return nullptr;
+  }
+  // See EdgePipeWrapGetStreamBase: verify the type tag before downcasting the
+  // unwrapped native pointer to avoid an out-of-bounds read on other wrap types.
+  bool is_tty = false;
+  if (napi_check_object_type_tag(env, value, &kTtyWrapTypeTag, &is_tty) != napi_ok || !is_tty) {
     return nullptr;
   }
   TtyWrap* wrap = nullptr;


### PR DESCRIPTION
## Problem

ASAN reports a `heap-buffer-overflow` (READ of size 8) in `EdgePipeWrapGetStreamBase` (`src/edge_pipe_wrap.cc`) when running `parallel/test-http2-client-jsstream-destroy.js` under the QuickJS-native target. Fixes [ECO-380](https://linear.app/wasmer/issue/ECO-380).

## Root cause

`EdgePipeWrapGetStreamBase` — and its TCP/TTY siblings — called `napi_unwrap` on any candidate JS object and immediately downcast the result to the wrap-specific struct, reading `->handle` fields to validate it. But `napi_unwrap` returns the native pointer of *any* wrapped object.

When the http2 path (`SessionConsume` → `EdgeStreamBaseFromValue`) passed in a JS-backed stream (`JsStreamWrap`, which is smaller and has no `handle` field), `&wrap->handle` already pointed past the end of the allocation, so reading `handle->data`/`handle->type` was an out-of-bounds read. The guard meant to reject non-pipes was itself the overflow.

The same unsafe downcast existed in all three sibling accessors:
- `EdgePipeWrapGetStreamBase` (`src/edge_pipe_wrap.cc`)
- `EdgeTcpWrapGetStreamBase` (`src/edge_tcp_wrap.cc`)
- `EdgeTtyWrapGetStreamBase` (`src/edge_tty_wrap.cc`)

## Fix

Tag Pipe/Tcp/Tty wrap objects with a unique `napi_type_tag` at construction, and verify the tag with `napi_check_object_type_tag` before unwrapping/dereferencing — mirroring the existing `MessagePort` pattern in `binding_messaging.cc`. The tag check inspects only the JS object's tag slot, never the native struct, so foreign wraps are rejected safely and fall through to the correct handler (the `_externalStream` path for JS-backed streams). All wrap construction paths — including server-accept `OnConnection`, which builds clients via the JS constructor — apply the tag, so legitimate sockets are unaffected.

## Verification

- Rebuilt the ASAN QuickJS target.
- Repro `test-http2-client-jsstream-destroy.js`: **10/10 clean** under `ASAN_OPTIONS=abort_on_error=1` (was aborting before).
- Adjacent legitimate stream paths still pass: `test-http2-create-client-session`, `test-pipe-address`, `test-net-pipe-connect-errors`.
- The repro test is already listed in `test/module-categories/node_http2.txt` and not in any QuickJS skip list, so it already runs in the `test-quickjs-only` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)