### PR TITLE
Framework parity: unskip js-etherpad / js-next-* on the V8-imports lane (ECO-416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,9 +586,12 @@ framework-test-quickjs-wasix: $(QUICKJS_WASIX_WASM)
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS QuickJS WASIX' \
 		$(MAKE) framework-test-run $(FRAMEWORK_TEST_SELECTOR)
 
-# js-etherpad (framework) and js-next-ssr/js-next-standalone (standalone) are
-# skipped on the V8 WASIX lane: unclean-exit and binary-garbage-as-JSON
-# failures from the same lane-inherent bridge bugs tracked in ECO-416.
+# All edge apps now run on the V8 WASIX lane (full parity with QuickJS): GuestHeap
+# removed the copy-layer corruption ("binary-garbage-as-JSON") and the N-API import
+# layers now re-raise guest WASI process exits (ECO-416), fixing js-etherpad's
+# unclean-exit and js-next-ssr/js-next-standalone. Only the docusaurus static sites
+# stay skipped here -- they fail to build on the Node.js reference itself (build
+# tooling), which QuickJS also skips via FRAMEWORK_TEST_NODE_SKIP.
 framework-test-v8-wasix: $(WASIX_EDGEJS_WASM)
 	@chmod +x "$(WASIX_FRAMEWORK_RUNNER)"
 	@command -v "$(WASMER_BIN)" >/dev/null 2>&1 || { \
@@ -599,9 +602,8 @@ framework-test-v8-wasix: $(WASIX_EDGEJS_WASM)
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS V8 WASIX' \
 		FRAMEWORK_TEST_NODE_SKIP='js-docusaurus-staticsite,js-docusaurus2-staticsite' \
-		FRAMEWORK_TEST_EDGE_SKIP='js-etherpad' \
 		WASIX_EDGEJS_PACKAGE_DIR="$(CURDIR)" \
-		WASMER_EXTRA_ARGS="--experimental-napi" \
+		WASMER_EXTRA_ARGS="--quiet --experimental-napi" \
 		$(MAKE) framework-test-run $(FRAMEWORK_TEST_SELECTOR)
 
 framework-test-reset:
@@ -639,9 +641,8 @@ standalone-build-test-v8-wasix: $(WASIX_EDGEJS_WASM)
 	@SYMLINK_TARGET="$(abspath $(WASIX_FRAMEWORK_RUNNER))" \
 		FRAMEWORK_TEST_SKIP_SAFE=1 \
 		FRAMEWORK_TEST_RUNNER_LABEL='EdgeJS V8 WASIX' \
-		FRAMEWORK_TEST_EDGE_SKIP='js-next-ssr,js-next-standalone' \
 		WASIX_EDGEJS_PACKAGE_DIR="$(CURDIR)" \
-		WASMER_EXTRA_ARGS="--experimental-napi" \
+		WASMER_EXTRA_ARGS="--quiet --experimental-napi" \
 		$(MAKE) standalone-build-test-run $(FRAMEWORK_TEST_SELECTOR)
 
 standalone-build-test-quickjs-native: $(QUICKJS_EDGE_BINARY)

--- a/scripts/framework-test.js
+++ b/scripts/framework-test.js
@@ -1445,6 +1445,13 @@ function makeProjectEnv(port) {
     BROWSER: 'none',
     CI: '1',
     HOST: DEFAULT_HOST,
+    // Pin HOSTNAME to the loopback host. Servers that bind process.env.HOSTNAME
+    // (e.g. the Next.js standalone server: `server.listen(port, HOSTNAME)`)
+    // would otherwise inherit the ambient machine hostname, which does not
+    // resolve inside the WASIX guest (its mounted /etc/hosts only knows
+    // localhost) -> the bind's DNS lookup hangs and the harness times out on
+    // 127.0.0.1. Mirrors HOST above and standalone.json's entry.env.
+    HOSTNAME: DEFAULT_HOST,
   };
 
   if (typeof port === 'number') {


### PR DESCRIPTION
Closes the last framework-lane gap between the V8-imports (WASIX) lane and the QuickJS lane.

## What
- `framework-test-v8-wasix`: drop `FRAMEWORK_TEST_EDGE_SKIP='js-etherpad'`.
- `standalone-build-test-v8-wasix`: drop `FRAMEWORK_TEST_EDGE_SKIP='js-next-ssr,js-next-standalone'`.
- Pass `--quiet` to `wasmer run` on both V8 lanes (spinner must not pollute captured output).
- Restore/keep only the docusaurus `NODE_SKIP` — those fail to build on the **Node.js reference** itself (build tooling); the QuickJS lane skips them identically.
- **Harness fix** (`scripts/framework-test.js`): pin `HOSTNAME` to the loopback host in `makeProjectEnv`.

## Why it works now
This rides on top of two already-landed ECO-416 fixes: **GuestHeap** (removed the copy-layer corruption — the "binary-garbage-as-JSON" failures) and the **N-API import-layer WASI-exit re-raise** (fixed etherpad's unclean exit). Together they let all edge apps run at parity.

## The `js-next-ssr` harness bug
Unskipping `js-next-ssr` surfaced a latent harness bug. The Next.js standalone server binds `server.listen(port, process.env.HOSTNAME)`. The runner forwards the **ambient machine HOSTNAME** into the guest, but that name does not resolve inside the WASIX guest (its mounted `/etc/hosts` only knows `localhost`) and on a Debian/Ubuntu host resolves to `127.0.1.1`, not the `127.0.0.1` the harness polls. So the server bound the wrong address / hung on the lookup, and the harness fell back to serving the **static export** instead of live SSR.

Fix: pin `HOSTNAME` to the loopback host (mirrors the existing `HOST` and `standalone.json`'s `entry.env`). `js-next-ssr` now validates via `start` (live SSR), not the static fallback.

## Verification
- Full framework suite: **EdgeJS V8 WASIX 14 pass / 0 fail**, no regressions vs Node.js.
- Standalone-build suite: **3 pass / 0 fail**.
- `js-etherpad`, `js-next-standalone`, `js-next-ssr` all validate via `start`.

## Dependency
Requires a `wasmer` provisioned from this ECO-416 stack (napi #47 → wasmer #6829), same as the sibling edgejs PRs. Stacked on #131 (`eco-416-pseudo-tty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)