### PR TITLE
framework-test: require an expected status before declaring a server ready

### DIFF
--- a/scripts/framework-test.js
+++ b/scripts/framework-test.js
@@ -594,9 +594,9 @@ async function testProject(project, stage, index, total, preparation) {
   let server = null;
   let activeRuntime = runtime;
   let usedProductionFallback = false;
-  let readinessPath = routeReadinessPath(project, stage, activeRuntime);
+  let readiness = routeReadinessTarget(project, stage, activeRuntime);
   try {
-    server = await startProjectServer(project, runtime, portCandidates, stage, readinessPath);
+    server = await startProjectServer(project, runtime, portCandidates, stage, readiness);
   } catch (error) {
     const fallbackRuntime = await maybePrepareProductionFallback(project, stage, runtime, shouldBuild, reuseExistingBuild, error);
     if (!fallbackRuntime) {
@@ -604,8 +604,8 @@ async function testProject(project, stage, index, total, preparation) {
     }
     activeRuntime = fallbackRuntime;
     usedProductionFallback = true;
-    readinessPath = routeReadinessPath(project, stage, activeRuntime);
-    server = await startProjectServer(project, fallbackRuntime, portCandidates, stage, readinessPath);
+    readiness = routeReadinessTarget(project, stage, activeRuntime);
+    server = await startProjectServer(project, fallbackRuntime, portCandidates, stage, readiness);
   }
   try {
     const routeResults = await validateRouteMatrix(project, activeRuntime, server.port, routes);
@@ -1151,10 +1151,11 @@ async function runProjectBuild(project, stage) {
   });
 }
 
-async function startProjectServer(project, runtime, portCandidates, stage, readinessPath) {
-  const readyPath = normalizeRoutePath(readinessPath);
+async function startProjectServer(project, runtime, portCandidates, stage, readiness) {
+  const readyPath = normalizeRoutePath(readiness.path);
+  const readyStatus = readiness.status;
   if (runtime.mode === 'static-export') {
-    return startStaticExportServer(project, runtime, portCandidates, stage, readyPath);
+    return startStaticExportServer(project, runtime, portCandidates, stage, { path: readyPath, status: readyStatus });
   }
 
   const logPath = serverLogPath(project, stage);
@@ -1182,7 +1183,7 @@ async function startProjectServer(project, runtime, portCandidates, stage, readi
       });
 
       try {
-        const response = await waitForHttpResponse(handle, buildRouteUrl(port, readyPath));
+        const response = await waitForHttpResponse(handle, buildRouteUrl(port, readyPath), readyStatus);
         return {
           candidate,
           handle,
@@ -1210,7 +1211,7 @@ async function startProjectServer(project, runtime, portCandidates, stage, readi
   });
 }
 
-async function startStaticExportServer(project, runtime, portCandidates, stage, readinessPath) {
+async function startStaticExportServer(project, runtime, portCandidates, stage, readiness) {
   if (!fs.existsSync(runtime.outputDir)) {
     fail(`expected static output directory for ${project.name}: ${runtime.outputDir}`);
   }
@@ -1237,7 +1238,7 @@ async function startStaticExportServer(project, runtime, portCandidates, stage, 
     });
 
     try {
-      const response = await waitForHttpResponse(handle, buildRouteUrl(port, readinessPath || '/'));
+      const response = await waitForHttpResponse(handle, buildRouteUrl(port, readiness.path || '/'), readiness.status);
       return {
         candidate: {
           description: 'static export fallback',
@@ -1576,9 +1577,16 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
 }
 
-async function waitForHttpResponse(handle, url) {
+// expectStatus, when provided, keeps the readiness poll going until the server
+// answers with a status the readiness route actually expects. A completed
+// response is not proof of readiness: frameworks that bind the port before
+// their route table is wired (Total.js, notably) answer 404 for a beat, and
+// treating that as ready makes the very next request race the same 404.
+async function waitForHttpResponse(handle, url, expectStatus) {
   const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  const wanted = Array.isArray(expectStatus) && expectStatus.length > 0 ? expectStatus : null;
   let lastError = null;
+  let lastStatus = null;
 
   while (Date.now() < deadline) {
     if (handle.exited) {
@@ -1590,16 +1598,30 @@ async function waitForHttpResponse(handle, url) {
 
     const response = await requestHttp(url);
     if (response.ok) {
-      return response;
+      if (!wanted || wanted.includes(response.statusCode)) {
+        return response;
+      }
+      lastStatus = response.statusCode;
+    } else {
+      lastError = response.error;
     }
 
-    lastError = response.error;
     await delay(HTTP_POLL_INTERVAL_MS);
   }
 
   if (handle.exited) {
     fail(formatProcessFailure(handle), {
       detail: summarizeLogFailure(handle.logPath),
+      logPath: handle.logPath,
+    });
+  }
+
+  // Deliberately not phrased as "timed out waiting": the server is up and
+  // answering, so retrying on another port cannot help. See
+  // shouldRetryWithAnotherPort().
+  if (lastStatus != null) {
+    fail(`${url} never returned an expected status (last: ${lastStatus}, expected ${wanted.join(' or ')})`, {
+      detail: summarizeLogFailure(handle.logPath, lastError),
       logPath: handle.logPath,
     });
   }
@@ -1759,12 +1781,14 @@ function routesJsonPath(project) {
   return path.join(project.dir, ROUTES_JSON_BASENAME);
 }
 
-function routeReadinessPath(project, stage, runtime) {
+// The readiness probe reuses the first configured route, so it can also reuse
+// that route's expected statuses to decide when the server is really up.
+function routeReadinessTarget(project, stage, runtime) {
   const routes = loadRouteMatrix(project, stage, runtime);
   if (routes.length === 0) {
-    return '/';
+    return { path: '/', status: null };
   }
-  return routes[0].path;
+  return { path: routes[0].path, status: routes[0].expect.status };
 }
 
 function loadRouteMatrix(project, stage, runtime) {

--- a/scripts/lib/framework-test-shared.js
+++ b/scripts/lib/framework-test-shared.js
@@ -829,12 +829,14 @@ function create(options) {
       .filter((route) => routeAppliesToStage(route, stage, runtime));
   }
 
-  function routeReadinessPath(project, stage, runtime, routesFile) {
+  // The readiness probe reuses the first configured route, so it can also reuse
+  // that route's expected statuses to decide when the server is really up.
+  function routeReadinessTarget(project, stage, runtime, routesFile) {
     const routes = loadRouteMatrix(project, stage, runtime, routesFile);
     if (routes.length === 0) {
-      return '/';
+      return { path: '/', status: null };
     }
-    return routes[0].path;
+    return { path: routes[0].path, status: routes[0].expect.status };
   }
 
   function summarizeBodySnippet(body) {
@@ -1128,9 +1130,16 @@ function create(options) {
     return handle;
   }
 
-  async function waitForHttpResponse(handle, url) {
+  // expectStatus, when provided, keeps the readiness poll going until the server
+  // answers with a status the readiness route actually expects. A completed
+  // response is not proof of readiness: frameworks that bind the port before
+  // their route table is wired (Total.js, notably) answer 404 for a beat, and
+  // treating that as ready makes the very next request race the same 404.
+  async function waitForHttpResponse(handle, url, expectStatus) {
     const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+    const wanted = Array.isArray(expectStatus) && expectStatus.length > 0 ? expectStatus : null;
     let lastError = null;
+    let lastStatus = null;
 
     while (Date.now() < deadline) {
       if (handle.exited) {
@@ -1142,16 +1151,29 @@ function create(options) {
 
       const response = await requestHttp(url);
       if (response.ok) {
-        return response;
+        if (!wanted || wanted.includes(response.statusCode)) {
+          return response;
+        }
+        lastStatus = response.statusCode;
+      } else {
+        lastError = response.error;
       }
 
-      lastError = response.error;
       await delay(HTTP_POLL_INTERVAL_MS);
     }
 
     if (handle.exited) {
       fail(formatProcessFailure(handle), {
         detail: summarizeLogFailure(handle.logPath),
+        logPath: handle.logPath,
+      });
+    }
+
+    // Deliberately not phrased as "timed out waiting": the server is up and
+    // answering, so retrying on another port cannot help.
+    if (lastStatus != null) {
+      fail(`${url} never returned an expected status (last: ${lastStatus}, expected ${wanted.join(' or ')})`, {
+        detail: summarizeLogFailure(handle.logPath, lastError),
         logPath: handle.logPath,
       });
     }
@@ -1412,7 +1434,7 @@ function create(options) {
     requestHttp,
     resolveHostNodeRunner,
     resolveRunnerTarget,
-    routeReadinessPath,
+    routeReadinessTarget,
     runRunnerStage,
     runSyncOrFail,
     shellQuote,

--- a/scripts/standalone-build-test.js
+++ b/scripts/standalone-build-test.js
@@ -39,7 +39,7 @@ const {
   readJsonFile,
   resolveHostNodeRunner,
   resolveRunnerTarget,
-  routeReadinessPath,
+  routeReadinessTarget,
   runRunnerStage,
   shellQuote,
   spawnLoggedProcess,
@@ -301,7 +301,6 @@ async function testProject(project, stage, index, total, preparation) {
     fail(`standalone entry missing for ${project.name}: ${entryAbsolutePath}`);
   }
 
-  const readinessPath = routeReadinessPath(project, stage, runtime, routesFile);
   const server = await startStandaloneEntry(project, stage, portCandidates, runtime);
   try {
     const routes = loadRouteMatrix(project, stage, runtime, routesFile);
@@ -411,8 +410,8 @@ async function startStandaloneEntry(project, stage, portCandidates, runtime) {
     });
 
     try {
-      const readinessPath = routeReadinessPath(project, stage, runtime, project.standalone.routes);
-      const response = await waitForHttpResponse(handle, buildRouteUrl(port, readinessPath));
+      const readiness = routeReadinessTarget(project, stage, runtime, project.standalone.routes);
+      const response = await waitForHttpResponse(handle, buildRouteUrl(port, readiness.path), readiness.status);
       return {
         handle,
         logPath,


### PR DESCRIPTION
## The bug

`waitForHttpResponse()` treated **any completed HTTP response** as proof the server was up — `requestHttp()` sets `ok: true` on completion regardless of status, so a 404 counted as ready.

Combined with `routeReadinessPath()` using the *first configured route* as the readiness probe, that's a race for any framework that binds its port before wiring its route table:

1. Framework binds the port, starts answering, route table not yet populated
2. Readiness probe hits the route, gets 404, declares the server ready
3. Route validation immediately hits the same route — same 404 — and fails

## The reproducer

`js-totaljs-cms` has exactly one route, `/admin`, so it serves as both readiness probe and assertion:

| Run | Stage | Time after start | Result |
|---|---|---|---|
| 29732599602 | QuickJS WASIX | 1.03s | **404 — failed** |
| 29598931774 | QuickJS WASIX | 1.02s | 200 — passed |
| 29732599602 | Node.js | 0.52s | 200 — passed |

Same code, same timing, opposite outcome. Node and native usually win the race; WASIX is slower to register routes, which is why it surfaced there. This is what blocked the nightly run after the gatsby fix landed.

## The fix

Thread the readiness route's expected statuses into the poll, so a response only ends the wait when its status is one the route actually expects. Routes that legitimately expect a non-2xx status still return immediately — the check consults `expect.status` rather than hardcoding 200.

The exhausted-deadline path deliberately avoids the phrase *"timed out waiting"*: `shouldRetryWithAnotherPort()` classifies that as retryable, and a server that's up but answering wrongly can't be fixed by changing ports. Without the distinct message this would burn `SERVER_READY_TIMEOUT_MS` (45s) on each of 10 candidate ports.

Also applied to `standalone-build-test.js`, which shares the helper and had the same race. `routeReadinessPath()` folds into `routeReadinessTarget()` (returns path + expected statuses); its last caller assigned it to an unused variable.

## Test

Exercised the shared helper directly against a server that 404s for 2s before answering 200:

```
no-expect   : returned status=404 after 17ms      <- the old behavior, i.e. the bug
expect-200  : returned status=200 after 2010ms    <- waits out the race
expect-404  : returned status=404 after 1ms       <- tolerant routes unaffected
```

And a permanently-404ing server:

```
failed after 45124ms
message: http://127.0.0.1:44061/admin never returned an expected status (last: 404, expected 200)
classified retryable (would try 10 ports)? false
```

`make framework-test-quickjs-native FRAMEWORK_TEST_SELECTOR=js-totaljs-cms` passes both stages. Note that app passed before this change too — native is fast enough to usually win the race — so the synthetic tests above are the real evidence, not that run.

## Caveat

This closes the readiness race, but any app whose first route is slow to wire now spends longer in the readiness poll rather than failing fast. That's the intended trade, and the 45s ceiling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)