### PR TITLE
CI: ship quickjs-wasm/etc in the WASIX dist zip (fixes publish-nightly)

### DIFF
--- a/.github/workflows/test-and-build-quickjs.yml
+++ b/.github/workflows/test-and-build-quickjs.yml
@@ -425,9 +425,10 @@ jobs:
           set -euo pipefail
           make dist-only BUILD_DIR=build-quickjs-wasix JOBS=4 ZIP_NAME=edge-quickjs-wasix.zip
           cp quickjs-wasm/wasmer.toml dist/wasmer.toml
+          cp -R quickjs-wasm/etc dist/etc
           perl -0pi -e 's#^source = ".*"#source = "./bin/edgejs"#m; s#"/usr/local/ssl" = "\.\./ssl-certs"#"/usr/local/ssl" = "./ssl-certs"#m' dist/wasmer.toml
           rm -f edge-quickjs-wasix.zip
-          (cd dist && zip -r ../edge-quickjs-wasix.zip bin bin-compat README.md wasmer.toml ssl-certs)
+          (cd dist && zip -r ../edge-quickjs-wasix.zip bin bin-compat README.md wasmer.toml ssl-certs etc)
 
       - name: Upload artifact edge
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
publish-nightly has been failing on main (since before #119 — same failure on the 2026-07-15 run) with:

```
error: While trying to build the package locally
│   1: While parsing the manifest (loaded from .../release-assets/wasix/unpacked/wasmer.toml)
╰─▶ 2: Path: "./etc" does not exist
```

`quickjs-wasm/wasmer.toml` gained a `"/etc" = "./etc"` mapping (guest `/etc/hosts`), but the quickjs workflow's "Generate dist" step copies that manifest into `dist/` without the `etc/` directory it references, and the zip line doesn't include it either. Copy the directory and add it to the archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)