### PR TITLE
Unskip pseudo-tty tests on the V8-imports lane via wasmer --quiet (ECO-416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,21 +50,7 @@ V8_WASIX_SKIP_TESTS := \
   parallel/test-crypto-worker-thread.js \
   parallel/test-diagnostics-channel-worker-threads.js \
   parallel/test-http2-reset-flood.js \
-  parallel/test-webcrypto-cryptokey-workers.js \
-  pseudo-tty/console-dumb-tty.js \
-  pseudo-tty/no_dropped_stdio.js \
-  pseudo-tty/no_interleaved_stdio.js \
-  pseudo-tty/stdin-setrawmode.js \
-  pseudo-tty/test-readable-tty-keepalive.js \
-  pseudo-tty/test-tty-color-support.js \
-  pseudo-tty/test-tty-color-support-warning-2.js \
-  pseudo-tty/test-tty-color-support-warning.js \
-  pseudo-tty/test-tty-isatty.js \
-  pseudo-tty/test-tty-stdin-call-end.js \
-  pseudo-tty/test-tty-stdin-end.js \
-  pseudo-tty/test-tty-stdout-end.js \
-  pseudo-tty/test-tty-stdout-resize.js \
-  pseudo-tty/test-tty-stream-constructors.js
+  parallel/test-webcrypto-cryptokey-workers.js
 
 # V8 (imports provider) WASIX lane: run the root wasmer.toml package
 # (build-wasix/edgejs.wasm) through the wasmer CLI's experimental N-API
@@ -75,7 +61,7 @@ WASIX_V8_LANE_ENV := \
 	WASIX_EDGEJS_PACKAGE_DIR="$(CURDIR)" \
 	WASIX_EDGEJS_WORKSPACE_DIRS="test,tests,lib,deps,assets,build-wasix" \
 	WASIX_EDGEJS_GUEST_EXEC_PATH="/workspace/build-wasix/edgejs.wasm" \
-	WASMER_EXTRA_ARGS="--experimental-napi"
+	WASMER_EXTRA_ARGS="--quiet --experimental-napi"
 EDGE_VERSION_MAJOR := $(shell awk '$$2 == "EDGE_MAJOR_VERSION" {print $$3; exit}' src/edge_version.h)
 EDGE_VERSION_MINOR := $(shell awk '$$2 == "EDGE_MINOR_VERSION" {print $$3; exit}' src/edge_version.h)
 EDGE_VERSION_PATCH := $(shell awk '$$2 == "EDGE_PATCH_VERSION" {print $$3; exit}' src/edge_version.h)


### PR DESCRIPTION
The 14 pseudo-tty tests were skipped on the V8-imports lane as "environmental," but the QuickJS lane runs and passes them on the **identical** wasmer + pty harness (node:tty: quickjs 15/15, V8 3/15).

**Root cause:** under the real pty that `tools/pseudo-tty.py` allocates, the wasmer CLI detects a terminal and renders its progress spinner ("Resolving dependencies", "Compiling edgejs", …) into the merged stdout/stderr, polluting the `.out` comparison. The guest test itself passes — `test-tty-isatty` exits 0, and with the spinner suppressed its output is byte-empty, matching its expected `.out`. Non-pty runs never hit this (only pseudo-tty failed); the V8 lane triggers it more than QuickJS because `--experimental-napi` does an LLVM compile at startup, giving the spinner time to render.

**Fix:** pass `--quiet` to `wasmer run` on the V8 lane (`WASIX_V8_LANE_ENV`), suppressing wasmer's progress messages without touching guest output.

**Result:** V8 `node:tty` 15/15 (was 3/15); full V8-wasix suite **1677 pass / 0 fail**. Dropped all 14 pseudo-tty entries from `V8_WASIX_SKIP_TESTS`.

`V8_WASIX_SKIP_TESTS` is now exactly the 7 worker/messageport tests QuickJS also skips (`QUICKJS_SKIP_WORKER_TESTS`) — a strict subset of the QuickJS skip set, since QuickJS additionally skips `test-tls-close-notify` which V8 runs. **Full parity with the QuickJS lane** (V8 marginally ahead). Stacked on #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)