### PR TITLE
Enable Etherpad on the QuickJS edge stages (native + WASIX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,15 +433,15 @@ framework-test-run:
 framework-test: $(EDGE_BINARY)
 	@"$(EDGE_BINARY)" "$(FRAMEWORK_TEST_SCRIPT)" test $(FRAMEWORK_TEST_SELECTOR)
 
-# js-etherpad is edge-skipped (Node baseline still runs): EdgeJS QuickJS native
-# hits missing Intl constructors (Intl.ListFormat, ECO-381) and WASIX hits a
-# runtime-esbuild call. Remove from FRAMEWORK_TEST_EDGE_SKIP once both are fixed.
-# (The GC use-after-frees that previously blocked it are fixed in #101.)
+# js-etherpad runs on both EdgeJS QuickJS Native and WASIX edge stages: the
+# ICU-backed Intl surface (ECO-359) supplies Intl.ListFormat, native-function
+# toString matches V8, and the example pre-bundles its client entrypoints at
+# build time so no esbuild runs at runtime. (GC use-after-frees fixed in #101.)
 framework-test-quickjs-native: $(QUICKJS_EDGE_BINARY)
 	@SYMLINK_TARGET="$(abspath $(QUICKJS_EDGE_BINARY))" \
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
 		FRAMEWORK_TEST_NODE_SKIP='js-docusaurus-staticsite,js-docusaurus2-staticsite' \
-		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone,js-etherpad' \
+		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone' \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS QuickJS Native' \
 		$(MAKE) framework-test-run $(FRAMEWORK_TEST_SELECTOR)
 
@@ -454,7 +454,7 @@ framework-test-quickjs-wasix: $(QUICKJS_WASIX_WASM)
 	@SYMLINK_TARGET="$(abspath $(WASIX_FRAMEWORK_RUNNER))" \
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
 		FRAMEWORK_TEST_NODE_SKIP='js-docusaurus-staticsite,js-docusaurus2-staticsite' \
-		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone,js-etherpad' \
+		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone' \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS QuickJS WASIX' \
 		$(MAKE) framework-test-run $(FRAMEWORK_TEST_SELECTOR)
 
@@ -484,7 +484,7 @@ standalone-build-test-run:
 standalone-build-test-quickjs-native: $(QUICKJS_EDGE_BINARY)
 	@SYMLINK_TARGET="$(abspath $(QUICKJS_EDGE_BINARY))" \
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
-		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone,js-etherpad' \
+		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone' \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS QuickJS Native' \
 		$(MAKE) standalone-build-test-run $(FRAMEWORK_TEST_SELECTOR)
 
@@ -496,7 +496,7 @@ standalone-build-test-quickjs-wasix: $(QUICKJS_WASIX_WASM)
 	}
 	@SYMLINK_TARGET="$(abspath $(WASIX_FRAMEWORK_RUNNER))" \
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
-		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone,js-etherpad' \
+		FRAMEWORK_TEST_EDGE_SKIP='js-astro-ssr-standalone' \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS QuickJS WASIX' \
 		$(MAKE) standalone-build-test-run $(FRAMEWORK_TEST_SELECTOR)
 


### PR DESCRIPTION
Bumps `wasmer-examples` and drops `js-etherpad` from `FRAMEWORK_TEST_EDGE_SKIP` on all QuickJS edge stages (native + WASIX, framework-test + standalone-build).

## Why it works now
Etherpad was edge-skipped pending three blockers, all now resolved:
- **`Intl.ListFormat` missing** → ICU-backed Intl surface (ECO-359, #103).
- **native-function `toString` mismatch** (broke `oidc-provider`'s exact-match TTL check) → engine fix (#105).
- **runtime esbuild** bundling the client entrypoints in `specialpages.ts` → the example now **pre-bundles them at build time** (`build-frontend.mjs`), so no esbuild runs at runtime. This is the `wasmer-examples` bump in this PR.

## Verified
Local `make framework-test-quickjs-native js-etherpad` and `make framework-test-quickjs-wasix js-etherpad` both pass — Etherpad serves `/health` and `/` (2/2 routes), no regressions vs the Node baseline, on **both** native and WASIX.

## Dependencies (stacked)
- Base: #102 (framework harness + example bump + gatsby-on-macOS skip).
- Needs **#103** (ICU Intl) and **#105** (native-fn toString) merged for the edge stages to be green in CI.
- `wasmer-examples` `edgejs` branch → `bf12708` (adds `build-frontend.mjs` + the `specialpages` pre-built-manifest path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)