### PR TITLE
Make the version suffix a valid semver pre-release identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,14 @@ endif()
 if(EDGE_VERSION_COMMIT STREQUAL "")
   set(EDGE_VERSION_COMMIT "unknown")
 endif()
+# The "g" prefix (git-describe convention) keeps the suffix a valid semver
+# pre-release identifier. A bare short SHA that happens to be all digits with a
+# leading zero -- e.g. 0692402 -- is a *numeric* identifier, and semver forbids
+# leading zeros on those, so `wasmer publish --version=0.0.0-0692402` is
+# rejected outright. Roughly 1 commit in 270 hits this.
 set(EDGE_VERSION_SUFFIX "")
 if(NOT EDGE_VERSION_COMMIT STREQUAL "unknown")
-  set(EDGE_VERSION_SUFFIX "-${EDGE_VERSION_COMMIT}")
+  set(EDGE_VERSION_SUFFIX "-g${EDGE_VERSION_COMMIT}")
 endif()
 if(EXISTS "${PROJECT_ROOT}/napi/v8/cmake/NapiBuildCache.cmake")
   include("${PROJECT_ROOT}/napi/v8/cmake/NapiBuildCache.cmake")


### PR DESCRIPTION
## The bug

`EDGE_VERSION_SUFFIX` is a bare 7-char short SHA (`CMakeLists.txt:35`). When that SHA happens to be **all digits with a leading zero**, it parses as a *numeric* semver pre-release identifier — and semver forbids leading zeros on those. The version isn't merely unusual, it's invalid.

This fired for the first time on 06924022 (#121), short SHA `0692402`. `publish-nightly` reached `wasmer publish` — the first time it had ever got that far, after 37b039c2 fixed the `./etc` manifest bug — and was rejected at argument parsing:

```
error: invalid value '0.0.0-0692402' for '--version <PACKAGE_VERSION>':
       invalid leading zero in pre-release identifier
```

Re-running can't help: the same commit always yields the same SHA. It needs the short SHA to be all digits *and* start with zero — roughly 1 commit in 270 — which is why every previously published version (`0.0.0-ad307e3`, `0.0.0-8f4b341`, `0.0.0-5ad7db6`, `0.0.0-20bd0b8`) got away with it.

## The fix

Prefix with `g`, git-describe convention, so the identifier is always alphanumeric and can never be parsed as numeric.

Fixing it in CMake rather than sanitizing in the workflow keeps `process.versions.edge` itself valid semver. That matters because it's the single source of truth in three places:

- both nightly workflows derive the published version from it (`test-and-build-quickjs.yml:302`, `test-and-build.yml:302`)
- `EDGE_DEFAULT_WASMER_PACKAGE` (`src/edge_compat_exec.cc:28`) pins `wasmer/edgejs@=EDGE_VERSION_STRING` from the same macro

So the published version and the runtime pin shift together and stay consistent.

## Behavior change

Versions now read `0.0.0-g<sha>` instead of `0.0.0-<sha>`. No test asserts the old shape. The registry will carry both forms across the cutover; already-published versions are untouched.

## Test

Against wasmer 7.2.0 — the version CI installs — reproducing the parse-time rejection offline:

```
0.0.0-0692402    -> REJECTED: invalid leading zero in pre-release identifier
0.0.0-g0692402   -> accepted
0.0.0-gf1d02e4   -> accepted
```

And running the edited CMake block against the current tree:

```
-- COMMIT=f1d02e4
-- SUFFIX=-gf1d02e4
```

## Context

Third distinct blocker in the chain that has kept nightlies red since 2026-06-30 — after the `./etc` manifest bug (#120) and the gatsby external-fetch flake (#121). Note that #122 landing already gives `main` a letter-containing SHA (`f1d02e4`), so the *next* nightly would publish regardless. This PR is what stops it recurring on some future unlucky commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)