### PR TITLE
Bump napi: fix the V8+WASIX large-payload leak and the host-heap corruption abort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,17 @@ WASIX_SKIP_UNIX_SOCKET_TESTS := \
   parallel/test-tls-net-connect-prefer-path.js \
   parallel/test-tls-wrap-econnreset-pipe.js \
   parallel/test-http-client-response-domain.js
+# The known_issues/ entry is a later addition (2026-08-11). Cluster shares a
+# dgram socket by sending the bound descriptor to the worker over IPC, and
+# primary.js always picks SharedHandle for udp4/udp6 regardless of scheduling
+# policy. WASI has no msghdr/SCM_RIGHTS, so that descriptor can never be
+# delivered and the worker's bind callback never fires -- the run times out
+# rather than failing, which a [negative] test needs it to do. Its non-negative
+# sibling sequential/test-dgram-bind-shared-ports.js is skipped just above for
+# the same reason; this one only escaped because the list carried no
+# known_issues/ paths. See wasix-org/libuv#14, which makes the underlying send
+# fail with ENOSYS instead of stalling silently -- necessary for diagnosing
+# this, but not sufficient to make the test pass.
 WASIX_SKIP_CLUSTER_FORK_TESTS := \
   parallel/test-dgram-bind-socket-close-before-cluster-reply.js \
   parallel/test-dgram-cluster-close-during-bind.js \
@@ -163,7 +174,8 @@ WASIX_SKIP_CLUSTER_FORK_TESTS := \
   parallel/test-crypto-secure-heap.js \
   parallel/test-domain-top-level-error-handler-throw.js \
   parallel/test-domain-uncaught-exception.js \
-  sequential/test-dgram-bind-shared-ports.js
+  sequential/test-dgram-bind-shared-ports.js \
+  known_issues/test-dgram-bind-shared-ports-after-port-0.js
 WASIX_SKIP_SUBPROCESS_SHELL_TESTS := \
   parallel/test-stream-pipeline-process.js \
   parallel/test-domain-abort-on-uncaught.js \

--- a/scripts/ci/provision-wasmer.sh
+++ b/scripts/ci/provision-wasmer.sh
@@ -111,7 +111,12 @@ fetch_source() {
   # wasmer-wild at lib/wild/libwild). --recursive covers lib/wild's nested
   # submodule. The test-suite submodules are not needed.
   git -C "$SRC_DIR" -c protocol.version=2 submodule update --init --depth 1 lib/napi
-  git -C "$SRC_DIR" -c protocol.version=2 submodule update --init --recursive --depth 1 lib/wild
+  # wasmerio/wasmer#6848 ("port to vanilla Wild") dropped the lib/wild submodule,
+  # so it only exists on refs from before that. Asking for it unconditionally
+  # fails the checkout outright on anything newer.
+  if [ -n "$(git -C "$SRC_DIR" ls-tree HEAD lib/wild 2>/dev/null)" ]; then
+    git -C "$SRC_DIR" -c protocol.version=2 submodule update --init --recursive --depth 1 lib/wild
+  fi
 }
 
 # Setup mirrored from wasmer's own Builds workflow (.github/workflows/build.yml


### PR DESCRIPTION
Submodule bumps only. Picks up three napi changes covering two independent bugs on the V8/N-API WASIX lane plus the API cleanup that came out of reviewing them. quickjs is unaffected by any of it.

**1. Guest-heap chunk allocators leaked ~2 MiB of host metadata per 1 MiB chunk** (wasmerio/napi#53). Every `GuestHeap` chunk built its offset allocator with `Allocator::new`, which sizes the node arena for 128Ki allocations no matter how small the chunk is. Chunks are claimed as a workload's peak grows and never released, so host RSS grew about three times the guest memory being managed. On the payload load test (echo-buffer, 10 MiB bodies, 1.95 GiB moved), net RSS growth drops 368 MB -> 134 MB and host-anonymous growth drops ~20 MB/GiB -> ~1 MB/GiB.

**2. The external-backing-store hint set was mutated from V8's ArrayBufferSweeper background threads** (wasmerio/napi#53) with no synchronization against the main thread, corrupting the host heap. The runtime aborted with `malloc_consolidate(): unaligned fastbin chunk detected` a few hundred requests into a payload-heavy workload. With a config that reproduces it, 2 of 6 runs died before the fix and 0 of 28 after.

**3. `GuestHeap` no longer reaches into wasmer's private VM types** (wasmerio/napi#54). It was holding a `VMSharedMemory` obtained through an accessor that returned an unnameable type and panicked on non-sys backends; it now uses the store-free `SharedMemory::grow`/`data_ptr`/`style` API added in wasmerio/wasmer#6877.

## Merge order

This branch's napi pin is the head of wasmerio/napi#54, so:

1. wasmerio/napi#53
2. wasmerio/napi#54
3. wasmerio/wasmer#6877 (its napi pin is #54's head too)
4. this PR

wasmerio/wasmer#6877 replaces the previous ten-PR `chore: bump napi` stack (#6819-#6850), which has been closed.

## Testing

Verified locally against this branch's napi pin, built into a `wasmer` CLI with `--features napi-v8,llvm`:

- 38/38 `wasmer-napi` lib tests green (2 new).
- Payload load test, 150 rounds / ~15 GiB: linear-memory claims converge — 72 chunks total, 66 of them in the first 25 rounds, then 2/2/0/1 per subsequent 25-round block.
- Separate 150-round / 29.3 GiB run: total RSS growth fits a logarithmic curve 2.4x better than linear, i.e. a converging high-water rather than a leak.
- Post-refactor re-verification: 20 rounds / 3.91 GiB verified byte-for-byte with flat per-round retention, and 8/8 clean abort-trial runs.

## Note for reviewers

For the `v8-wasix` CI lane to actually exercise any of this, the `WASMER_SOURCE_REF` repo var needs to point at a wasmer build carrying wasmerio/wasmer#6877 — otherwise the lane builds the runtime with wasmer main's older napi pin and tests none of these fixes.
