### PR TITLE
Guest N-API finalizer dispatch + memory-pressure test (ECO-415)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-edge build-edge-quickjs-cli build-wasix build-quickjs-wasix build-napi build-napi-quickjs build-native-v8 build-native-quickjs build-wasix-napi build-wasix-napi-quickjs build-napi-wasmer-cli test-wasix-napi test-wasix-napi-quickjs test-wasix-napi-cli test-wasix-safe-mode test-wasix-quickjs-only test-quickjs-intl test-quickjs-lang test-wasix-quickjs-intl test-intl test-lang test-wasix-v8-only test-wasix-v8-intl framework-test-v8-wasix standalone-build-test-v8-wasix test test-only check-portability clean clean-napi-quickjs clean-edge-quickjs-cli clean-dist dist dist-only framework-test framework-test-quickjs-native framework-test-quickjs-wasix framework-test-run framework-test-reset standalone-build-test standalone-build-test-run standalone-build-test-quickjs-native standalone-build-test-quickjs-wasix
+.PHONY: build build-edge build-edge-quickjs-cli build-wasix build-quickjs-wasix build-napi build-napi-quickjs build-native-v8 build-native-quickjs build-wasix-napi build-wasix-napi-quickjs build-napi-wasmer-cli test-wasix-napi test-wasix-napi-quickjs test-wasix-napi-cli test-wasix-safe-mode test-wasix-quickjs-only test-quickjs-intl test-quickjs-lang test-wasix-quickjs-intl test-intl test-lang test-wasix-v8-only test-wasix-v8-intl test-wasix-v8-lang framework-test-v8-wasix standalone-build-test-v8-wasix test test-only check-portability clean clean-napi-quickjs clean-edge-quickjs-cli clean-dist dist dist-only framework-test framework-test-quickjs-native framework-test-quickjs-wasix framework-test-run framework-test-reset standalone-build-test standalone-build-test-run standalone-build-test-quickjs-native standalone-build-test-quickjs-wasix
 
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -111,7 +111,7 @@ WASIX_V8_LANE_ENV := \
 	WASMER_BIN="$(WASMER_BIN)" \
 	EDGEJS_ROOT="$(CURDIR)" \
 	WASIX_EDGEJS_PACKAGE_DIR="$(CURDIR)" \
-	WASIX_EDGEJS_WORKSPACE_DIRS="test,lib,deps,assets,build-wasix" \
+	WASIX_EDGEJS_WORKSPACE_DIRS="test,tests,lib,deps,assets,build-wasix" \
 	WASIX_EDGEJS_GUEST_EXEC_PATH="/workspace/build-wasix/edgejs.wasm" \
 	WASMER_EXTRA_ARGS="--experimental-napi"
 EDGE_VERSION_MAJOR := $(shell awk '$$2 == "EDGE_MAJOR_VERSION" {print $$3; exit}' src/edge_version.h)
@@ -503,6 +503,23 @@ test-wasix-v8-intl: $(WASIX_EDGEJS_WASM)
 	  $(WASIX_V8_LANE_ENV) "$(WASIX_QUICKJS_NODE_TEST_RUNNER)" "$(CURDIR)/test/$$t.js"; \
 	done
 	@echo "[intl v8 wasix] all locale tests passed"
+
+# edgejs-owned tests (tests/js) that exercise behavior specific to the
+# V8-imports WASIX bridge — e.g. guest N-API finalizer dispatch, which only
+# exists when JS runs in host V8 and the node runtime runs in the guest. These
+# are self-contained (assert + non-zero exit) and run directly through the
+# WASIX runner, not the node-test harness.
+WASIX_V8_LANG_TESTS := \
+  guest-finalizer-memory
+
+test-wasix-v8-lang: $(WASIX_EDGEJS_WASM)
+	@command -v "$(WASMER_BIN)" >/dev/null 2>&1 || { \
+		echo "error: $(WASMER_BIN) is required for test-wasix-v8-lang" >&2; exit 1; }
+	@set -e; for t in $(WASIX_V8_LANG_TESTS); do \
+	  echo "[lang v8 wasix] $$t"; \
+	  $(WASIX_V8_LANE_ENV) "$(WASIX_QUICKJS_NODE_TEST_RUNNER)" "$(CURDIR)/tests/js/$$t.js"; \
+	done
+	@echo "[lang v8 wasix] all language tests passed"
 
 test-bytecode-cache:
 	EDGE_BIN=$(EDGE_BINARY) ./scripts/test-bytecode-cache.sh

