### PR TITLE
EdgeJS QuickJS: explicit resource management via quickjs-ng v0.15.1 (ECO-382)

### DIFF
--- a/.github/workflows/test-and-build-quickjs.yml
+++ b/.github/workflows/test-and-build-quickjs.yml
@@ -149,6 +149,12 @@ jobs:
           set -euo pipefail
           make test-quickjs-intl
 
+      - name: Test language (explicit resource management, QuickJS native)
+        shell: bash
+        run: |
+          set -euo pipefail
+          make test-quickjs-lang
+
       - name: Test framework apps (QuickJS native)
         shell: bash
         run: |
@@ -274,6 +280,12 @@ jobs:
         run: |
           set -euo pipefail
           make test-quickjs-intl
+
+      - name: Test language (explicit resource management, QuickJS native)
+        shell: bash
+        run: |
+          set -euo pipefail
+          make test-quickjs-lang
 
       - name: Test framework apps (QuickJS native)
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,12 @@ EDGE_NODE_TEST_SKIP_CI_20260703 := \
   parallel/test-http-pipeline-requests-connection-leak.js
 EDGE_NODE_TEST_SKIP_TESTS ?= $(subst $(SPACE),$(COMMA),$(strip $(EDGE_NODE_TEST_SKIP_CI_20260518) $(EDGE_NODE_TEST_SKIP_CI_20260703)))
 
-# QuickJS currently cannot parse explicit resource management `using` syntax.
-QUICKJS_SKIP_USING_PARSER_TESTS := parallel/test-stream-duplex-destroy.js,parallel/test-stream-readable-dispose.js,parallel/test-stream-transform-destroy.js,parallel/test-stream-writable-destroy.js
 # QuickJS worker_threads/MessagePort support is incomplete; these worker-backed
 # tests time out or fail in the QuickJS lane while V8 continues to cover them.
 QUICKJS_SKIP_WORKER_TESTS := parallel/test-diagnostics-channel-worker-threads.js,client-proxy/test-http-proxy-request-invalid-char-in-url.mjs,parallel/test-crypto-key-objects-messageport.js,parallel/test-crypto-prime.js,parallel/test-crypto-worker-thread.js,parallel/test-http2-reset-flood.js,parallel/test-webcrypto-cryptokey-workers.js
 # QuickJS currently regresses TLS close-notify handling under --expose-internals.
 QUICKJS_SKIP_TLS_TESTS := parallel/test-tls-close-notify.js
-QUICKJS_SKIP_TESTS ?= $(EDGE_NODE_TEST_SKIP_TESTS),$(QUICKJS_SKIP_USING_PARSER_TESTS),$(QUICKJS_SKIP_WORKER_TESTS),$(QUICKJS_SKIP_TLS_TESTS)
+QUICKJS_SKIP_TESTS ?= $(EDGE_NODE_TEST_SKIP_TESTS),$(QUICKJS_SKIP_WORKER_TESTS),$(QUICKJS_SKIP_TLS_TESTS)
 
 # Expected WASIX environment limits from the 2026-06-23 triage run (1674 passed /
 # 64 failed). These 52 tests are unix sockets, cluster/fork, subprocess/shell,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-edge build-edge-quickjs-cli build-wasix build-quickjs-wasix build-napi build-napi-quickjs build-native-v8 build-native-quickjs build-wasix-napi build-wasix-napi-quickjs build-napi-wasmer-cli test-wasix-napi test-wasix-napi-quickjs test-wasix-napi-cli test-wasix-safe-mode test-wasix-quickjs-only test-quickjs-intl test-wasix-quickjs-intl test test-only check-portability clean clean-napi-quickjs clean-edge-quickjs-cli clean-dist dist dist-only framework-test framework-test-quickjs-native framework-test-quickjs-wasix framework-test-run framework-test-reset standalone-build-test standalone-build-test-run standalone-build-test-quickjs-native standalone-build-test-quickjs-wasix
+.PHONY: build build-edge build-edge-quickjs-cli build-wasix build-quickjs-wasix build-napi build-napi-quickjs build-native-v8 build-native-quickjs build-wasix-napi build-wasix-napi-quickjs build-napi-wasmer-cli test-wasix-napi test-wasix-napi-quickjs test-wasix-napi-cli test-wasix-safe-mode test-wasix-quickjs-only test-quickjs-intl test-quickjs-lang test-wasix-quickjs-intl test test-only check-portability clean clean-napi-quickjs clean-edge-quickjs-cli clean-dist dist dist-only framework-test framework-test-quickjs-native framework-test-quickjs-wasix framework-test-run framework-test-reset standalone-build-test standalone-build-test-run standalone-build-test-quickjs-native standalone-build-test-quickjs-wasix
 
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -380,6 +380,20 @@ test-quickjs-intl:
 	  EDGE_BYTECODE_CACHE=0 $(QUICKJS_EDGE_BINARY) "$(CURDIR)/test/$$t.js"; \
 	done
 	@echo "[intl native] all locale tests passed"
