### PR TITLE
Fix use-after-free of libuv shutdown request (re-enables test-tls-alert-handling)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,13 +86,12 @@ EDGE_NODE_TEST_SKIP_CI_20260518 := \
   parallel/test-zlib-type-error.js \
   pseudo-tty/console_colors.js
 # Additional intermittent CI failures quarantined 2026-07-03 (shared by both
-# lanes). test-tls-alert-handling SIGSEGVs on macOS during TLS alert teardown
-# (already skipped on QuickJS via QUICKJS_SKIP_TLS_TESTS; also flakes the V8
-# lane, so skip it here for both). test-http-pipeline-requests-connection-leak
-# is timing-sensitive like the already-quarantined http keepalive-timeout tests
-# and intermittently fails on Linux.
+# lanes). test-http-pipeline-requests-connection-leak is a throughput stress
+# test (10k pipelined requests / ~160 MB of responses) that races the 10s
+# per-test timeout under parallel CI load. (test-tls-alert-handling was also
+# quarantined here for a macOS SIGSEGV; that shutdown-request use-after-free is
+# fixed in this change, so it is re-enabled.)
 EDGE_NODE_TEST_SKIP_CI_20260703 := \
-  parallel/test-tls-alert-handling.js \
   parallel/test-http-pipeline-requests-connection-leak.js
 EDGE_NODE_TEST_SKIP_TESTS ?= $(subst $(SPACE),$(COMMA),$(strip $(EDGE_NODE_TEST_SKIP_CI_20260518) $(EDGE_NODE_TEST_SKIP_CI_20260703)))
 
@@ -102,7 +101,6 @@ QUICKJS_SKIP_USING_PARSER_TESTS := parallel/test-stream-duplex-destroy.js,parall
 # tests time out or fail in the QuickJS lane while V8 continues to cover them.
 QUICKJS_SKIP_WORKER_TESTS := parallel/test-diagnostics-channel-worker-threads.js,client-proxy/test-http-proxy-request-invalid-char-in-url.mjs,parallel/test-crypto-key-objects-messageport.js,parallel/test-crypto-prime.js,parallel/test-crypto-worker-thread.js,parallel/test-http2-reset-flood.js,parallel/test-webcrypto-cryptokey-workers.js
 # QuickJS currently regresses TLS close-notify handling under --expose-internals.
-# (test-tls-alert-handling is quarantined for both lanes in the 2026-07-03 list.)
 QUICKJS_SKIP_TLS_TESTS := parallel/test-tls-close-notify.js
 QUICKJS_SKIP_TESTS ?= $(EDGE_NODE_TEST_SKIP_TESTS),$(QUICKJS_SKIP_USING_PARSER_TESTS),$(QUICKJS_SKIP_WORKER_TESTS),$(QUICKJS_SKIP_TLS_TESTS)
 

--- a/src/edge_stream_base.cc
+++ b/src/edge_stream_base.cc
@@ -2019,6 +2019,14 @@ napi_value EdgeLibuvStreamShutdown(EdgeStreamBase* base, napi_value req_obj) {
   if (rc != 0) {
     EdgeStreamBaseSetReqError(base->env, req_obj, rc);
     EdgeStreamReqMarkDone(base->env, req_obj);
+    // uv_shutdown failed synchronously, so OnShutdownDone will never run. Undo
+    // the active-request registration before freeing sr; otherwise the freed
+    // request stays in the Environment's active list and CancelActiveRequests()
+    // calls uv_cancel() on it during cleanup (use-after-free).
+    if (sr->active_request_token != nullptr) {
+      EdgeUnregisterActiveRequestToken(base->env, sr->active_request_token);
+      sr->active_request_token = nullptr;
+    }
     DeleteRefIfPresent(base->env, &sr->req_obj_ref);
     delete sr;
   }


### PR DESCRIPTION
## Summary
Root-causes and fixes the intermittent, macOS-only **SIGSEGV** that made `test-tls-alert-handling` flaky (quarantined in #108), and re-enables the test.

It's a **use-after-free of a `uv_shutdown` request** in the shared libuv stream-shutdown path (`edge_stream_base.cc`) — not TLS-specific:

1. `EdgeLibuvStreamShutdown` allocates a `LibuvShutdownReq` and **registers it in the Environment's active-request list** (so it can be cancelled at cleanup), then calls `uv_shutdown`.
2. When `uv_shutdown` fails **synchronously** (`rc != 0`) — e.g. the parent socket is already closing during a TLS-over-TCP teardown — the request is `delete`d **without being unregistered** (the async path, `OnShutdownDone`, unregisters before freeing; the sync-failure branch forgot).
3. The freed request stays in the active list, and `Environment::CancelActiveRequests()` calls `uv_cancel()` on it during process cleanup → **UAF**.

On Linux the freed block is still readable (test passes); on macOS the allocator reuses/unmaps it → SIGSEGV. `test-tls-alert-handling` drives exactly this path (it feeds a malformed TLS record, triggering the errored teardown).

## Fix
Unregister the active-request token before freeing in the synchronous-failure branch, mirroring `OnShutdownDone`. Because it's the shared shutdown path, this also hardens **TCP / Pipe / TTY**, not just TLS.

## Verification
ASAN build: the exact `heap-use-after-free` reproduced **1/1** in `uv_cancel` (freed by `EdgeLibuvStreamShutdown`) before the fix, **0/30** after; the test passes.

```
freed by:  EdgeLibuvStreamShutdown  edge_stream_base.cc:2023 (delete sr)
used by:   uv_cancel <- Environment::CancelActiveRequests()  (process cleanup)
```

## Test re-enable
Removes `parallel/test-tls-alert-handling.js` from the `EDGE_NODE_TEST_SKIP_CI_20260703` list (it was quarantined while this was being diagnosed). It stays skipped in the separate pre-existing `WASIX_SKIP_PARITY_TESTS` list; I'm verifying whether the fix lets it run under WASIX too and will follow up if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)