### PR TITLE
chore: bump napi submodule: non-zero heap_size_limit on QuickJS

### DIFF
--- a/wasmer.toml
+++ b/wasmer.toml
@@ -20,3 +20,9 @@ runner = "https://webc.org/runner/wasi"
 [command.annotations.wasi]
 atom = "edgejs"
 # env = ["EDGEJS_LIB_DIR=/node-lib"]
+
+# child_process.exec()/execSync() run their command through `/bin/sh -c`, so
+# without a shell in the package every exec() call fails to spawn. The QuickJS
+# package has carried this since it was created; this one was missing it.
+[dependencies]
+"wasmer/bash" = "1.0.25"


### PR DESCRIPTION
Stacked on #144. Merge bottom-up: **#143 → #144 → this → #115**.

Picks up wasmerio/napi#57 (stacked on napi#54, which #143 already pins).

## Why this is needed

#144 fixes the dgram timeout, and `v8-wasix` goes green — but `quickjs-wasix` then fails at a *later* step it had never previously reached:

```
v8 heap statistics report the embedder limit stdout mismatch
expected: 'HEAP true\n'   actual: 'HEAP false\n'
```

This is not a regression from #144. The check was added to `scripts/test-wasix-safe-mode.py` on 2026-08-05 (`b7b3c149`) — the same day the dgram regression began aborting that job at the earlier test-suite step. Since then the smoke-test step has never run to completion on the QuickJS lane, so **the check has never passed there**. Skipping the dgram test is simply what let CI get far enough to see it.

Confirmed against the last green run (30567886962, 2026-07-30): the case did not exist yet, and the smoke-test step passed.

## Root cause

`unofficial_napi_get_heap_statistics()` in the QuickJS backend memsets the struct and fills only the size fields, leaving `heap_size_limit` at 0. The V8 backend sets it from `stats.heap_size_limit()`, which is why `v8-wasix` was unaffected.

It can't be forwarded directly either: QuickJS spells "no limit" as `malloc_limit == 0`, the inverse of the N-API convention. napi#57 translates between them — a configured limit is reported as-is, an unset one reports the address-space ceiling (on wasm32, `SIZE_MAX` = 4 GiB − 1, exactly the linear-memory ceiling).

Per the check's own comment this is a real bug, not just a test artifact: Next.js reads the value to decide whether a worker is near its heap limit, and a zero makes its memory watchdog exit eagerly.

## Verification

Rebuilt the quickjs-wasix guest with the bump; the full safe-mode suite passes:

```
[ok] v8 heap statistics report the embedder limit: HEAP true
All WASIX safe-mode smoke tests passed.
```

Values now reported under WASIX:

```
heap_size_limit      = 4294967295
used_heap_size       = 4107220
total_available_size = 4290860075
```