### PR TITLE
fix(wasix): package shell and update libuv

### DIFF
--- a/wasmer.toml
+++ b/wasmer.toml
@@ -71,3 +71,9 @@ env = [
   "HOME=/tmp",
   "npm_config_update_notifier=false",
 ]
+
+# child_process.exec()/execSync() run their command through `/bin/sh -c`, so
+# without a shell in the package every exec() call fails to spawn. The QuickJS
+# package has carried this since it was created; this one was missing it.
+[dependencies]
+"wasmer/bash" = "1.0.25"


### PR DESCRIPTION
## Summary

- package `wasmer/bash` 1.0.25 so `child_process.exec()` and `execSync()` can invoke `/bin/sh -c` in the V8 WASIX package
- advance `deps/libuv-wasix` to wasix-org/libuv@0b210e26989088bc9681ab56c4d610c679798767 from the `wasix-1.51.0` branch
- include the upstream WASIX IPC descriptor-passing guard, which reports `ENOSYS` before attempting unsupported descriptor transfer

## Verification

- `make build-wasix JOBS=4`
  - built `build-wasix/edge.wasm` and `build-wasix/edgejs.wasm`
  - validated 110 N-API imports and 67 extension imports
- `wasmer package build --check .`