### PR TITLE
Release the TLSWrap active-handle registration on destroySSL (WAX-609)

### DIFF
--- a/src/crypto/edge_crypto_binding.cc
+++ b/src/crypto/edge_crypto_binding.cc
@@ -781,10 +781,22 @@ std::string CanonicalizeDigestName(const std::string& in) {
   return out;
 }
 
+// An SSL_CTX plus the state CreateConfiguredSecureContext attaches to it costs
+// ~30 KiB of native memory the GC cannot see, and tls.connect() mints one
+// SecureContext per connection. Unreported, the JS heap stays small, no
+// collection is triggered, and dead contexts pile up -- native high-water
+// growth that never comes back on an allocator that does not return pages.
+// Measured at 30.5 KiB/context (2000 contexts, RSS delta); rounded down so we
+// under-report rather than over-trigger collection.
+constexpr int64_t kSecureContextExternalBytes = 28 * 1024;
+
 void SecureContextFinalizer(node_api_basic_env env, void* data, void* hint) {
-  (void)env;
   (void)hint;
   auto* holder = reinterpret_cast<SecureContextHolder*>(data);
+  if (env != nullptr) {
+    int64_t adjusted = 0;
+    (void)napi_adjust_external_memory(env, -kSecureContextExternalBytes, &adjusted);
+  }
   delete holder;
 }
 
@@ -1600,6 +1612,8 @@ napi_value CryptoSecureContextCreate(napi_env env, napi_callback_info info) {
     delete holder;
     return nullptr;
   }
+  int64_t adjusted = 0;
+  (void)napi_adjust_external_memory(env, kSecureContextExternalBytes, &adjusted);
   return out;
 }
 

