### PR TITLE
Unskip test-tls-handshake-exception on the V8-imports lane (ECO-416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ V8_WASIX_SKIP_TESTS := \
   parallel/test-crypto-worker-thread.js \
   parallel/test-diagnostics-channel-worker-threads.js \
   parallel/test-http2-reset-flood.js \
-  parallel/test-tls-handshake-exception.js \
   parallel/test-webcrypto-cryptokey-workers.js \
   pseudo-tty/console-dumb-tty.js \
   pseudo-tty/no_dropped_stdio.js \


### PR DESCRIPTION
`test-tls-handshake-exception` hung on the V8-imports lane because the wasmer N-API callback trampoline swallowed the guest's WASI `proc_exit` (Node's fatal-exception `std::_Exit`) when it trapped out of a host→guest callback — so the child never terminated and the parent's `spawnSync` never returned.

Fixed host-side by re-raising the `WasiError::Exit` through the N-API import layers (wasmerio/napi#47, provisioned via wasmerio/wasmer#6829). With that fix the child exits cleanly and the test passes, so drop it from `V8_WASIX_SKIP_TESTS`.

Requires the wasmer build to include napi#47 (via the CI wasmer-provisioning source commit). Stacked on #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)