--- a/tests/js/guest-finalizer-memory.js
+++ b/tests/js/guest-finalizer-memory.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Regression test for guest N-API finalizer dispatch (ECO-415), V8-imports
+// (WASIX) lane.
+//
+// `Buffer.allocUnsafe(n)` for n larger than the Buffer pool routes through
+// `createUnsafeArrayBuffer`, which does a guest-side `std::malloc` and hands V8
+// an *external* ArrayBuffer whose finalizer (`ExternalArrayBufferFinalize` ->
+// `free`) runs in the guest. That finalize callback is a wasm function pointer
+// the host cannot invoke directly; the bridge must re-enter the guest on its
+// deferred finalizer drain to run it.
+//
+// If that dispatch does not happen, every large `allocUnsafe` leaks its guest
+// allocation. The guest lives in a wasm32 linear memory capped at 4 GiB (and
+// `memory.grow` never shrinks), so an unbounded leak makes the heap climb until
+// `malloc` fails and `allocUnsafe` throws. This test churns well over 4 GiB in
+// aggregate while dropping each buffer and forcing collection, so it can only
+// run to completion if the guest finalizer actually reclaims memory.
+//
+// Self-contained (no node-test harness / common) so it runs directly via the
+// edgejs-owned tests/js lane. A non-zero exit signals failure.
+//
+// Notes on this lane: `global.gc()` is not wired to V8 here and
+// `process.memoryUsage().rss` reports 0, so neither is usable. A heap snapshot
+// forces a full GC; successful completion past the 4 GiB ceiling is the signal.
+
+const assert = require('assert');
+const v8 = require('v8');
+
+const CHUNK = 4 * 1024 * 1024;   // 4 MiB: safely bypasses the Buffer pool.
+const ITERS = 1536;              // 6 GiB aggregate, ~1.5x the 4 GiB guest cap.
+const FORCE_EVERY = 64;          // How often to force GC + drain finalizers.
+
+function forceGcAndDrain() {
+  // A heap snapshot forces a full GC, collecting the dropped ArrayBuffers.
+  try {
+    v8.getHeapSnapshot().pause().read();
+  } catch {
+    if (typeof global.gc === 'function') global.gc();
+  }
+  // A turn of the event loop runs the bridge's deferred finalizer drain, which
+  // is where the guest finalize callbacks are dispatched.
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function main() {
+  let completed = 0;
+  for (let i = 0; i < ITERS; i++) {
+    let b = Buffer.allocUnsafe(CHUNK);
+    // Touch both ends so the pages are actually committed.
+    b[0] = i & 0xff;
+    b[CHUNK - 1] = 0xab;
+    assert.strictEqual(b[CHUNK - 1], 0xab);
+    b = null;
+    completed++;
+
+    if (i % FORCE_EVERY === 0) {
+      await forceGcAndDrain();
+    }
+  }
+  await forceGcAndDrain();
+
+  assert.strictEqual(completed, ITERS);
+  console.log(
+    `guest-finalizer-memory: reclaimed across ${ITERS} iters ` +
+    `(${((ITERS * CHUNK) / (1024 ** 3)).toFixed(1)} GiB aggregate, ` +
+    `${(CHUNK / (1024 ** 2)).toFixed(0)} MiB each) without exhausting the ` +
+    'guest heap');
+}
+
+main().then(
+  () => {},
+  (err) => {
+    console.error('guest-finalizer-memory FAILED:', err && err.stack || err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Guest N-API finalizer dispatch (ECO-415), stacked on the ECO-416 work.

## What
`napi_wrap` / `napi_add_finalizer` / `napi_create_external_{arraybuffer,buffer}` accept a guest finalize callback (a wasm function pointer) that the bridge was **dropping** — the host can't invoke a wasm function pointer from V8's GC thread — so guest-registered finalizers never ran and every guest-owned native allocation / wrapped C++ object leaked for the life of the process.

## How
- **napi submodule** (wasmerio/napi#44): dispatch guest finalizers on the **deferred drain**. All four paths register a host trampoline carrying `{guest_env, wasm_fn_ptr, data, hint}`; `napi_wrap`/`napi_add_finalizer` enqueue via RefBase weak callbacks, and the external creators skip V8's synchronous backing-store deleter and attach via `napi_add_finalizer` so they take the same deferred path. The drain runs inside the guest's `process-microtasks` import call, where an active callback ctx lets the trampoline re-enter the guest and dispatch `finalize(env, data, hint)` through the indirect table (new 2-arg host variant). At env teardown (no active ctx) records are dropped without re-entering the dying guest.
- **tests/js/guest-finalizer-memory.js** + `test-wasix-v8-lang` lane: an edgejs-owned (NOT the node-test mirror) self-contained memory-pressure test. Churns **6 GiB** of `Buffer.allocUnsafe` (guest `malloc` + external-AB finalizer) past the 4 GiB wasm ceiling — completes only if guest finalizers reclaim memory. Mounts `tests/` into the WASIX guest workspace.

## Verification
- New lane `make test-wasix-v8-lang`: passes (6.0 GiB reclaimed).
- v8-wasix node suite (`test-wasix-v8-only`): **1623 pass**, 0 real failures (3 flaky proxy/TLS pass on retry).
- ECO-414-style teardown loop 40/40 clean with live guest finalizers at exit.

Stacked on `napi-value-scope-rework` (ECO-416). Not independently mergeable yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