--- a/src/edge_stream_base.cc
+++ b/src/edge_stream_base.cc
@@ -903,6 +903,12 @@ void EdgeStreamBaseSetWrapperRef(EdgeStreamBase* base, napi_ref wrapper_ref) {
 
 napi_value EdgeStreamBaseGetWrapper(EdgeStreamBase* base) {
   if (base == nullptr || base->env == nullptr) return nullptr;
+  // Once we are finalizing, the wrapper is being collected and may already be a
+  // zombie inside QuickJS's cycle sweep. Materialising it here would take a new
+  // reference to memory the collector is about to release, and whichever scope
+  // owns that napi_value would free it again afterwards. Every JS-touching
+  // caller funnels through here, so this is the one place to stop it.
+  if (base->finalized) return nullptr;
   return GetRefValue(base->env, base->wrapper_ref);
 }
 
@@ -979,6 +985,12 @@ void EdgeStreamBaseFinalize(EdgeStreamBase* base) {
 
   StreamBaseDetach(base);
   DestroyBase(base);
+}
+
+void EdgeStreamBaseReleaseActiveHandle(EdgeStreamBase* base) {
+  if (base == nullptr || base->env == nullptr || base->active_handle_token == nullptr) return;
+  EdgeUnregisterActiveHandle(base->env, base->active_handle_token);
+  base->active_handle_token = nullptr;
 }
 
 void EdgeStreamBaseOnClosed(EdgeStreamBase* base) {

--- a/src/edge_stream_base.h
+++ b/src/edge_stream_base.h
@@ -73,6 +73,12 @@ void EdgeStreamBaseSetInitialStreamProperties(EdgeStreamBase* base,
 
 void EdgeStreamBaseFinalize(EdgeStreamBase* base);
 void EdgeStreamBaseOnClosed(EdgeStreamBase* base);
+
+// Drop only the active-handle registration (and the strong ref to the wrapper
+// it holds) without emitting the close/destroy lifecycle. For streams that have
+// no libuv handle of their own -- TLSWrap -- the registration would otherwise
+// outlive the stream and pin the wrapper forever.
+void EdgeStreamBaseReleaseActiveHandle(EdgeStreamBase* base);
 void EdgeStreamBaseEmitAfterWrite(EdgeStreamBase* base, napi_value req_obj, int status);
 void EdgeStreamBaseEmitAfterShutdown(EdgeStreamBase* base, napi_value req_obj, int status);
 void EdgeStreamBaseEmitAfterShutdown(EdgeStreamBase* base,

--- a/src/edge_tls_wrap.cc
+++ b/src/edge_tls_wrap.cc
@@ -1166,16 +1166,39 @@ void DestroySsl(TlsWrap* wrap) {
   DeleteRefIfPresent(wrap->env, &wrap->user_read_buffer_ref);
   wrap->user_buffer_base = nullptr;
   wrap->user_buffer_len = 0;
+  // We just detached from the parent stream, so ParentStreamOnClose can no
+  // longer fire, and Node's JS TLSWrap.prototype.close shadows TlsWrapClose and
+  // delegates to the parent handle -- so nothing will ever reach
+  // EdgeStreamBaseOnClosed for this stream. Its active-handle registration
+  // holds a strong ref to our wrapper, which would keep the wrapper (and this
+  // whole TlsWrap, the parent handle and the SecureContext) alive forever and
+  // stop TlsWrapFinalize from ever running. Drop just the registration and
+  // nothing else: emitting the full close/destroy lifecycle from here instead
+  // re-enters JS while the socket still owns the handle, which fails several
+  // node:tls tests under the QuickJS provider.
+  EdgeStreamBaseReleaseActiveHandle(&wrap->base);
   ReleaseKeepaliveHandle(wrap);
 }
 
 void TlsWrapFinalize(napi_env env, void* data, void* /*hint*/) {
   auto* wrap = static_cast<TlsWrap*>(data);
   if (wrap == nullptr) return;
+  // Mark the stream finalized up front: this runs from QuickJS's cycle sweep,
+  // and everything below (DestroySsl, NotifyTlsStreamClosed) would otherwise
+  // reach back into the JS object graph and resurrect zombies.
+  wrap->base.finalized = true;
+  auto* environment = EdgeEnvironmentGet(env);
+  const bool cleanup_started = environment == nullptr || environment->cleanup_started();
+  if (cleanup_started) {
+    // Finalizer order within a teardown sweep is unspecified, so the parent
+    // stream may already be gone and its listener chain freed with it. Nothing
+    // will drive this listener again either way, so drop it without walking.
+    wrap->parent_stream_base = nullptr;
+    wrap->parent_stream_listener.previous = nullptr;
+  }
   DestroySsl(wrap);
   ReleaseKeepaliveHandle(wrap);
-  auto* environment = EdgeEnvironmentGet(env);
-  if (environment == nullptr || !environment->cleanup_started()) {
+  if (!cleanup_started) {
     NotifyTlsStreamClosed(wrap);
   }
   RemoveWrapFromState(wrap);


### PR DESCRIPTION
Fixes [WAX-609](https://linear.app/wasmer/issue/WAX-609/wasix-node-leaks-memory-on-every-outbound-connection).

## The leak

Every outbound TLS connection permanently retained its `TlsWrap` — ~107 KB a time.

`EdgeStreamBaseSetWrapperRef` registers every stream in `Environment::active_handles_`, holding a **strong** `napi_ref` to the handle's JS wrapper so `process._getActiveHandles()` can see it. Only `EdgeStreamBaseOnClosed` releases that registration, and TCP reaches it from its libuv close callback.

`TLSWrap` owns no libuv handle of its own (`kTlsWrapOps` is all-nullptr), so its only routes there are `ParentStreamOnClose` and `TlsWrapClose`:

- `TlsWrapClose` is dead code — Node's JS `TLSWrap.prototype.close` in `lib/_tls_wrap.js` shadows it and delegates to the parent handle.
- That JS close calls `destroySSL()` **first**, which detaches the parent listener — so `ParentStreamOnClose` can never fire either.

The registration was therefore never released → the wrapper was pinned → `TlsWrapFinalize` never ran → the `TlsWrap`, its 64 KiB read buffer, the parent TCP handle and the `SecureContext`/`SSL_CTX` all leaked. Self-sustaining: the registry pinned the object, so the finalizer that would have cleared the registry could never run.

Confirmed with heaptrack (26.21 MB over exactly 400 calls for 400 cycles — precisely 64 KiB each), `WeakRef` + GC pressure (TLS 200/200 retained vs TCP 0/200), and gdb (3 `TLSWrap` registrations, 0 unregistrations over 3 cycles).

## The fix

1. **Release the registration in `DestroySsl`** — and nothing else. Emitting the full close/destroy lifecycle there re-enters JS while the socket still owns the handle, and fails several `node:tls` tests under QuickJS.

2. Letting the wrapper actually be collected then exposed a **latent use-after-free**: `TlsWrapFinalize` runs inside QuickJS's cycle sweep, where other cycle members are still visible as zombies (what `JS_IsLiveObject` is for). It reached back through `EdgeStreamBaseGetWrapper` → `napi_get_reference_value` → `dup_inner()` and resurrected one.
   - `EdgeStreamBaseGetWrapper` now reports nothing once the stream is finalizing. Every JS-touching stream caller funnels through it, so it is the one place to stop this.
   - `TlsWrapFinalize` marks the stream finalized before doing any work, and during env teardown drops `parent_stream_base` without walking the parent's listener chain — finalizer order in a teardown sweep is unspecified, so the parent may already be freed. That was a *second* UAF, at exit.

3. **Report the `SecureContext`'s `SSL_CTX` to the GC.** `tls.connect()` mints one per connection at ~30 KiB of native memory the collector cannot see, so the JS heap stays small, no collection is triggered, and dead contexts accumulate.

## Results

10 000 TLS connect/close cycles:

| | before | after |
|---|---|---|
| WASIX (QuickJS), RSS growth | 809.5 MB | **35.5 MB** (92 → 3.6 KB/cycle) |
| Native V8 | 107 KB/cycle, dead linear | **plateaus** |

The WASIX baseline reproduces the ticket almost exactly (ticket: 10 016 cycles, 730.9 → 1256.6 MB; here: 10 000 cycles, 376 → 1271 MB). Controls: an idle loop is flat (0.1 MB/10k) and plaintext TCP plateaus (12 MB/40k), matching the ticket's plaintext arm.

## Testing

- `node:tls` + `node:https` + `node:crypto`: **433/433 on both the V8 and QuickJS providers**, matching baseline.
- ASAN build (`-fsanitize=address`, QuickJS provider) clean on the four tests that previously aborted with `corrupted double-linked list`.
- `node:http2` + `node:http` + `node:stream` show no new failures; `test-http2-response-splitting` and `test-stream-readable-async-iterators` fail on QuickJS *before* this change too, and the `test-http-server-*-timeout-keepalive` pair flakes under `-j 8` on both providers but passes in isolation.

## Related

wasmerio/napi#67 hardens `napi_get_reference_value` against the same zombie resurrection for any addon. It is **not** required by this PR — this branch is green and ASAN-clean with or without it.

## Known remaining gap

WASIX still does not fully plateau (late/early slope ~1.0 vs V8's 0.08). The `SecureContext` accounting drives V8's GC but is inert under QuickJS, whose `napi_adjust_external_memory` only increments a counter. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)