### PR TITLE
fix(signal): set SA_SIGINFO when installing a three-argument handler

### DIFF
--- a/.github/workflows/test-and-build-quickjs.yml
+++ b/.github/workflows/test-and-build-quickjs.yml
@@ -357,7 +357,7 @@ jobs:
         uses: wasix-org/wasixcc@v0.4.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          sysroot-tag: v2026-06-25.1
+          sysroot-tag: v2026-07-30.1
           version: v0.4.3
 
       # See the quickjs-linux job for how Wasmer provisioning modes work. In
@@ -412,6 +412,12 @@ jobs:
         run: |
           set -euo pipefail
           make test-wasix-quickjs-only TEST_JOBS=1
+
+      - name: Smoke test safe mode (QuickJS WASIX)
+        shell: bash
+        run: |
+          set -euo pipefail
+          make test-wasix-safe-mode WASIX_PACKAGE_DIR="$PWD/quickjs-wasm"
 
       - name: Test locale (Intl/ICU, QuickJS WASIX)
         shell: bash

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -186,7 +186,7 @@ jobs:
         uses: wasix-org/wasixcc@v0.4.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          sysroot-tag: v2026-06-25.1
+          sysroot-tag: v2026-07-30.1
           version: v0.4.3
 
       - name: Install wasm-tools

--- a/scripts/ci/provision-wasmer.sh
+++ b/scripts/ci/provision-wasmer.sh
@@ -106,10 +106,12 @@ fetch_source() {
   git -C "$SRC_DIR" remote add origin "https://github.com/${WASMER_SOURCE_REPO}.git"
   git -C "$SRC_DIR" fetch --depth 1 origin "$sha"
   git -C "$SRC_DIR" checkout -q FETCH_HEAD
-  # lib/napi is a workspace member, so cargo needs it present even for
-  # builds that don't enable the napi features. The test-suite submodules
-  # are not needed.
+  # lib/napi and lib/wild are workspace members, so cargo needs them present even
+  # for builds that don't enable their features (wasmer-compiler path-depends on
+  # wasmer-wild at lib/wild/libwild). --recursive covers lib/wild's nested
+  # submodule. The test-suite submodules are not needed.
   git -C "$SRC_DIR" -c protocol.version=2 submodule update --init --depth 1 lib/napi
+  git -C "$SRC_DIR" -c protocol.version=2 submodule update --init --recursive --depth 1 lib/wild
 }
 
 # Setup mirrored from wasmer's own Builds workflow (.github/workflows/build.yml

--- a/scripts/test-wasix-safe-mode.py
+++ b/scripts/test-wasix-safe-mode.py
@@ -5,12 +5,24 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 
 IGNORED_STDERR_PATTERNS = (
     re.compile(r"Skipping duplicate additional import env\.memory"),
 )
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    script: str
+    expected_stdout: str = ""
+    # Cases that exercise process termination expect a specific exit status and
+    # are allowed to say so on stderr; everything else must exit 0 silently.
+    expected_returncode: int = 0
+    expected_stderr_contains: str = ""
 
 
 def sanitize_stderr(stderr: str) -> str:
@@ -23,8 +35,8 @@ def sanitize_stderr(stderr: str) -> str:
     return "\n".join(lines)
 
 
-def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script: str,
-             expected_stdout: str) -> None:
+def run_case(wasmer_bin: str, package_dir: Path, timeout: int, case: Case) -> None:
+    name = case.name
     cmd = [
         wasmer_bin,
         "run",
@@ -33,7 +45,7 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
         "--net",
         "--",
         "-e",
-        script,
+        case.script,
     ]
 
     try:
