### PR TITLE
N-API handle-scope discipline in guest dispatch paths

### DIFF
--- a/src/edge_environment.cc
+++ b/src/edge_environment.cc
@@ -928,6 +928,9 @@ void Environment::EmitProcessWarning(const std::string& message,
                                      const char* type,
                                      const char* code) const {
   if (env_ == nullptr || message.empty() || !can_call_into_js()) return;
+  // Called from native fd tracking with no ambient scope.
+  edge::HandleScope handle_scope(env_);
+  if (!handle_scope.is_open()) return;
   napi_value global = nullptr;
   napi_value process = nullptr;
   napi_value emit_warning = nullptr;

--- a/src/edge_module_loader.cc
+++ b/src/edge_module_loader.cc
@@ -29,6 +29,7 @@
 #include "edge_udp_wrap.h"
 #include "edge_url.h"
 #include "edge_environment.h"
+#include "edge_handle_scope.h"
 #include "edge_loader_bindings.h"
 #include "edge_util.h"
 #include "edge_worker_env.h"
@@ -150,6 +151,12 @@ static void DestroyContextifyScriptInstance(napi_env env,
                                             bool detach_wrapper) {
   if (instance == nullptr) return;
   if (env == nullptr && instance->state != nullptr) env = instance->state->env;
+
+  // Runs from a napi_wrap finalizer; own the values minted below instead of
+  // relying on a runtime-provided finalizer scope. Cleanup continues even if
+  // the scope fails to open (env teardown) — the ref deletions below must run.
+  std::optional<edge::HandleScope> handle_scope;
+  if (env != nullptr) handle_scope.emplace(env);
 
   if (env != nullptr && instance->wrapper_ref != nullptr) {
     napi_value wrapper = nullptr;

--- a/src/edge_runtime.cc
+++ b/src/edge_runtime.cc
@@ -1339,6 +1339,13 @@ int HandleExtractedException(napi_env env,
 }
 
 int HandlePendingExceptionAfterLoopStep(napi_env env, std::string* error_out) {
+  // Mints exception/stringification values; callers are not guaranteed to hold
+  // a scope. Results leave as std::string, so a plain scope suffices.
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) {
+    if (error_out != nullptr) *error_out = "Failed to open handle scope";
+    return 1;
+  }
   PendingExceptionInfo pending = {};
   if (!TakePendingExceptionInfo(env, &pending) || !pending.has_exception) {
     return -1;
@@ -1612,7 +1619,11 @@ int WaitForTopLevelPromiseToSettle(napi_env env, napi_value value, std::string* 
   if (!IsPromisePending(env, value)) return -1;
 
   uv_loop_t* loop = EdgeGetEnvLoop(env);
-  while (IsPromisePending(env, value)) {
+  while (true) {
+    // Per-turn scope: each wait iteration mints promise-inspection values that
+    // must not accumulate in the caller's scope for the life of the wait.
+    edge::HandleScope turn_scope(env);
+    if (!turn_scope.is_open() || !IsPromisePending(env, value)) break;
     if (loop != nullptr) {
       (void)uv_run(loop, UV_RUN_NOWAIT);
     }
@@ -1814,6 +1825,13 @@ int RunEventLoopUntilQuiescent(napi_env env, std::string* error_out) {
 
   int idle_drain_turns = 0;
   while (true) {
+    // Per-turn scope: values minted by the loop turn itself (handle summaries,
+    // exception formatting, lifecycle events) must not outlive the iteration.
+    edge::HandleScope turn_scope(env);
+    if (!turn_scope.is_open()) {
+      if (error_out != nullptr) *error_out = "Failed to open loop handle scope";
+      return 1;
+    }
     if (IsProcessExiting(env)) {
       break;
     }
@@ -3195,16 +3213,13 @@ void EdgePrepareProcessExit(napi_env env, int exit_code) {
   }
 }
 
-napi_status EdgeMakeCallbackWithFlags(napi_env env,
-                                     napi_value recv,
-                                     napi_value callback,
-                                     size_t argc,
-                                     napi_value* argv,
-                                     napi_value* result,
-                                     int flags) {
-  if (env == nullptr || recv == nullptr || callback == nullptr) {
-    return napi_invalid_arg;
-  }
+static napi_status EdgeMakeCallbackWithFlagsImpl(napi_env env,
+                                                 napi_value recv,
+                                                 napi_value callback,
+                                                 size_t argc,
+                                                 napi_value* argv,
+                                                 napi_value* result,
+                                                 int flags) {
   thread_local int detached_callback_scope_depth = 0;
   edge::Environment* environment = EdgeEnvironmentGet(env);
   if (environment != nullptr) {
@@ -3261,6 +3276,35 @@ napi_status EdgeMakeCallbackWithFlags(napi_env env,
     environment->DecrementAsyncCallbackScopeDepth();
   } else {
     detached_callback_scope_depth--;
+  }
+  return status;
+}
+
+// The InternalCallbackScope equivalent: every native->JS callback dispatch owns
+// a handle scope so values minted during the callback (and its checkpoint) are
+// reclaimed when the dispatch completes. Escapable because the callback result
+// is returned to the caller through `result`.
+napi_status EdgeMakeCallbackWithFlags(napi_env env,
+                                     napi_value recv,
+                                     napi_value callback,
+                                     size_t argc,
+                                     napi_value* argv,
+                                     napi_value* result,
+                                     int flags) {
+  if (env == nullptr || recv == nullptr || callback == nullptr) {
+    return napi_invalid_arg;
+  }
+  edge::EscapableHandleScope scope(env);
+  if (!scope.is_open()) {
+    return scope.status();
+  }
+  napi_status status =
+      EdgeMakeCallbackWithFlagsImpl(env, recv, callback, argc, argv, result, flags);
+  if (result != nullptr && *result != nullptr) {
+    *result = scope.Escape(*result);
+    if (*result == nullptr && status == napi_ok) {
+      status = napi_generic_failure;
+    }
   }
   return status;
 }
@@ -3369,6 +3413,11 @@ napi_status EdgeRunCallbackScopeCheckpoint(napi_env env) {
 bool EdgeHandlePendingExceptionNow(napi_env env, bool* handled_out) {
   if (handled_out != nullptr) *handled_out = false;
   if (env == nullptr) return false;
+
+  // Reachable with no ambient scope (e.g. timers-host checkpoint failure path)
+  // and mints exception values; all results leave as bool/std::string.
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) return false;
 
   if (IsEnvironmentExitRequested(env) ||
       (!EdgeWorkerEnvOwnsProcessState(env) && EdgeWorkerEnvStopRequested(env))) {

--- a/src/edge_udp_wrap.cc
+++ b/src/edge_udp_wrap.cc
@@ -710,6 +710,9 @@ class UdpWrap final : public EdgeUdpWrapBase, public EdgeUdpListener {
   uv_udp_t handle{};
   int32_t provider_type = kEdgeProviderUdpWrap;
   int64_t async_id = -1;
+  // Raw scratch handles, valid ONLY within one synchronous Send() activation
+  // (set/cleared around the call; promoted to napi_ref in CreateSendWrap).
+  // If Send ever becomes asynchronous these must become napi_ref.
   napi_value current_send_req_obj = nullptr;
   napi_value current_send_chunks_obj = nullptr;
   bool current_send_has_callback = false;

--- a/src/internal_binding/binding_performance.cc
+++ b/src/internal_binding/binding_performance.cc
@@ -1,5 +1,6 @@
 #include "internal_binding/binding_initializers.h"
 #include "internal_binding/binding_performance.h"
+#include "edge_handle_scope.h"
 
 #include <chrono>
 #include <cstdint>
@@ -317,6 +318,10 @@ void PerformanceEmitEntry(napi_env env,
                           napi_value details) {
   auto* state = GetPerformanceState(env);
   if (state == nullptr || state->observer_callback_ref == nullptr) return;
+  // Exported helper invoked from other bindings' dispatch paths; own the
+  // values it mints rather than relying on every caller's scope.
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) return;
   napi_value callback = nullptr;
   if (napi_get_reference_value(env, state->observer_callback_ref, &callback) != napi_ok ||
       callback == nullptr) {

--- a/src/internal_binding/binding_watchdog.cc
+++ b/src/internal_binding/binding_watchdog.cc
@@ -1,5 +1,6 @@
 #include "internal_binding/binding_initializers.h"
 #include "internal_binding/watchdog.h"
+#include "edge_handle_scope.h"
 
 #include <algorithm>
 #include <atomic>
@@ -111,6 +112,14 @@ std::string FormatCallSiteLine(napi_env env, napi_value callsite) {
 
 void PrintTraceSigintStack(napi_env env) {
   std::fputs("KEYBOARD_INTERRUPT: Script execution was interrupted by `SIGINT`\n", stderr);
+
+  // The unofficial_napi_request_interrupt fallback dispatches this with no
+  // ambient scope (the Environment::RequestInterrupt path is already scoped).
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) {
+    std::fflush(stderr);
+    return;
+  }
 
   napi_value callsites = nullptr;
   if (unofficial_napi_get_call_sites(env, 10, &callsites) != napi_ok || callsites == nullptr) {

--- a/src/internal_binding/binding_worker.cc
+++ b/src/internal_binding/binding_worker.cc
@@ -252,6 +252,14 @@ void OnWorkerReportInterrupt(napi_env env, void* data) {
     return;
   }
 
+  // The unofficial_napi_request_interrupt fallback dispatches this with no
+  // ambient scope (the Environment::RequestInterrupt path is already scoped).
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) {
+    CompleteWorkerReportTask(task, {});
+    return;
+  }
+
   std::string json;
   napi_value report_binding = EdgeGetReportBinding(env);
   napi_value get_report = GetNamed(env, report_binding, "getReport");

--- a/src/internal_binding/binding_zlib.cc
+++ b/src/internal_binding/binding_zlib.cc
@@ -1,4 +1,5 @@
 #include "internal_binding/binding_initializers.h"
+#include "edge_handle_scope.h"
 
 #include <algorithm>
 #include <array>
@@ -1237,6 +1238,11 @@ void ExecuteCompressionWork(napi_env /*env*/, void* data) {
 void CompleteCompressionWork(napi_env env, napi_status status, void* data) {
   auto* handle = static_cast<CompressionHandle*>(data);
   if (handle == nullptr) return;
+
+  // Threadpool completion dispatched outside any JS callback; own the values
+  // minted below (error strings, write results, callback dispatch).
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) return;
 
   napi_async_work work = handle->async_work;
   handle->async_work = nullptr;

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -374,6 +374,10 @@ void UvAfterWork(uv_work_t* req, int status) {
 void napi_v8_run_async_cleanup_hooks(napi_env env) {
   if (!CheckEnv(env)) return;
 
+  // Teardown path with no ambient scope; hooks may mint values.
+  edge::HandleScope handle_scope(env);
+  if (!handle_scope.is_open()) return;
+
   if (auto* environment = GetAttachedEnvironment(env); environment != nullptr) {
     environment->RunAsyncCleanupHooks();
     return;
@@ -428,6 +432,9 @@ napi_status NAPI_CDECL node_api_post_finalizer(node_api_basic_env env,
                                                void* finalize_hint) {
   napi_env napiEnv = const_cast<napi_env>(env);
   if (!CheckEnv(napiEnv) || finalize_cb == nullptr) return napi_invalid_arg;
+  // Finalizers may mint values and can run with no ambient scope.
+  edge::HandleScope handle_scope(napiEnv);
+  if (!handle_scope.is_open()) return handle_scope.status();
   finalize_cb(napiEnv, finalize_data, finalize_hint);
   return napi_ok;
 }
@@ -708,18 +715,32 @@ napi_status NAPI_CDECL napi_make_callback(napi_env env,
   if (!CheckEnv(env) || recv == nullptr || func == nullptr || (argc > 0 && argv == nullptr)) {
     return napi_invalid_arg;
   }
-  if (async_context == nullptr) {
-    return EdgeCallCallbackWithDomain(
-        env, recv, func, argc, const_cast<napi_value*>(argv), result);
+  // Addons invoke this from native contexts with no ambient handle scope; own
+  // the dispatch's values here (Node wraps this in InternalCallbackScope).
+  // Escapable because the callback result goes back through `result`.
+  edge::EscapableHandleScope handle_scope(env);
+  if (!handle_scope.is_open()) {
+    return handle_scope.status();
   }
+  napi_status call_status;
+  if (async_context == nullptr) {
+    call_status = EdgeCallCallbackWithDomain(
+        env, recv, func, argc, const_cast<napi_value*>(argv), result);
+  } else {
+    const napi_status scope_status = EnterAsyncContextScope(env, async_context);
+    if (scope_status != napi_ok) return scope_status;
 
-  const napi_status scope_status = EnterAsyncContextScope(env, async_context);
-  if (scope_status != napi_ok) return scope_status;
-
-  napi_status call_status =
-      EdgeCallCallbackWithDomain(env, recv, func, argc, const_cast<napi_value*>(argv), result);
-  const bool failed = (call_status != napi_ok) || HasPendingException(env);
-  ExitAsyncContextScope(env, async_context, failed);
+    call_status =
+        EdgeCallCallbackWithDomain(env, recv, func, argc, const_cast<napi_value*>(argv), result);
+    const bool failed = (call_status != napi_ok) || HasPendingException(env);
+    ExitAsyncContextScope(env, async_context, failed);
+  }
+  if (result != nullptr && *result != nullptr) {
+    *result = handle_scope.Escape(*result);
+    if (*result == nullptr && call_status == napi_ok) {
+      call_status = napi_generic_failure;
+    }
+  }
   return call_status;
 }
 

--- a/src/unofficial_napi_testing_until_gc.cc
+++ b/src/unofficial_napi_testing_until_gc.cc
@@ -2,6 +2,7 @@
 #include <string>
 
 #include "unofficial_napi.h"
+#include "edge_handle_scope.h"
 
 namespace {
 
@@ -88,6 +89,14 @@ napi_value UnofficialNapiTestingUntilGc(napi_env env, napi_callback_info info) {
   }
 
   while (true) {
+    // Per-iteration scope: the poll loop otherwise accumulates handles in the
+    // enclosing callback scope for as long as the condition stays false.
+    edge::HandleScope iteration_scope(env);
+    if (!iteration_scope.is_open()) {
+      napi_reject_deferred(env, deferred,
+                           MakeError(env, "Unable to open handle scope"));
+      return promise;
+    }
     napi_value result = nullptr;
     napi_status call_status = napi_call_function(env, global, argv[1], 0, nullptr, &result);
     if (call_status != napi_ok) {


### PR DESCRIPTION
**Stack 1/3 (edgejs).** Base: `main`. → next: `edgejs-v8-imports-bridge-fixes`.

Guest-side scope insertions to match the N-API scope-bound value-lifetime rework: EscapableHandleScope/HandleScope discipline across the guest dispatch paths (EdgeMakeCallbackWithFlags, napi_make_callback, event-loop steps, module loader, internal bindings) so returned values are escaped to the parent scope and per-iteration scopes bound value churn.

Pairs with wasmerio/napi#41. ⚠️ Stacked chain, merge bottom-up; not yet mergeable.