### PR TITLE
Fix use-after-free of http2 parent stream listener on teardown

### DIFF
--- a/src/internal_binding/binding_http2.cc
+++ b/src/internal_binding/binding_http2.cc
@@ -239,6 +239,13 @@ struct Http2SessionWrap {
   napi_ref parent_handle_ref = nullptr;
   EdgeStreamBase* parent_stream_base = nullptr;
   EdgeStreamListener parent_stream_listener{};
+  // The base our parent_stream_listener is actually registered on. Tracked
+  // separately from parent_stream_base because several paths null the latter
+  // (its "native parent stream is usable" meaning) without unregistering the
+  // listener. Kept in lockstep with registration so Http2SessionFinalize can
+  // always remove the listener before `delete wrap` frees it — otherwise it
+  // dangles in the parent stream's listener_state.current (use-after-free).
+  EdgeStreamBase* parent_stream_listener_base = nullptr;
   int32_t type = kSessionTypeServer;
   int64_t async_id = -1;
   int32_t next_stream_id = 2;
@@ -1442,10 +1449,17 @@ void Http2SessionFinalize(napi_env env, void* data, void* /*hint*/) {
   for (auto& pending : wrap->pending_settings) DeletePendingSettings(env, &pending);
   for (auto& pending : wrap->pending_pings) DeletePendingPing(env, &pending);
   ClearPendingParentRead(wrap);
-  if (wrap->parent_stream_base != nullptr) {
-    (void)EdgeStreamBaseRemoveListener(wrap->parent_stream_base, &wrap->parent_stream_listener);
-    wrap->parent_stream_base = nullptr;
+  // Remove via parent_stream_listener_base, not parent_stream_base: several
+  // paths null parent_stream_base (its "native parent usable" meaning) without
+  // unregistering the listener, so it can be null here while the listener is
+  // still registered. parent_handle_ref keeps the parent base alive until just
+  // below, so the removal is safe. (A no-op if an earlier path already removed
+  // it.)
+  if (wrap->parent_stream_listener_base != nullptr) {
+    (void)EdgeStreamBaseRemoveListener(wrap->parent_stream_listener_base, &wrap->parent_stream_listener);
+    wrap->parent_stream_listener_base = nullptr;
   }
+  wrap->parent_stream_base = nullptr;
   wrap->parent_stream_listener.env = nullptr;
   wrap->parent_stream_listener.on_alloc = nullptr;
   wrap->parent_stream_listener.on_read = nullptr;
@@ -3017,6 +3031,7 @@ napi_value SessionConsume(napi_env env, napi_callback_info info) {
     wrap->parent_stream_listener.on_close = ParentStreamOnClose;
     wrap->parent_stream_listener.data = wrap;
     (void)EdgeStreamBasePushListener(wrap->parent_stream_base, &wrap->parent_stream_listener);
+    wrap->parent_stream_listener_base = wrap->parent_stream_base;
   }
 
   int32_t ignored = 0;


### PR DESCRIPTION
## Summary
Fixes a pre-existing, flaky **use-after-free** that segfaults `test/parallel/test-http2-session-unref.js` (**~9/100 on `main`**, 0/150 after this fix). It also silently soaks CI: the crash is intermittent, so runs pass or fail by luck.

## Root cause
An `Http2Session` registers `&wrap->parent_stream_listener` on its parent stream's base in `SessionConsume`. Several paths null `wrap->parent_stream_base` (its "the native parent stream is usable" meaning) **without unregistering the listener** — notably `ParentStreamOnRead` on `nread < 0` (parent EOF). `Http2SessionFinalize`'s removal is guarded on `parent_stream_base != nullptr`, so it's skipped, and `delete wrap` leaves the listener dangling in the parent stream's `listener_state.current`. The next `EmitAfterShutdown` (e.g. `JsStreamFinishShutdown`, when a JS-backed stream like `duplexPair` is used with http2) dereferences the freed listener:

```
JsStreamFinishShutdown → EdgeStreamBaseEmitAfterShutdown
 → EmitAfterShutdownFrom(listener=0xd116…GARBAGE) → SIGSEGV
```

## Fix
Track the base the listener is registered on in a dedicated `parent_stream_listener_base` field (set on push, used at finalize), so `Http2SessionFinalize` can always remove the listener regardless of the semantic `parent_stream_base`. `parent_handle_ref` keeps the parent base alive until finalize, and the removal is a safe no-op if an earlier path already removed it.

An earlier attempt that unregistered eagerly at read-EOF removed the SEGV but broke teardown (hung `test-http2-client-destroy`); the dedicated-field approach keeps the listener receiving shutdown/close events until finalize.

## Verification
- `test-http2-session-unref`: **0 SIGSEGV / 150 runs** (was ~9/100 on main)
- No teardown regression: `test-http2-client-destroy` unchanged vs main; `test-http2-client-jsstream-destroy`, `test-http2-compat-serverresponse-destroy`, `test-http2-client-upload`, `test-http2-server-rst-stream` all pass

## Relation to #104
Independent of #104 (which fixes the pipe/tcp/tty wrap-accessor heap-overflow). #104's red CI is this same flaky UAF, not #104's change — this fix unblocks it. #104 should rebase onto `main` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)