@@ -55,60 +67,90 @@ def run_case(wasmer_bin: str, package_dir: Path, timeout: int, name: str, script
     stdout = completed.stdout
     stderr = sanitize_stderr(completed.stderr)
 
-    if completed.returncode != 0:
+    if completed.returncode != case.expected_returncode:
         raise RuntimeError(
-            f"{name} exited with {completed.returncode}\n"
+            f"{name} exited with {completed.returncode}, "
+            f"expected {case.expected_returncode}\n"
             f"stdout: {stdout}\n"
             f"stderr: {stderr}"
         )
 
-    if stdout != expected_stdout:
+    if stdout != case.expected_stdout:
         raise RuntimeError(
             f"{name} stdout mismatch\n"
-            f"expected: {expected_stdout!r}\n"
+            f"expected: {case.expected_stdout!r}\n"
             f"actual:   {stdout!r}\n"
             f"stderr: {stderr}"
         )
 
-    if stderr:
+    if case.expected_stderr_contains:
+        if case.expected_stderr_contains not in stderr:
+            raise RuntimeError(
+                f"{name} stderr missing expected text\n"
+                f"expected to contain: {case.expected_stderr_contains!r}\n"
+                f"stderr: {stderr}"
+            )
+    elif stderr:
         raise RuntimeError(
             f"{name} emitted unexpected stderr\n"
             f"stderr: {stderr}"
         )
 
-    print(f"[ok] {name}: {stdout.strip()}")
+    print(f"[ok] {name}: {stdout.strip() or completed.returncode}")
 
 
-def build_cases(host: str, include_network: bool) -> list[tuple[str, str, str]]:
+def build_cases(host: str, include_network: bool) -> list[Case]:
     cases = [
-        (
-            "queueMicrotask",
-            "console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
-            "A\nC\nB\n",
+        Case(
+            name="queueMicrotask",
+            script="console.log('A'); queueMicrotask(() => console.log('B')); console.log('C');",
+            expected_stdout="A\nC\nB\n",
         ),
-        (
-            "blob.arrayBuffer",
-            "new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
-            "BLOB 3\n",
+        Case(
+            name="blob.arrayBuffer",
+            script="new Blob([new Uint8Array([65,66,67])]).arrayBuffer().then((ab) => console.log('BLOB', ab.byteLength));",
+            expected_stdout="BLOB 3\n",
+        ),
+        # Regression coverage for the signal handler arity bug. SIGINT and
+        # SIGTERM are installed by RegisterSignalHandler() as three-argument
+        # sa_sigaction handlers; when SA_SIGINFO was missing, wasix-libc
+        # dispatched them through the one-argument signature and the
+        # mismatched call_indirect trapped ("indirect call type mismatch"),
+        # killing the instance with exit 27 before node::SignalExit could run.
+        #
+        # Without a JS listener the signal must instead reach SignalExit, which
+        # re-raises so the default disposition terminates the process. Note
+        # this only reproduces under WASIX: on native ABIs the surplus
+        # arguments are harmless, so the equivalent native test cannot catch it.
+        Case(
+            name="SIGINT without a JS listener terminates",
+            script="process.kill(process.pid, 'SIGINT'); setTimeout(() => console.log('NOT REACHED'), 500);",
+            expected_returncode=127,
+            expected_stderr_contains="termination signal",
+        ),
+        Case(
+            name="SIGTERM reaches a JS listener",
+            script="process.on('SIGTERM', () => { console.log('HANDLED'); process.exit(0); }); process.kill(process.pid, 'SIGTERM'); setTimeout(() => {}, 5000);",
+            expected_stdout="HANDLED\n",
         ),
     ]
 
     if include_network:
         cases.extend([
-            (
-                f"fetch http://{host}/",
-                f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
-                "FETCH 200\n",
+            Case(
+                name=f"fetch http://{host}/",
+                script=f"const keepAlive = setTimeout(() => {{}}, 30000); fetch('http://{host}/').then((r) => console.log('FETCH', r.status)).catch((e) => {{ console.error('FETCHERR', e && (e.stack || e.message || e)); process.exitCode = 1; }}).finally(() => clearTimeout(keepAlive));",
+                expected_stdout="FETCH 200\n",
             ),
-            (
-                f"https.get https://{host}/",
-                f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
-                "HTTPS 200\n",
+            Case(
+                name=f"https.get https://{host}/",
+                script=f"require('node:https').get({{ hostname: '{host}', port: 443, path: '/', servername: '{host}' }}, (r) => {{ console.log('HTTPS', r.statusCode); r.resume(); }}).on('error', (e) => {{ console.error('HTTPSERR', e && (e.stack || e.message || e)); process.exit(1); }});",
+                expected_stdout="HTTPS 200\n",
             ),
-            (
-                f"tls.connect verified {host}",
-                f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
-                "TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
+            Case(
+                name=f"tls.connect verified {host}",
+                script=f"const tls=require('node:tls'); const s=tls.connect(443,'{host}',{{servername:'{host}'}},()=>{{ console.log('TLS CONNECTED', s.authorized); s.destroy(); }}); s.on('close',()=>console.log('TLS CLOSE')); process.on('exit',(code)=>console.log('TLS EXIT', code)); s.on('error',(e)=>{{ console.error('TLSERR', e && (e.stack || e.message || e)); process.exitCode = 1; }});",
+                expected_stdout="TLS CONNECTED true\nTLS CLOSE\nTLS EXIT 0\n",
             ),
         ])
 
@@ -151,8 +193,8 @@ def main() -> int:
 
     cases = build_cases(args.https_host, include_network=args.include_network)
 
-    for name, script, expected_stdout in cases:
-        run_case(args.wasmer_bin, package_dir, args.timeout, name, script, expected_stdout)
+    for case in cases:
+        run_case(args.wasmer_bin, package_dir, args.timeout, case)
 
     if not args.include_network:
         print("Skipped outbound network smoke tests; pass --include-network to run them.")

--- a/src/edge_node_compat.cc
+++ b/src/edge_node_compat.cc
@@ -86,7 +86,12 @@ __attribute__((visibility("default"))) void RegisterSignalHandler(
   struct sigaction sa;
   std::memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = handler;
-  sa.sa_flags = reset_handler ? SA_RESETHAND : 0;
+  // `handler` is the three-argument form, so SA_SIGINFO is required: without
+  // it POSIX dispatches through the one-argument `sa_handler` member of the
+  // union instead. Native ABIs ignore the surplus arguments, but on wasm the
+  // argument count is part of the function type and the mismatched
+  // `call_indirect` traps, taking the whole instance down.
+  sa.sa_flags = SA_SIGINFO | (reset_handler ? SA_RESETHAND : 0);
   sigfillset(&sa.sa_mask);
   (void)sigaction(signal, &sa, nullptr);
 }


### PR DESCRIPTION
## Problem

`RegisterSignalHandler()` assigns a three-argument handler to `sa_sigaction` but never sets `SA_SIGINFO`:

```cpp
void RegisterSignalHandler(int signal,
    void (*handler)(int signal, siginfo_t* info, void* ucontext),
    bool reset_handler) {
  ...
  sa.sa_sigaction = handler;
  sa.sa_flags = reset_handler ? SA_RESETHAND : 0;   // no SA_SIGINFO
  (void)sigaction(signal, &sa, nullptr);
}
```

Without that flag POSIX dispatches through `sa_handler` — the one-argument member of the same union — so the handler is invoked with the wrong arity. Native ABIs ignore the surplus register arguments, which is why this has been harmless upstream (the pattern comes from Node's `node.cc`). On wasm the argument count is part of the function type, so the mismatched `call_indirect` traps:

```
RuntimeError: indirect call type mismatch
    at __wasm_signal (edge[328]:0x41d80)
```

The runtime turns that into `WasiError::Exit(Errno::Intr)` — exit code 27 — killing the instance outright.

`SIGINT` and `SIGTERM` are registered this way with `node::SignalExit` (`src/edge_cli.cc:1226-1227`), plus `SIGINT` again in `src/internal_binding/binding_watchdog.cc:242`. On Wasmer Edge, `InstanceHandle::stop_graceful()` sends `SIGTERM` when draining an instance, so a graceful stop killed the instance on a type trap instead of running `SignalExit`'s stdio-reset-and-re-raise path — surfacing as a 5xx whenever it raced an in-flight request. Reproduced against the published package:

```
$ RUST_LOG=warn wasmer run wasmer/edgejs-quickjs \
    -- -e 'process.kill(process.pid, "SIGTERM"); setTimeout(()=>console.log("alive"),500);'
WARN wasmer_wasix::state::env: signal handler runtime error pid=1
     runtime_err=RuntimeError: indirect call type mismatch
    at __wasm_signal (edge[328]:0x41d80)
exit=27
```

## Fix

```cpp
sa.sa_flags = SA_SIGINFO | (reset_handler ? SA_RESETHAND : 0);
```

`napi/v8/src/unofficial_napi_contextify.cc:397` already sets `SA_SIGINFO` correctly, so this brings the two registration sites into agreement. The `ResetSignalHandlers()` sites use `sa_handler` with `SIG_IGN`/`SIG_DFL` and need no change.

## Requires a libc fix too

This alone is not sufficient: wasix-libc's `__wasm_signal` ignored `SA_SIGINFO` entirely and always called handlers as `void(int)`. That is fixed in **wasix-org/wasix-libc#128**, which also implements `SA_RESETHAND` and per-thread signal masks (regression tests in wasmerio/wasmer#6838).

So edgejs must be rebuilt against a sysroot containing that libc change. With both in place:

| Case | Before | After |
|---|---|---|
| `SIGINT`, no JS listener | trap, exit 27 | exit 127, `termination signal: Interrupt` |
| `SIGTERM`, no JS listener | trap, exit 27 | exit 127, `termination signal: Terminated` |
| `SIGINT` + `process.on` listener | ok | ok |
| no signal | ok | ok |

Terminating on an unhandled `SIGINT`/`SIGTERM` is the correct outcome — that is what `SignalExit` is for, and it now runs its `ResetStdioImpl()` path before the default action rather than dying on a type trap.

Verified by building `make build-quickjs-wasix` against a patched sysroot and running the cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
