### PR TITLE
V8-imports lane parity with QuickJS: promise-reject, string-max, structuredClone, DNS (ECO-416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,64 +45,29 @@ WASIX_QUICKJS_NODE_TEST_RUNNER ?= $(CURDIR)/scripts/edge-wasix-node-runner.sh
 # worker/messageport crypto, http2 ping/goaway/debug, misc.
 V8_WASIX_SKIP_TESTS := \
   client-proxy/test-http-proxy-request-invalid-char-in-url.mjs \
-  parallel/test-buffer-ascii.js \
-  parallel/test-buffer-constants.js \
   parallel/test-c-ares.js \
   parallel/test-crypto-key-objects-messageport.js \
   parallel/test-crypto-prime.js \
   parallel/test-crypto-worker-thread.js \
-  parallel/test-dgram-connect-send-callback-multi-buffer.js \
-  parallel/test-dgram-connect-send-default-host.js \
-  parallel/test-dgram-connect-send-empty-array.js \
-  parallel/test-dgram-connect-send-empty-packet.js \
-  parallel/test-dgram-connect-send-multi-buffer-copy.js \
-  parallel/test-dgram-connect-send-multi-string-array.js \
-  parallel/test-dgram-implicit-bind.js \
-  parallel/test-dgram-send-callback-multi-buffer-empty-address.js \
-  parallel/test-dgram-send-callback-multi-buffer.js \
-  parallel/test-dgram-send-default-host.js \
-  parallel/test-dgram-send-empty-array.js \
-  parallel/test-dgram-send-empty-packet.js \
-  parallel/test-dgram-send-multi-buffer-copy.js \
-  parallel/test-dgram-send-multi-string-array.js \
-  parallel/test-dgram-udp4.js \
-  parallel/test-diagnostics-channel-tracing-channel-promise-unhandled.js \
   parallel/test-diagnostics-channel-worker-threads.js \
-  parallel/test-dns-cancel-reverse-lookup.js \
-  parallel/test-dns-multi-channel.js \
-  parallel/test-dns-resolveany-bad-ancount.js \
-  parallel/test-dns-resolveany.js \
-  parallel/test-dns-resolver-max-timeout.js \
-  parallel/test-dns.js \
-  parallel/test-domain-promise.js \
-  parallel/test-event-capture-rejections.js \
   parallel/test-file.js \
-  parallel/test-http-autoselectfamily.js \
-  parallel/test-http2-debug.js \
-  parallel/test-http2-goaway-opaquedata.js \
-  parallel/test-http2-onping.js \
-  parallel/test-http2-ping.js \
   parallel/test-http2-reset-flood.js \
-  parallel/test-https-autoselectfamily.js \
-  parallel/test-string-decoder-fuzz.js \
   parallel/test-tls-handshake-exception.js \
   parallel/test-webcrypto-cryptokey-workers.js \
-  parallel/test-x509-escaping.js \
   pseudo-tty/console-dumb-tty.js \
   pseudo-tty/no_dropped_stdio.js \
   pseudo-tty/no_interleaved_stdio.js \
   pseudo-tty/stdin-setrawmode.js \
   pseudo-tty/test-readable-tty-keepalive.js \
+  pseudo-tty/test-tty-color-support.js \
   pseudo-tty/test-tty-color-support-warning-2.js \
   pseudo-tty/test-tty-color-support-warning.js \
-  pseudo-tty/test-tty-color-support.js \
   pseudo-tty/test-tty-isatty.js \
   pseudo-tty/test-tty-stdin-call-end.js \
   pseudo-tty/test-tty-stdin-end.js \
   pseudo-tty/test-tty-stdout-end.js \
   pseudo-tty/test-tty-stdout-resize.js \
-  pseudo-tty/test-tty-stream-constructors.js \
-  sequential/test-dgram-pingpong.js
+  pseudo-tty/test-tty-stream-constructors.js
 
 # V8 (imports provider) WASIX lane: run the root wasmer.toml package
 # (build-wasix/edgejs.wasm) through the wasmer CLI's experimental N-API
@@ -309,7 +274,6 @@ WASIX_SLOW_WEBCRYPTO_TESTS := \
   parallel/test-webcrypto-wrap-unwrap.js
 # CI-only harness timeouts under parallel WASIX load (default harness timeout is 10s).
 WASIX_SLOW_TESTS := \
-  parallel/test-buffer-constants.js \
   parallel/test-crypto-oneshot-hash-xof.js \
   parallel/test-fastutf8stream-flush-sync.js \
   parallel/test-http2-respond-file-with-pipe.js \

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,10 @@ WASIX_QUICKJS_NODE_TEST_RUNNER ?= $(CURDIR)/scripts/edge-wasix-node-runner.sh
 # worker/messageport crypto, http2 ping/goaway/debug, misc.
 V8_WASIX_SKIP_TESTS := \
   client-proxy/test-http-proxy-request-invalid-char-in-url.mjs \
-  parallel/test-c-ares.js \
   parallel/test-crypto-key-objects-messageport.js \
   parallel/test-crypto-prime.js \
   parallel/test-crypto-worker-thread.js \
   parallel/test-diagnostics-channel-worker-threads.js \
-  parallel/test-file.js \
   parallel/test-http2-reset-flood.js \
   parallel/test-tls-handshake-exception.js \
   parallel/test-webcrypto-cryptokey-workers.js \

--- a/etc/hosts
+++ b/etc/hosts
@@ -1,0 +1,2 @@
+127.0.0.1 localhost
+::1 localhost ip6-localhost ip6-loopback

--- a/src/edge_buffer.cc
+++ b/src/edge_buffer.cc
@@ -32,11 +32,18 @@ constexpr double kEdgeUnsafeArrayBufferAllocCap = 2147483647.0;
 #if defined(EDGE_NAPI_QUICKJS)
 constexpr size_t kEdgeStringMaxLength = 0x3fffffff;
 constexpr const char* kEdgeStringMaxLengthHex = "0x3fffffff";
-#else
+#elif defined(EDGE_EMBEDDED_NAPI_PROVIDER)
+// Embedded V8: strings live in-process; size by the actual pointer width.
 constexpr size_t kEdgeStringMaxLength =
     sizeof(void*) == 4 ? static_cast<size_t>(0x18ffffe8) : static_cast<size_t>(0x1fffffe8);
 constexpr const char* kEdgeStringMaxLengthHex =
     sizeof(void*) == 4 ? "0x18ffffe8" : "0x1fffffe8";
+#else
+// Imports provider: strings are created in the host's 64-bit V8, so the limit
+// is V8 String::kMaxLength (0x1fffffe8 with pointer compression), independent
+// of the wasm32 guest's pointer width.
+constexpr size_t kEdgeStringMaxLength = static_cast<size_t>(0x1fffffe8);
+constexpr const char* kEdgeStringMaxLengthHex = "0x1fffffe8";
 #endif
 
 std::string GetUtf8String(napi_env env, napi_value value);

--- a/src/edge_string_decoder.cc
+++ b/src/edge_string_decoder.cc
@@ -19,8 +19,15 @@ constexpr int kBufferedBytes = 5;
 constexpr int kEncodingField = 6;
 constexpr int kSize = 7;
 constexpr int kNumFields = 7;
+#if defined(EDGE_EMBEDDED_NAPI_PROVIDER)
+// Embedded engine: strings live in-process; size by the actual pointer width.
 constexpr size_t kEdgeStringMaxLength =
     sizeof(void*) == 4 ? static_cast<size_t>(0x18ffffe8) : static_cast<size_t>(0x1fffffe8);
+#else
+// Imports provider: strings are created in the host's 64-bit V8, so the limit
+// is V8 String::kMaxLength, independent of the wasm32 guest's pointer width.
+constexpr size_t kEdgeStringMaxLength = static_cast<size_t>(0x1fffffe8);
+#endif
 
 using edge::encoding_ids::kEncAscii;
 using edge::encoding_ids::kEncBase64;

--- a/src/edge_task_queue.cc
+++ b/src/edge_task_queue.cc
@@ -91,9 +91,13 @@ static napi_value TaskQueueSetPromiseRejectCallback(napi_env env, napi_callback_
   napi_value argv[1] = {nullptr};
   if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc < 1) return nullptr;
 
-#if defined(EDGE_EMBEDDED_NAPI_PROVIDER)
+  // Install V8's promise-reject callback on every provider. On the embedded
+  // providers (bundled-v8 / quickjs) this links directly; on the imports
+  // provider it resolves to the N-API bridge import, which tells the host to
+  // wire PromiseRejectCallback and dispatch rejections back into the guest.
+  // Without this the imports lane never emits 'unhandledRejection' (and the
+  // captureRejections / promise-unhandled diagnostics never fire).
   (void)unofficial_napi_set_promise_reject_callback(env, argv[0]);
-#endif
 
   auto& st = GetTaskQueueState(env);
   DeleteRefIfAny(env, &st.promise_reject_callback_ref);


### PR DESCRIPTION
Brings the V8-imports (WASIX) lane to parity with the QuickJS lane, which runs the same test categories on the same wasix and is green. Combined with the napi-side fixes (wasmerio/napi#46), the skip list drops **59 → 22** and the full v8-wasix node suite is green (**1662 pass, 0 failures**).

## Guest / infra fixes in this PR
- **Promise-reject callback** was `#if defined(EDGE_EMBEDDED_NAPI_PROVIDER)`-guarded, so it was never wired on the imports provider → `unhandledRejection` never fired and domain promise-tracking broke. Removed the guard (for imports it resolves to the N-API bridge import). → **event-capture-rejections, diagnostics-promise-unhandled, domain-promise**.
- **`kEdgeStringMaxLength`** keyed off the wasm32 guest pointer width; imports-lane strings live in the host's 64-bit V8, so report `String::kMaxLength` (`0x1fffffe8`). → **buffer-constants**.
- **`etc/hosts`** added: the runner mounts `<package_dir>/etc`, and the imports package dir is the repo root (QuickJS had `quickjs-wasm/etc/hosts`). Without it, c-ares reverse DNS returns `ENOTFOUND`. → **test-c-ares**.
- **`V8_WASIX_SKIP_TESTS` pruned 59 → 22** for all the above plus the napi-side buffer/string/structuredClone fixes.

## Remaining 22 skips
- 14 pseudo-tty — environmental (no PTY under `wasmer run`).
- 7 shared with the QuickJS lane (worker/messageport/reset-flood) — already at parity.
- 1 genuinely V8-specific: `test-tls-handshake-exception` (TLS handshake over a custom Duplex hangs) — tracked separately.

Not independently mergeable yet (stacked on ECO-415 / `napi-value-scope-rework`; needs a CI-provisioned wasmer with the napi fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)