+
+# Language-level tests run directly against the QuickJS edge binary. These are
+# edgejs-owned (under tests/js, not the vendored node-test submodule) and are
+# self-contained, so they need neither the node-test harness nor a module
+# category.
+QUICKJS_LANG_TESTS := \
+  quickjs-explicit-resource-management
+
+test-quickjs-lang:
+	@set -e; for t in $(QUICKJS_LANG_TESTS); do \
+	  echo "[lang native] $$t"; \
+	  EDGE_BYTECODE_CACHE=0 $(QUICKJS_EDGE_BINARY) "$(CURDIR)/tests/js/$$t.js"; \
+	done
+	@echo "[lang native] all language tests passed"
 
 test-wasix-quickjs-intl:
 	@command -v "$(WASMER_BIN)" >/dev/null 2>&1 || { \

--- a/tests/js/quickjs-explicit-resource-management.js
+++ b/tests/js/quickjs-explicit-resource-management.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// Explicit resource management (`using` / `await using`) on the EdgeJS QuickJS
+// provider. The engine gained this syntax with the quickjs-ng v0.15.1 bump
+// (ECO-382); this exercises the core disposal semantics end to end through the
+// edge binary, complementing the node stream dispose tests.
+//
+// Self-contained (uses only the `assert` builtin) so it can run directly via
+// `make test-quickjs-lang` without the node-test harness. A non-zero exit
+// signals failure; the async guard below fails the run if the async block is
+// skipped or rejects.
+
+const assert = require('assert');
+
+// Well-known disposal symbols exist.
+assert.strictEqual(typeof Symbol.dispose, 'symbol');
+assert.strictEqual(typeof Symbol.asyncDispose, 'symbol');
+
+// 1. Synchronous `using` disposes in reverse (LIFO) order at scope exit.
+{
+  const order = [];
+  {
+    using a = { [Symbol.dispose]() { order.push('a'); } };
+    using b = { [Symbol.dispose]() { order.push('b'); } };
+    order.push('body');
+  }
+  assert.deepStrictEqual(order, ['body', 'b', 'a']);
+}
+
+// 2. Disposal still runs when the block exits via a thrown error.
+{
+  const order = [];
+  assert.throws(() => {
+    using a = { [Symbol.dispose]() { order.push('dispose-a'); } };
+    order.push('before-throw');
+    throw new Error('boom');
+  }, /boom/);
+  assert.deepStrictEqual(order, ['before-throw', 'dispose-a']);
+}
+
+// 3. `null`/`undefined` resources are allowed and simply skipped.
+{
+  let disposed = false;
+  {
+    using a = null;
+    using b = undefined;
+    using c = { [Symbol.dispose]() { disposed = true; } };
+  }
+  assert.strictEqual(disposed, true);
+}
+
+// 4. When both the body and a disposer throw, the disposal error is surfaced as
+//    a SuppressedError wrapping the original.
+{
+  assert.throws(() => {
+    using a = { [Symbol.dispose]() { throw new Error('dispose-error'); } };
+    throw new Error('body-error');
+  }, (err) => {
+    assert.strictEqual(err.name, 'SuppressedError');
+    assert.strictEqual(err.error.message, 'dispose-error');
+    assert.strictEqual(err.suppressed.message, 'body-error');
+    return true;
+  });
+}
+
+// 5. `await using` awaits async disposal, in LIFO order, after the body.
+async function asyncDisposal() {
+  const order = [];
+  {
+    await using a = {
+      async [Symbol.asyncDispose]() {
+        await Promise.resolve();
+        order.push('a');
+      },
+    };
+    await using b = {
+      [Symbol.asyncDispose]() { order.push('b'); },
+    };
+    order.push('body');
+  }
+  assert.deepStrictEqual(order, ['body', 'b', 'a']);
+}
+
+// 6. `await using` disposal runs on an async throw too.
+async function asyncDisposalOnThrow() {
+  const order = [];
+  await assert.rejects(async () => {
+    await using a = {
+      async [Symbol.asyncDispose]() { order.push('dispose'); },
+    };
+    order.push('before-throw');
+    throw new Error('async-boom');
+  }, /async-boom/);
+  assert.deepStrictEqual(order, ['before-throw', 'dispose']);
+}
+
+// Guard: fail the process if the async block does not run to completion.
+let asyncCompleted = false;
+process.on('exit', () => {
+  if (!asyncCompleted) {
+    console.error('async explicit-resource-management block did not complete');
+    process.exit(1);
+  }
+});
+
+(async () => {
+  await asyncDisposal();
+  await asyncDisposalOnThrow();
+  asyncCompleted = true;
+  console.log('explicit resource management: OK');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes **ECO-382** — the QuickJS provider could not parse `using` / `await using` (explicit resource management). Fixed by bumping the vendored engine to **quickjs-ng v0.15.1** (upstream PR #1458) via the napi submodule.

### Changes
- **Bump napi submodule** → pulls quickjs-ng v0.15.1 into the QuickJS provider.
- **Re-enable the 4 stream dispose tests** previously skipped for the parser gap (`QUICKJS_SKIP_USING_PARSER_TESTS` removed): test-stream-{duplex-destroy,readable-dispose,transform-destroy,writable-destroy}.
- **Add a focused ERM test** (`tests/js/quickjs-explicit-resource-management.js`, edgejs-owned, self-contained) run via a new `make test-quickjs-lang` target, wired into both QuickJS-native CI lanes. Covers sync LIFO disposal, disposal on throw, null/undefined resources, SuppressedError, async disposal ordering, and async disposal on throw.

### Verification
- `using` / `await using` work on the edge binary (correct LIFO disposal, sync + async).
- Full `make test-quickjs-only`: **1741 passed, 0 failed** (incl. the 4 re-enabled tests).
- Leak check: 100k requests against non-WASM totaljs-cms → RSS flat at 105120 kB across 16 rounds, 0 failures — no leak.

### Merge chain (bottom-up)
1. wasmerio/quickjs **#8**
2. wasmerio/napi (bump quickjs pointer)
3. **this PR** (bump napi pointer + tests)

Merge last, after the napi PR, so the napi commit this points at is on napi `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)