### PR TITLE
test: FinalizationRegistry cleanup regression test + napi bump (foreground-task queue drain)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,7 +457,8 @@ test-wasix-v8-intl: $(WASIX_EDGEJS_WASM)
 # are self-contained (assert + non-zero exit) and run directly through the
 # WASIX runner, not the node-test harness.
 WASIX_V8_LANG_TESTS := \
-  guest-finalizer-memory
+  guest-finalizer-memory \
+  finalization-registry-fires
 
 test-wasix-v8-lang: $(WASIX_EDGEJS_WASM)
 	@command -v "$(WASMER_BIN)" >/dev/null 2>&1 || { \

--- a/tests/js/finalization-registry-fires.js
+++ b/tests/js/finalization-registry-fires.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// Regression test for the V8-imports (WASIX) lane: FinalizationRegistry
+// cleanup callbacks must actually fire.
+//
+// V8 posts the callback for a FinalizationRegistry with dead targets as a
+// deferred foreground task (Heap::PostFinalizationRegistryCleanupTaskIfNeeded)
+// after GC. In this lane the host's default enqueue path for that kind of
+// task went nowhere -- the task was posted but nothing ever ran it -- so GC
+// correctly reclaimed the dead targets, but FinalizationRegistry callbacks
+// registered for them never fired. Node's own AbortSignal/WeakRef-based
+// cleanup (lib/internal/abort_controller.js) depends on this, so the practical
+// effect was a slow, unbounded per-request leak in every long-running edgejs
+// process.
+//
+// Deliberately does NOT use v8.getHeapSnapshot() to force GC (as
+// guest-finalizer-memory does): that path does not reliably drive this
+// specific mechanism. Instead this churns real allocation pressure across
+// setTimeout-spaced rounds, like a real request-serving workload would --
+// which is what actually surfaced the bug originally.
+//
+// Self-contained (no node-test harness / common) so it runs directly through
+// the WASIX runner, same as guest-finalizer-memory. A non-zero exit signals
+// failure.
+
+const assert = require('assert');
+
+const ROUNDS = 30;
+const PER_ROUND = 2000;
+const ROUND_DELAY_MS = 100;
+// The unpatched bridge finalizes exactly zero, ever, regardless of how much
+// pressure or how many rounds; a fixed bridge finalizes the large majority of
+// same-turn garbage within the first few rounds. Any real threshold above
+// zero distinguishes a working drain from a broken one.
+const MIN_FINALIZED_RATE = 0.5;
+
+let finalized = 0;
+let registered = 0;
+const registry = new FinalizationRegistry(() => {
+  finalized++;
+});
+
+function makeGarbage() {
+  for (let i = 0; i < PER_ROUND; i++) {
+    let obj = { data: new Array(500).fill(i), tag: `obj-${i}` };
+    registry.register(obj, i);
+    registered++;
+    obj = null;
+  }
+  // Extra allocation pressure to encourage V8 to run GC cycles.
+  let pressure = [];
+  for (let i = 0; i < 500; i++) {
+    pressure.push(new Array(2000).fill(Math.random()));
+  }
+  pressure = null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  for (let round = 0; round < ROUNDS; round++) {
+    makeGarbage();
+    await sleep(ROUND_DELAY_MS);
+  }
+
+  const rate = registered === 0 ? 0 : finalized / registered;
+  console.log(
+    `finalization-registry-fires: finalized ${finalized}/${registered} ` +
+    `(${(rate * 100).toFixed(1)}%)`);
+  assert.ok(
+    rate > MIN_FINALIZED_RATE,
+    `FinalizationRegistry callbacks barely fired (${finalized}/${registered}, ` +
+    `expected > ${(MIN_FINALIZED_RATE * 100).toFixed(0)}%) -- the deferred ` +
+    'cleanup task V8 posts after GC is not being drained');
+}
+
+main().then(
+  () => {},
+  (err) => {
+    console.error('finalization-registry-fires FAILED:', err && err.stack || err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Bumps the \`napi\` submodule to wasmerio/napi#50 (branch
\`fix/foreground-task-queue-drain\`), which fixes V8-internal
FinalizationRegistry cleanup callbacks never firing in the V8-imports
(WASIX) lane: the cleanup task V8 posts after GC was silently dropped
whenever the guest hadn't bound its own foreground-task hook (edgejs never
does -- it drives everything through
\`unofficial_napi_process_microtasks\`), because nothing pumped the fallback
platform runner those tasks fell back to. GC still correctly reclaimed the
dead targets, but the registered callbacks never fired -- and Node's own
AbortSignal/WeakRef-based cleanup depends on this, so the practical effect
was a slow, unbounded per-request leak in every long-running edgejs
process.

Adds \`tests/js/finalization-registry-fires.js\` to the
\`test-wasix-v8-lang\` lane: churns real allocation pressure across
setTimeout-spaced rounds (deliberately not \`v8.getHeapSnapshot()\`-forced
GC, as \`guest-finalizer-memory\` uses -- that path doesn't reliably drive
this specific mechanism and produced false passes even against the broken
bridge) and asserts the large majority of registered callbacks actually
fire. Confirmed: fails (0/60000) against the pre-fix bridge, passes
(60000/60000) after.

See wasmerio/napi#50 for the full root-cause writeup and additional
verification (standalone V8 repro proving the bug is in the embedding, not
V8 itself).

Stacked on #136.